### PR TITLE
Video Sequencer - Add Modifier double entry name inconsistency #926

### DIFF
--- a/release/scripts/startup/bl_ui/space_sequencer.py
+++ b/release/scripts/startup/bl_ui/space_sequencer.py
@@ -799,7 +799,7 @@ class SEQUENCER_MT_context_menu(Menu):
 
                 layout.separator()
                 layout.operator_menu_enum("sequencer.strip_modifier_add", "type", text="Add Strip Modifier")
-                layout.operator("sequencer.strip_modifier_copy", text="Copy Modifiers to Selection", icon='ICON_COPYDOWN')
+                layout.operator("sequencer.strip_modifier_copy", text="Copy Modifiers to Selection", icon='COPYDOWN')
 
                 if selected_sequences_len(context) >= 2:
                     layout.separator()

--- a/release/scripts/startup/bl_ui/space_sequencer.py
+++ b/release/scripts/startup/bl_ui/space_sequencer.py
@@ -721,7 +721,7 @@ class SEQUENCER_MT_strip(Menu):
 
             if stype != 'SOUND':
                 layout.separator()
-                layout.operator_menu_enum("sequencer.strip_modifier_add", "type", text="Add Modifier")
+                layout.operator_menu_enum("sequencer.strip_modifier_add", "type", text="Add Strip Modifier")
                 layout.operator("sequencer.strip_modifier_copy", text="Copy Modifiers to Selection", icon='COPYDOWN')
 
             if stype in {
@@ -798,7 +798,7 @@ class SEQUENCER_MT_context_menu(Menu):
             if stype != 'SOUND':
 
                 layout.separator()
-                layout.operator_menu_enum("sequencer.strip_modifier_add", "type", text="Add Modifier")
+                layout.operator_menu_enum("sequencer.strip_modifier_add", "type", text="Add Strip Modifier")
                 layout.operator("sequencer.strip_modifier_copy", text="Copy Modifiers to Selection", icon='ICON_COPYDOWN')
 
                 if selected_sequences_len(context) >= 2:


### PR DESCRIPTION
Changed name to "Add Strip Modifier" to be consistent with the modifier tab dropdown panel. 