### PR TITLE
Video Sequencer - compare merge side panel changes from Blender 2.8 t…

### DIFF
--- a/release/scripts/startup/bl_ui/space_sequencer.py
+++ b/release/scripts/startup/bl_ui/space_sequencer.py
@@ -155,7 +155,6 @@ class SEQUENCER_MT_editor_menus(Menu):
             layout.menu("SEQUENCER_MT_select")
             layout.menu("SEQUENCER_MT_marker")
             layout.menu("SEQUENCER_MT_add")
-            layout.menu("SEQUENCER_MT_frame")
             layout.menu("SEQUENCER_MT_strip")
 
 
@@ -189,6 +188,21 @@ class SEQUENCER_MT_view_cache(Menu):
         col.prop(ed, "show_cache_composite")
 
 
+class SEQUENCER_MT_range(Menu):
+    bl_label = "Range"
+
+    def draw(self, _context):
+        layout = self.layout
+
+        layout.operator("anim.previewrange_set", text="Set Preview Range")
+        layout.operator("anim.previewrange_clear", text="Clear Preview Range")
+
+        layout.separator()
+
+        layout.operator("anim.start_frame_set", text="Set Start Frame")
+        layout.operator("anim.end_frame_set", text="Set End Frame")
+
+
 class SEQUENCER_MT_view(Menu):
     bl_label = "View"
 
@@ -204,7 +218,6 @@ class SEQUENCER_MT_view(Menu):
             # mode, else the lookup for the shortcut will fail in
             # wm_keymap_item_find_props() (see #32595).
             layout.operator_context = 'INVOKE_REGION_PREVIEW'
-
         layout.prop(st, "show_region_ui")
         layout.operator_context = 'INVOKE_DEFAULT'
 
@@ -218,7 +231,19 @@ class SEQUENCER_MT_view(Menu):
             layout.operator("sequencer.view_all", text="View all Sequences", icon = "VIEWALL" )
             layout.operator("sequencer.view_selected", text = "View Selected", icon='VIEW_SELECTED')
             layout.operator("sequencer.view_frame", icon = "VIEW_FRAME" )
+
+            layout.separator()
+
             layout.operator_context = 'INVOKE_DEFAULT'
+            layout.menu("SEQUENCER_MT_navigation")
+            layout.menu("SEQUENCER_MT_range")
+
+            layout.separator()
+
+            layout.operator("sequencer.refresh_all", icon='FILE_REFRESH', text="Refresh All")
+
+            layout.separator()
+
         if is_preview:
             layout.operator_context = 'INVOKE_REGION_PREVIEW'
             layout.operator("sequencer.view_all_preview", text="Fit Preview in window")
@@ -274,6 +299,50 @@ class SEQUENCER_MT_select_none(bpy.types.Operator):
         bpy.ops.sequencer.select_all(action = 'DESELECT')
         return {'FINISHED'}
 
+class SEQUENCER_MT_select_handle(Menu):
+    bl_label = "Select Handle"
+
+    def draw(self, _context):
+        layout = self.layout
+
+        layout.operator("sequencer.select_handles", text="Both").side = 'BOTH'
+        layout.operator("sequencer.select_handles", text="Left").side = 'LEFT'
+        layout.operator("sequencer.select_handles", text="Right").side = 'RIGHT'
+
+
+class SEQUENCER_MT_select_channel(Menu):
+    bl_label = "Select Channel"
+
+    def draw(self, _context):
+        layout = self.layout
+
+        layout.operator("sequencer.select_active_side", text="Left").side = 'LEFT'
+        layout.operator("sequencer.select_active_side", text="Right").side = 'RIGHT'
+
+
+class SEQUENCER_MT_select_linked(Menu):
+    bl_label = "Select Linked"
+
+    def draw(self, _context):
+        layout = self.layout
+
+        layout.operator("sequencer.select_linked", text="All")
+        layout.operator("sequencer.select_less", text="Less")
+        layout.operator("sequencer.select_more", text="More")
+
+
+class SEQUENCER_MT_select_playhead(Menu):
+    bl_label = "Select Playhead"
+
+    def draw(self, _context):
+        layout = self.layout
+
+        props = layout.operator("sequencer.select", text="Left")
+        props.left_right = 'LEFT'
+        props.linked_time = True
+        props = layout.operator("sequencer.select", text="Right")
+        props.left_right = 'RIGHT'
+        props.linked_time = True
 
 class SEQUENCER_MT_select(Menu):
     bl_label = "Select"
@@ -287,30 +356,17 @@ class SEQUENCER_MT_select(Menu):
 
         layout.separator()
 
+        layout.operator("sequencer.select_box", text="Box Select")
+
+        layout.separator()
+
+        layout.menu("SEQUENCER_MT_select_playhead", text="Playhead")
+        layout.menu("SEQUENCER_MT_select_handle", text="Handle")
+        layout.menu("SEQUENCER_MT_select_channel", text="Channel")
+        layout.menu("SEQUENCER_MT_select_linked", text="Linked")
+
+        layout.separator()
         layout.operator_menu_enum("sequencer.select_grouped", "type", text="Grouped")
-        layout.operator("sequencer.select_linked")
-
-        layout.separator()
-
-        layout.operator("sequencer.select_active_side", text="Strips to the Left").side = 'LEFT'
-        layout.operator("sequencer.select_active_side", text="Strips to the Right").side = 'RIGHT'
-        props = layout.operator("sequencer.select", text="All Strips to the Left")
-        props.left_right = 'LEFT'
-        props.linked_time = True
-        props = layout.operator("sequencer.select", text="All Strips to the Right")
-        props.left_right = 'RIGHT'
-        props.linked_time = True
-
-        layout.separator()
-
-        layout.operator("sequencer.select_handles", text="Surrounding Handles").side = 'BOTH'
-        layout.operator("sequencer.select_handles", text="Left Handle").side = 'LEFT'
-        layout.operator("sequencer.select_handles", text="Right Handle").side = 'RIGHT'
-
-        layout.separator()
-
-        layout.operator("sequencer.select_less", text = "Less")
-        layout.operator("sequencer.select_more", text = "More")
 
 
 class SEQUENCER_MT_marker(Menu):
@@ -353,14 +409,17 @@ class SEQUENCER_MT_change(Menu):
                 prop.filter_sound = True
 
 
-class SEQUENCER_MT_frame(Menu):
-    bl_label = "Frame"
+class SEQUENCER_MT_navigation(Menu):
+    bl_label = "Navigation"
 
     def draw(self, _context):
         layout = self.layout
 
-        layout.operator("anim.previewrange_clear")
-        layout.operator("anim.previewrange_set")
+        layout.operator("screen.animation_play")
+
+        layout.separator()
+
+        layout.operator("sequencer.view_frame", text="Go to Playhead")
 
         layout.separator()
 
@@ -574,6 +633,26 @@ class SEQUENCER_MT_strip_lock_mute(Menu):
         layout.operator("sequencer.unmute", text="Unmute Deselected Strips", icon='SHOW_UNSELECTED').unselected = True
 
 
+class SEQUENCER_MT_strip_effect(Menu):
+    bl_label = "Effect Strip"
+
+    def draw(self, _context):
+        layout = self.layout
+
+        layout.operator_menu_enum("sequencer.change_effect_input", "swap")
+        layout.operator_menu_enum("sequencer.change_effect_type", "type")
+        layout.operator("sequencer.reassign_inputs")
+        layout.operator("sequencer.swap_inputs")
+
+
+class SEQUENCER_MT_strip_movie(Menu):
+    bl_label = "Movie Strip"
+
+    def draw(self, _context):
+        layout = self.layout
+
+        layout.operator("sequencer.rendersize")
+        layout.operator("sequencer.deinterlace_selected_movies")
 
 
 class SEQUENCER_MT_strip(Menu):
@@ -590,14 +669,14 @@ class SEQUENCER_MT_strip(Menu):
         layout.operator("sequencer.offset_clear")
 
         layout.separator()
+        layout.operator("sequencer.cut", text="Cut", icon='SEQ_CUT_HARD_AT_FRAME').type = 'SOFT'
+        layout.operator("sequencer.cut", text="Hold Cut", icon='SEQ_CUT_SOFT_AT_FRAME').type = 'HARD'
+
+        layout.separator()
         layout.operator("sequencer.copy", text="Copy", icon='COPYDOWN')
         layout.operator("sequencer.paste", text="Paste", icon='PASTEDOWN')
         layout.operator("sequencer.duplicate_move", icon='DUPLICATE')
         layout.operator("sequencer.delete", text="Delete...", icon='DELETE')
-
-        layout.separator()
-        layout.operator("sequencer.cut", text="Cut (Hard) at Playhead", icon='SEQ_CUT_HARD_AT_FRAME').type = 'HARD'
-        layout.operator("sequencer.cut", text="Cut (Soft) at Playhead", icon='SEQ_CUT_SOFT_AT_FRAME').type = 'SOFT'
 
         layout.separator()
         layout.operator("sequencer.deinterlace_selected_movies")
@@ -644,7 +723,81 @@ class SEQUENCER_MT_strip(Menu):
         layout.separator()
         layout.menu("SEQUENCER_MT_strip_input")
 
+
+class SEQUENCER_MT_context_menu(Menu):
+    bl_label = "Sequencer Context Menu"
+
+    def draw(self, context):
+        layout = self.layout
+
+        layout.operator_context = 'INVOKE_REGION_WIN'
+
+        layout.operator("sequencer.cut", text="Cut").type = 'SOFT'
+
         layout.separator()
+
+        layout.operator("sequencer.copy", text="Copy", icon='COPYDOWN')
+        layout.operator("sequencer.paste", text="Paste", icon='PASTEDOWN')
+        layout.operator("sequencer.duplicate_move")
+        layout.operator("sequencer.delete", text="Delete...")
+
+        layout.separator()
+
+        layout.operator("sequencer.slip", text="Slip Strip Contents")
+        layout.operator("sequencer.snap")
+
+        layout.separator()
+
+        layout.operator("sequencer.gap_remove").all = False
+        layout.operator("sequencer.gap_insert")
+
+        strip = act_strip(context)
+
+        if strip:
+            strip_type = strip.type
+
+            if strip_type != 'SOUND':
+
+                layout.separator()
+                layout.operator_menu_enum("sequencer.strip_modifier_add", "type", text="Add Modifier")
+                layout.operator("sequencer.strip_modifier_copy", text="Copy Modifiers to Selection")
+
+                if selected_sequences_len(context) >= 2:
+                    layout.separator()
+                    col = layout.column()
+                    col.menu("SEQUENCER_MT_add_transitions", text="Add Transition")
+
+            elif selected_sequences_len(context) >= 2:
+                layout.separator()
+                layout.operator("sequencer.crossfade_sounds", text="Crossfade Sounds")
+
+            if strip_type in {
+                    'CROSS', 'ADD', 'SUBTRACT', 'ALPHA_OVER', 'ALPHA_UNDER',
+                    'GAMMA_CROSS', 'MULTIPLY', 'OVER_DROP', 'WIPE', 'GLOW',
+                    'TRANSFORM', 'COLOR', 'SPEED', 'MULTICAM', 'ADJUSTMENT',
+                    'GAUSSIAN_BLUR', 'TEXT',
+            }:
+                layout.separator()
+                layout.menu("SEQUENCER_MT_strip_effect")
+            elif strip_type in 'MOVIE':
+                layout.separator()
+                layout.menu("SEQUENCER_MT_strip_movie")
+            elif strip_type == 'IMAGE':
+                layout.separator()
+                layout.operator("sequencer.rendersize")
+                layout.operator("sequencer.images_separate")
+            elif strip_type == 'META':
+                layout.separator()
+                layout.operator("sequencer.meta_make")
+                layout.operator("sequencer.meta_separate")
+                layout.operator("sequencer.meta_toggle", text="Toggle Meta")
+            if strip_type != 'META':
+                layout.separator()
+                layout.operator("sequencer.meta_make")
+                layout.operator("sequencer.meta_toggle", text="Toggle Meta")
+
+        layout.separator()
+
         layout.menu("SEQUENCER_MT_strip_lock_mute")
 
 
@@ -675,79 +828,107 @@ class SequencerButtonsPanel_Output:
         return cls.has_preview(context)
 
 
-class SEQUENCER_PT_edit(SequencerButtonsPanel, Panel):
-    bl_label = "Edit Strip"
+class SEQUENCER_PT_strip(SequencerButtonsPanel, Panel):
+    bl_label = ""
+    bl_options = {'HIDE_HEADER'}
     bl_category = "Strip"
 
     def draw(self, context):
-
         layout = self.layout
-
-        scene = context.scene
-        frame_current = scene.frame_current
         strip = act_strip(context)
-
-        split = layout.split(factor=0.25)
-        split.label(text="Name:")
-        split.prop(strip, "name", text="")
-
-        split = layout.split(factor=0.25)
-        split.label(text="Type:")
-        split.prop(strip, "type", text="")
-
         strip_type = strip.type
 
-        if strip_type != 'SOUND':
-            split = layout.split(factor=0.25)
-            split.label(text="Blend:")
-            split.prop(strip, "blend_type", text="")
-
-            row = layout.row(align=True)
-            sub = row.row(align=True)
-            sub.active = (not strip.mute)
-            sub.prop(strip, "blend_alpha", text="Opacity", slider=True)
-            row.prop(strip, "mute", toggle=True, icon_only=True)
-
+        if strip_type in {
+                'ADD', 'SUBTRACT', 'ALPHA_OVER', 'ALPHA_UNDER', 'MULTIPLY',
+                'OVER_DROP', 'GLOW', 'TRANSFORM', 'SPEED', 'MULTICAM',
+                'GAUSSIAN_BLUR', 'COLORMIX',
+        }:
+            icon_header = 'SHADERFX'
+        elif strip_type in {
+                'CROSS', 'GAMMA_CROSS', 'WIPE',
+        }:
+            icon_header = 'ARROW_LEFTRIGHT'
+        elif strip_type == 'SCENE':
+            icon_header = 'SCENE_DATA'
+        elif strip_type == 'MOVIECLIP':
+            icon_header = 'TRACKER'
+        elif strip_type == 'MASK':
+            icon_header = 'MOD_MASK'
+        elif strip_type == 'MOVIE':
+            icon_header = 'FILE_MOVIE'
+        elif strip_type == 'SOUND':
+            icon_header = 'FILE_SOUND'
+        elif strip_type == 'IMAGE':
+            icon_header = 'FILE_IMAGE'
+        elif strip_type == 'COLOR':
+            icon_header = 'COLOR'
+        elif strip_type == 'TEXT':
+            icon_header = 'FONT_DATA'
+        elif strip_type == 'ADJUSTMENT':
+            icon_header = 'COLOR'
         else:
-            row = layout.row()
-            row.prop(strip, "mute", toggle=True, icon_only=True, icon='MUTE_IPO_OFF')
+            icon_header = 'SEQ_SEQUENCER'
+
+        row = layout.row()
+        row.label(text="", icon=icon_header)
+        row.prop(strip, "name", text="")
+        row.prop(strip, "mute", toggle=True, icon_only=True, emboss=False)
+
+
+class SEQUENCER_PT_adjust_transform_offset(SequencerButtonsPanel, Panel):
+    bl_label = "Offset"
+    bl_parent_id = "SEQUENCER_PT_adjust_transform"
+    bl_options = {'DEFAULT_CLOSED'}
+    bl_category = "Strip"
+
+    @classmethod
+    def poll(cls, context):
+        strip = act_strip(context)
+        return strip.type != 'SOUND'
+
+    def draw_header(self, context):
+        strip = act_strip(context)
+        self.layout.prop(strip, "use_translation", text="")
+
+    def draw(self, context):
+        strip = act_strip(context)
+        layout = self.layout
+        layout.use_property_split = True
+
+        layout.active = strip.use_translation and (not strip.mute)
 
         col = layout.column(align=True)
-        row = col.row(align=True)
+        col.prop(strip.transform, "offset_x", text="Position X")
+        col.prop(strip.transform, "offset_y", text="Y")
 
-        row_sub = row.row(align=True)
-        row_sub.enabled = not strip.lock
-        row_sub.prop(strip, "channel")
-        row.prop(strip, "lock", toggle=True, icon_only=True)
 
-        sub = col.column(align=True)
-        sub.enabled = not strip.lock
-        sub.prop(strip, "frame_start")
-        sub.prop(strip, "frame_final_duration")
+class SEQUENCER_PT_adjust_transform_crop(SequencerButtonsPanel, Panel):
+    bl_label = "Crop"
+    bl_parent_id = "SEQUENCER_PT_adjust_transform"
+    bl_options = {'DEFAULT_CLOSED'}
+    bl_category = "Strip"
+
+    @classmethod
+    def poll(cls, context):
+        strip = act_strip(context)
+        return strip.type != 'SOUND'
+
+    def draw_header(self, context):
+        strip = act_strip(context)
+        self.layout.prop(strip, "use_crop", text="")
+
+    def draw(self, context):
+        strip = act_strip(context)
+        layout = self.layout
+        layout.use_property_split = True
+
+        layout.active = strip.use_crop and (not strip.mute)
 
         col = layout.column(align=True)
-        row = col.row(align=True)
-        row.label(text=iface_("Final Length: %s") % bpy.utils.smpte_from_frame(strip.frame_final_duration),
-                  translate=False)
-        row = col.row(align=True)
-        row.active = strip.frame_start <= frame_current <= strip.frame_start + strip.frame_duration
-        row.label(text=iface_("Playhead: %d") % (frame_current - strip.frame_start), translate=False)
-
-        col.label(text=iface_("Frame Offset %d:%d") % (strip.frame_offset_start, strip.frame_offset_end),
-                  translate=False)
-        col.label(text=iface_("Frame Still %d:%d") % (strip.frame_still_start, strip.frame_still_end), translate=False)
-
-        elem = False
-
-        if strip.type == 'IMAGE':
-            elem = strip.strip_elem_from_frame(frame_current)
-        elif strip.type == 'MOVIE':
-            elem = strip.elements[0]
-
-        if elem and elem.orig_width > 0 and elem.orig_height > 0:
-            col.label(text=iface_("Original Dimension: %dx%d") % (elem.orig_width, elem.orig_height), translate=False)
-        else:
-            col.label(text="Original Dimension: None")
+        col.prop(strip.crop, "min_x")
+        col.prop(strip.crop, "max_x")
+        col.prop(strip.crop, "max_y")
+        col.prop(strip.crop, "min_y" )
 
 
 class SEQUENCER_PT_effect(SequencerButtonsPanel, Panel):
@@ -896,10 +1077,10 @@ class SEQUENCER_PT_effect(SequencerButtonsPanel, Panel):
             rowsub.active = strip.use_shadow
             rowsub.prop(strip, "shadow_color", text="")
 
-            col.prop(strip, "align_x")
-            col.prop(strip, "align_y", text="Y")
+            col.prop(strip, "align_x", text="Horizontal")
+            col.prop(strip, "align_y", text="Vertical")
             row = col.row(align=True)
-            row.prop(strip, "location", text="Location")
+            row.prop(strip, "location", text="Location", slider=True)
             col.prop(strip, "wrap_width")
 
             layout.operator("sequencer.export_subtitles", text="Export Subtitles", icon='EXPORT')
@@ -921,8 +1102,9 @@ class SEQUENCER_PT_effect(SequencerButtonsPanel, Panel):
             row.prop(strip, "factor", slider=True)
 
 
-class SEQUENCER_PT_input(SequencerButtonsPanel, Panel):
-    bl_label = "Strip Input"
+class SEQUENCER_PT_source(SequencerButtonsPanel, Panel):
+    bl_label = "Source"
+    bl_options = {'DEFAULT_CLOSED'}
     bl_category = "Strip"
 
     @classmethod
@@ -934,13 +1116,7 @@ class SEQUENCER_PT_input(SequencerButtonsPanel, Panel):
         if not strip:
             return False
 
-        return strip.type in {
-            'MOVIE', 'IMAGE', 'SCENE', 'MOVIECLIP', 'META',
-            'ADD', 'SUBTRACT', 'ALPHA_OVER', 'ALPHA_UNDER',
-            'CROSS', 'GAMMA_CROSS', 'MULTIPLY', 'OVER_DROP',
-            'WIPE', 'GLOW', 'TRANSFORM', 'COLOR',
-            'MULTICAM', 'SPEED', 'ADJUSTMENT', 'COLORMIX'
-        }
+        return strip.type in {'MOVIE', 'IMAGE', 'SOUND'}
 
     def draw(self, context):
         layout = self.layout
@@ -948,62 +1124,64 @@ class SEQUENCER_PT_input(SequencerButtonsPanel, Panel):
         layout.use_property_decorate = False
 
         scene = context.scene
-
         strip = act_strip(context)
         strip_type = strip.type
 
-        seq_type = strip.type
+        layout.active = not strip.mute
 
-        # draw a filename if we have one
-        if seq_type == 'IMAGE':
-            split = layout.split(factor=0.2)
-            split.label(text="Path:")
-            split.prop(strip, "directory", text="")
+        # Draw a filename if we have one.
+        if strip_type == 'SOUND':
+            sound = strip.sound
+            layout.template_ID(strip, "sound", open="sound.open")
+            if sound is not None:
 
-            # Current element for the filename
+                col = layout.column()
+                col.prop(sound, "filepath", text="")
 
-            elem = strip.strip_elem_from_frame(scene.frame_current)
-            if elem:
-                split = layout.split(factor=0.2)
-                split.label(text="File:")
-                split.prop(elem, "filename", text="")  # strip.elements[0] could be a fallback
+                col.alignment = 'RIGHT'
+                sub = col.column(align=True)
+                split = sub.split(factor=0.5, align=True)
+                split.alignment = 'RIGHT'
+                if sound.packed_file:
+                    split.label(text="Unpack")
+                    split.operator("sound.unpack", icon='PACKAGE', text="")
+                else:
+                    split.label(text="Pack")
+                    split.operator("sound.pack", icon='UGLYPACKAGE', text="")
 
-            split = layout.split(factor=0.4)
-            split.label(text="Color Space:")
-            split.prop(strip.colorspace_settings, "name", text="")
+                layout.prop(sound, "use_memory_cache")
+        else:
+            if strip_type == 'IMAGE':
+                col = layout.column()
+                col.prop(strip, "directory", text="")
 
-            split = layout.split(factor=0.4)
-            split.label(text="Alpha:")
-            split.prop(strip, "alpha_mode", text="")
+                # Current element for the filename.
+                elem = strip.strip_elem_from_frame(scene.frame_current)
+                if elem:
+                    col.prop(elem, "filename", text="")  # strip.elements[0] could be a fallback
 
-            layout.operator("sequencer.change_path", icon='FILEBROWSER').filter_image = True
+                col.prop(strip.colorspace_settings, "name", text="Color Space")
 
-        elif seq_type == 'MOVIE':
-            split = layout.split(factor=0.2)
-            split.label(text="Path:")
-            split.prop(strip, "filepath", text="")
+                col.prop(strip, "alpha_mode", text="Alpha")
+                sub = col.column(align=True)
+                sub.operator("sequencer.change_path", text="Change Data/Files", icon='FILEBROWSER').filter_image = True
+            else:  # elif strip_type == 'MOVIE':
+                elem = strip.elements[0]
 
-            split = layout.split(factor=0.4)
-            split.label(text="Color Space:")
-            split.prop(strip.colorspace_settings, "name", text="")
+                col = layout.column()
+                col.prop(strip, "filepath", text="")
+                col.prop(strip.colorspace_settings, "name", text="Color Space")
+                col.prop(strip, "mpeg_preseek")
+                col.prop(strip, "stream_index")
+                col.prop(strip, "use_deinterlace")
 
-            layout.prop(strip, "mpeg_preseek")
-            layout.prop(strip, "stream_index")
+            if scene.render.use_multiview:
+                layout.prop(strip, "use_multiview")
 
-        layout.prop(strip, "use_translation", text="Image Offset")
-        if strip.use_translation:
-            row = layout.row(align=True)
-            row.prop(strip.transform, "offset_x", text="X")
-            row.prop(strip.transform, "offset_y", text="Y")
+                col = layout.column()
+                col.active = strip.use_multiview
 
-        layout.prop(strip, "use_crop", text="Image Crop")
-        if strip.use_crop:
-            col = layout.column(align=True)
-            col.prop(strip.crop, "max_y")
-            row = col.row(align=True)
-            row.prop(strip.crop, "min_x")
-            row.prop(strip.crop, "max_x")
-            col.prop(strip.crop, "min_y")
+                col.row().prop(strip, "views_format", expand=True)
 
             box = col.box()
             box.active = strip.views_format == 'STEREO_3D'
@@ -1043,7 +1221,6 @@ class SEQUENCER_PT_sound(SequencerButtonsPanel, Panel):
         layout = self.layout
         layout.use_property_split = True
 
-        st = context.space_data
         strip = act_strip(context)
         sound = strip.sound
 
@@ -1053,35 +1230,22 @@ class SEQUENCER_PT_sound(SequencerButtonsPanel, Panel):
         if sound is not None:
             layout.prop(sound, "filepath", text="")
 
-            row = layout.row()
+            layout.use_property_split = True
+            layout.use_property_decorate = False
+
+            layout.alignment = 'RIGHT'
+            sub = layout.column(align=True)
+            split = sub.split(factor=0.5, align=True)
+            split.alignment = 'RIGHT'
             if sound.packed_file:
-                row.operator("sound.unpack", icon='PACKAGE', text="Unpack")
+                split.label(text="Unpack")
+                split.operator("sound.unpack", icon='PACKAGE', text="")
             else:
-                row.operator("sound.pack", icon='UGLYPACKAGE', text="Pack")
+                split.label(text="Pack")
+                split.operator("sound.pack", icon='UGLYPACKAGE', text="")
 
-            row.prop(sound, "use_memory_cache")
+            layout.prop(sound, "use_memory_cache")
 
-            layout.prop(sound, "use_mono")
-
-        if st.waveform_display_type == 'DEFAULT_WAVEFORMS':
-            layout.prop(strip, "show_waveform")
-
-        col = layout.column(align=True)
-        col.prop(strip, "volume")
-        col.prop(strip, "pitch")
-        col.prop(strip, "pan")
-
-        col = layout.column(align=True)
-        col.label(text="Trim Duration (hard):")
-        row = layout.row(align=True)
-        row.prop(strip, "animation_offset_start", text="Start")
-        row.prop(strip, "animation_offset_end", text="End")
-
-        col = layout.column(align=True)
-        col.label(text="Trim Duration (soft):")
-        row = layout.row(align=True)
-        row.prop(strip, "frame_offset_start", text="Start")
-        row.prop(strip, "frame_offset_end", text="End")
 
 
 class SEQUENCER_PT_scene(SequencerButtonsPanel, Panel):
@@ -1116,7 +1280,7 @@ class SEQUENCER_PT_scene(SequencerButtonsPanel, Panel):
         if scene:
             layout.prop(scene, "audio_volume", text="Volume")
 
-        if strip.scene_input == '3D_CAMERA':
+        if strip.scene_input == 'CAMERA':
             layout.alignment = 'RIGHT'
             sub = layout.column(align=True)
             split = sub.split(factor=0.5, align=True)
@@ -1126,20 +1290,11 @@ class SEQUENCER_PT_scene(SequencerButtonsPanel, Panel):
 
             layout.prop(strip, "use_grease_pencil", text="Show Grease Pencil")
 
-        if scene:
-            layout.prop(scene, "audio_volume", text="Audio Volume")
-
-        if not strip.use_sequence:
             if scene:
                 # Warning, this is not a good convention to follow.
                 # Expose here because setting the alpha from the 'Render' menu is very inconvenient.
-                layout.label(text="Preview")
-                layout.prop(scene.render, "alpha_mode")
-
-        if scene:
-            sta = scene.frame_start
-            end = scene.frame_end
-            layout.label(text=iface_("Original frame range: %d-%d (%d)") % (sta, end, end - sta + 1), translate=False)
+                # layout.label(text="Preview")
+                layout.prop(scene.render, "film_transparent")
 
 
 class SEQUENCER_PT_mask(SequencerButtonsPanel, Panel):
@@ -1175,8 +1330,247 @@ class SEQUENCER_PT_mask(SequencerButtonsPanel, Panel):
             layout.label(text=iface_("Original frame range: %d-%d (%d)") % (sta, end, end - sta + 1), translate=False)
 
 
-class SEQUENCER_PT_filter(SequencerButtonsPanel, Panel):
-    bl_label = "Filter"
+class SEQUENCER_PT_time(SequencerButtonsPanel, Panel):
+    bl_label = "Time"
+    bl_options = {'DEFAULT_CLOSED'}
+    bl_category = "Strip"
+
+    @classmethod
+    def poll(cls, context):
+        if not cls.has_sequencer(context):
+            return False
+
+        strip = act_strip(context)
+        if not strip:
+            return False
+
+        return strip.type
+
+    def draw_header_preset(self, context):
+        layout = self.layout
+        layout.alignment = 'RIGHT'
+        strip = act_strip(context)
+
+        layout.prop(strip, "lock", text="", icon_only=True, emboss=False)
+
+    def draw(self, context):
+        from bpy.utils import smpte_from_frame
+
+        layout = self.layout
+        layout.use_property_split = False
+        layout.use_property_decorate = False
+
+        scene = context.scene
+        frame_current = scene.frame_current
+        strip = act_strip(context)
+
+        length_list = (
+            str(strip.frame_start),
+            str(strip.frame_final_end),
+            str(strip.frame_final_duration),
+            str(strip.frame_offset_start),
+            str(strip.frame_offset_end),
+        )
+
+        if not isinstance(strip, bpy.types.EffectSequence):
+            length_list = length_list + (
+                str(strip.animation_offset_start),
+                str(strip.animation_offset_end),
+            )
+
+        max_length = max(len(x) for x in length_list)
+        max_factor = (1.9 - max_length) / 30
+
+        layout.enabled = not strip.lock
+        layout.active = not strip.mute
+
+        sub = layout.row(align=True)
+        split = sub.split(factor=0.5 + max_factor)
+        split.alignment = 'RIGHT'
+        split.label(text='Channel')
+        split.prop(strip, "channel", text="")
+
+        sub = layout.column(align=True)
+        split = sub.split(factor=0.5 + max_factor, align=True)
+        split.alignment = 'RIGHT'
+        split.label(text="Start")
+        split.prop(strip, "frame_final_start", text=smpte_from_frame(strip.frame_final_start))
+
+        split = sub.split(factor=0.5 + max_factor, align=True)
+        split.alignment = 'RIGHT'
+        split.label(text="End")
+        split.prop(strip, "frame_final_end", text=smpte_from_frame(strip.frame_final_end))
+
+        split = sub.split(factor=0.5 + max_factor, align=True)
+        split.alignment = 'RIGHT'
+        split.label(text="Duration")
+        split.prop(strip, "frame_final_duration", text=smpte_from_frame(strip.frame_final_duration))
+
+        if not isinstance(strip, bpy.types.EffectSequence):
+
+            layout.alignment = 'RIGHT'
+            sub = layout.column(align=True)
+
+            split = sub.split(factor=0.5 + max_factor, align=True)
+            split.alignment = 'RIGHT'
+            split.label(text="Strip Offset Start")
+            split.prop(strip, "frame_offset_start", text=smpte_from_frame(strip.frame_offset_start))
+
+            split = sub.split(factor=0.5 + max_factor, align=True)
+            split.alignment = 'RIGHT'
+            split.label(text='End')
+            split.prop(strip, "frame_offset_end", text=smpte_from_frame(strip.frame_offset_end))
+
+            layout.alignment = 'RIGHT'
+            sub = layout.column(align=True)
+
+            split = sub.split(factor=0.5 + max_factor, align=True)
+            split.alignment = 'RIGHT'
+            split.label(text="Hold Offset Start")
+            split.prop(strip, "animation_offset_start", text=smpte_from_frame(strip.animation_offset_start))
+
+            split = sub.split(factor=0.5 + max_factor, align=True)
+            split.alignment = 'RIGHT'
+            split.label(text='End')
+            split.prop(strip, "animation_offset_end", text=smpte_from_frame(strip.animation_offset_end))
+
+        col = layout.column(align=True)
+        col = col.box()
+        col.active = (
+            (frame_current >= strip.frame_final_start) and
+            (frame_current <= strip.frame_final_start + strip.frame_final_duration)
+        )
+
+        split = col.split(factor=0.5 + max_factor, align=True)
+        split.alignment = 'RIGHT'
+        split.label(text="Playhead")
+        split = split.split(factor=0.8 + max_factor, align=True)
+        playhead = frame_current - strip.frame_final_start
+        split.label(text='{:>14}'.format(smpte_from_frame(playhead) + ":"))
+        split.alignment = 'RIGHT'
+        split.label(text=str(playhead) + " ")
+
+        if strip.type == 'SCENE':
+            scene = strip.scene
+
+            if scene:
+                sta = scene.frame_start
+                end = scene.frame_end
+                split = col.split(factor=0.5 + max_factor)
+                split.alignment = 'RIGHT'
+                split.label(text="Original Frame Range")
+                split.alignment = 'LEFT'
+                split.label(text="%d-%d (%d)" % (sta, end, end - sta + 1), translate=False)
+
+
+class SEQUENCER_PT_adjust(SequencerButtonsPanel, Panel):
+    bl_label = "Adjust"
+    bl_category = "Strip"
+
+    def draw(self, context):
+        pass
+
+
+class SEQUENCER_PT_adjust_sound(SequencerButtonsPanel, Panel):
+    bl_label = "Sound"
+    bl_parent_id = "SEQUENCER_PT_adjust"
+    bl_category = "Strip"
+
+    @classmethod
+    def poll(cls, context):
+        strip = act_strip(context)
+        return strip.type == 'SOUND'
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+
+        st = context.space_data
+        strip = act_strip(context)
+        sound = strip.sound
+
+        layout.active = not strip.mute
+
+        col = layout.column()
+
+        col.prop(strip, "volume", text="Volume")
+        col.prop(strip, "pitch")
+        col.prop(strip, "pan")
+
+        if sound is not None:
+
+            if st.waveform_display_type == 'DEFAULT_WAVEFORMS':
+                col.prop(strip, "show_waveform")
+            col.prop(sound, "use_mono")
+
+
+class SEQUENCER_PT_adjust_comp(SequencerButtonsPanel, Panel):
+    bl_label = "Compositing"
+    bl_parent_id = "SEQUENCER_PT_adjust"
+    bl_category = "Strip"
+
+    @classmethod
+    def poll(cls, context):
+        strip = act_strip(context)
+        return strip.type != 'SOUND'
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+
+        strip = act_strip(context)
+
+        layout.active = not strip.mute
+
+        col = layout.column()
+        col.prop(strip, "blend_type", text="Blend")
+        col.prop(strip, "blend_alpha", text="Opacity", slider=True)
+
+
+class SEQUENCER_PT_adjust_transform(SequencerButtonsPanel, Panel):
+    bl_label = "Transform"
+    bl_parent_id = "SEQUENCER_PT_adjust"
+    bl_category = "Strip"
+
+    @classmethod
+    def poll(cls, context):
+        if not cls.has_sequencer(context):
+            return False
+
+        strip = act_strip(context)
+        if not strip:
+            return False
+
+        return strip.type in {
+            'MOVIE', 'IMAGE', 'SCENE', 'MOVIECLIP', 'MASK',
+            'META', 'ADD', 'SUBTRACT', 'ALPHA_OVER',
+            'ALPHA_UNDER', 'CROSS', 'GAMMA_CROSS', 'MULTIPLY',
+            'OVER_DROP', 'WIPE', 'GLOW', 'TRANSFORM', 'COLOR',
+            'MULTICAM', 'SPEED', 'ADJUSTMENT', 'COLORMIX'
+        }
+
+    def draw(self, context):
+        layout = self.layout
+        strip = act_strip(context)
+
+        layout.active = not strip.mute
+
+        split = layout.split()
+
+        col = split.column()
+        col.alignment = 'RIGHT'
+        col.label(text="Mirror")
+
+        col = split.column()
+        row = col.row(align=True)
+        row.prop(strip, "use_flip_x", text="X", toggle=True)
+        row.prop(strip, "use_flip_y", text="Y", toggle=True)
+
+
+class SEQUENCER_PT_adjust_video(SequencerButtonsPanel, Panel):
+    bl_label = "Video"
+    bl_parent_id = "SEQUENCER_PT_adjust"
+    bl_options = {'DEFAULT_CLOSED'}
     bl_category = "Strip"
 
     @classmethod
@@ -1199,10 +1593,14 @@ class SEQUENCER_PT_filter(SequencerButtonsPanel, Panel):
     def draw(self, context):
         layout = self.layout
 
-        strip = act_strip(context)
+        layout.use_property_split = True
 
         col = layout.column()
-        col.label(text="Video:")
+
+        strip = act_strip(context)
+
+        layout.active = not strip.mute
+
         col.prop(strip, "strobe")
 
         if strip.type == 'MOVIECLIP':
@@ -1215,17 +1613,41 @@ class SEQUENCER_PT_filter(SequencerButtonsPanel, Panel):
             col.prop(strip, "undistort")
             col.separator()
 
-        split = layout.split(factor=0.6)
-        col = split.column()
-        #col.prop(strip, "use_reverse_frames", text="Reverse")
-        col.prop(strip, "use_deinterlace")
+        col.prop(strip, "playback_direction")
 
-        col = split.column()
-        col.prop(strip, "use_flip_x", text="X Flip")
-        col.prop(strip, "use_flip_y", text="Y Flip")
 
-        layout.label(text="Color:")
-        col = layout.column(align=True)
+class SEQUENCER_PT_adjust_color(SequencerButtonsPanel, Panel):
+    bl_label = "Color"
+    bl_parent_id = "SEQUENCER_PT_adjust"
+    bl_options = {'DEFAULT_CLOSED'}
+    bl_category = "Strip"
+
+    @classmethod
+    def poll(cls, context):
+        if not cls.has_sequencer(context):
+            return False
+
+        strip = act_strip(context)
+        if not strip:
+            return False
+
+        return strip.type in {
+            'MOVIE', 'IMAGE', 'SCENE', 'MOVIECLIP', 'MASK',
+            'META', 'ADD', 'SUBTRACT', 'ALPHA_OVER',
+            'ALPHA_UNDER', 'CROSS', 'GAMMA_CROSS', 'MULTIPLY',
+            'OVER_DROP', 'WIPE', 'GLOW', 'TRANSFORM', 'COLOR',
+            'MULTICAM', 'SPEED', 'ADJUSTMENT', 'COLORMIX'
+        }
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+
+        strip = act_strip(context)
+
+        layout.active = not strip.mute
+
+        col = layout.column()
         col.prop(strip, "color_saturation", text="Saturation")
         col.prop(strip, "color_multiply", text="Multiply")
         col.prop(strip, "use_float", text="Convert to Float")
@@ -1419,6 +1841,32 @@ class SEQUENCER_PT_view(SequencerButtonsPanel_Output, Panel):
         col.prop(st, "proxy_render_size")
 
 
+class SEQUENCER_PT_frame_overlay(SequencerButtonsPanel_Output, Panel):
+    bl_label = "Frame Overlay"
+    bl_category = "View"
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw_header(self, context):
+        scene = context.scene
+        ed = scene.sequence_editor
+
+        self.layout.prop(ed, "show_overlay", text="")
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        st = context.space_data
+        scene = context.scene
+        ed = scene.sequence_editor
+
+        layout.active = ed.show_overlay
+
+        col = layout.column()
+        col.prop(ed, "overlay_frame", text="Frame Offset")
+        col.prop(st, "overlay_type")
+        col.prop(ed, "use_overlay_lock")
 class SEQUENCER_PT_view_safe_areas(SequencerButtonsPanel_Output, Panel):
     bl_label = "Safe Areas"
     bl_options = {'DEFAULT_CLOSED'}
@@ -1441,7 +1889,38 @@ class SEQUENCER_PT_view_safe_areas(SequencerButtonsPanel_Output, Panel):
         st = context.space_data
         safe_data = context.scene.safe_areas
 
-        draw_display_safe_settings(layout, safe_data, st)
+        layout.active = st.show_safe_areas
+
+        col = layout.column()
+
+        sub = col.column()
+        sub.prop(safe_data, "title", slider=True)
+        sub.prop(safe_data, "action", slider=True)
+
+
+class SEQUENCER_PT_view_safe_areas_center_cut(SequencerButtonsPanel_Output, Panel):
+    bl_label = "Center-Cut Safe Areas"
+    bl_parent_id = "SEQUENCER_PT_view_safe_areas"
+    bl_options = {'DEFAULT_CLOSED'}
+    bl_category = "View"
+
+    def draw_header(self, context):
+        st = context.space_data
+
+        layout = self.layout
+        layout.active = st.show_safe_areas
+        layout.prop(st, "show_safe_center", text="")
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        safe_data = context.scene.safe_areas
+        st = context.space_data
+
+        layout.active = st.show_safe_areas and st.show_safe_center
+
+        col = layout.column()
+        col.prop(safe_data, "title_center", slider=True)
 
 
 class SEQUENCER_PT_modifiers(SequencerButtonsPanel, Panel):
@@ -1458,7 +1937,7 @@ class SEQUENCER_PT_modifiers(SequencerButtonsPanel, Panel):
         layout.prop(strip, "use_linear_modifiers")
 
         layout.operator_menu_enum("sequencer.strip_modifier_add", "type")
-        layout.operator("sequencer.strip_modifier_copy", icon='ICON_COPYDOWN')
+        layout.operator("sequencer.strip_modifier_copy", icon='COPYDOWN')
 
         for mod in strip.modifiers:
             box = layout.box()
@@ -1600,40 +2079,69 @@ classes = (
     SEQUENCER_MT_change,
     SEQUENCER_HT_header,
     SEQUENCER_MT_editor_menus,
+    SEQUENCER_MT_range,
     SEQUENCER_MT_view,
     SEQUENCER_MT_view_cache,
     SEQUENCER_MT_view_toggle,
-    SEQUENCER_MT_select_inverse,
-    SEQUENCER_MT_select_none,
+    SEQUENCER_MT_select_playhead,
+    SEQUENCER_MT_select_handle,
+    SEQUENCER_MT_select_channel,
+    SEQUENCER_MT_select_linked,
     SEQUENCER_MT_select,
+    SEQUENCER_MT_select_none,
+    SEQUENCER_MT_select_inverse,
     SEQUENCER_MT_marker,
-    SEQUENCER_MT_frame,
+    SEQUENCER_MT_navigation,
     SEQUENCER_MT_add,
     SEQUENCER_MT_add_effect,
     SEQUENCER_MT_add_transitions,
     SEQUENCER_MT_add_empty,
+    SEQUENCER_MT_strip_effect,
+    SEQUENCER_MT_strip_movie,
     SEQUENCER_MT_strip,
     SEQUENCER_MT_strip_transform,
     SEQUENCER_MT_strip_input,
     SEQUENCER_MT_strip_lock_mute,
-    SEQUENCER_PT_edit,
+    SEQUENCER_MT_context_menu,
+
+    SEQUENCER_PT_strip,
+
+    SEQUENCER_PT_adjust,
+    SEQUENCER_PT_adjust_comp,
+    SEQUENCER_PT_adjust_transform,
+    SEQUENCER_PT_adjust_transform_offset,
+    SEQUENCER_PT_adjust_transform_crop,
+    SEQUENCER_PT_adjust_video,
+    SEQUENCER_PT_adjust_color,
+    SEQUENCER_PT_adjust_sound,
+
     SEQUENCER_PT_effect,
-    SEQUENCER_PT_input,
-    SEQUENCER_PT_sound,
     SEQUENCER_PT_scene,
     SEQUENCER_PT_mask,
-    SEQUENCER_PT_filter,
+
+    SEQUENCER_PT_time,
+    SEQUENCER_PT_source,
+
+    SEQUENCER_PT_modifiers,
+
     SEQUENCER_PT_cache_settings,
+    SEQUENCER_PT_strip_cache,
     SEQUENCER_PT_proxy_settings,
     SEQUENCER_PT_strip_proxy,
-    SEQUENCER_PT_strip_cache,
+
+    SEQUENCER_PT_custom_props,
+
     SEQUENCER_PT_preview,
     SEQUENCER_PT_view,
+    SEQUENCER_PT_frame_overlay,
     SEQUENCER_PT_view_safe_areas,
-    SEQUENCER_PT_modifiers,
+    SEQUENCER_PT_view_safe_areas_center_cut,
+
     SEQUENCER_PT_grease_pencil,
     SEQUENCER_PT_grease_pencil_tools,
-    SEQUENCER_PT_custom_props,
+
+#BFA
+
     SEQUENCER_PT_marker_options,
     SEQUENCER_PT_view_options
 )


### PR DESCRIPTION
Video Sequencer - compare merge side panel changes from Blender 2.8 to Bforartists 2 #1000

- Merged in most of the 2.8 changes
- kept in the header refresh button for now
- made sure all the BFA changes are kept and are working
- checked and squashed all bugs in the workflow, but not with a heavy video edit test

I know this isn't standard, but I also fixed this task in the process to clear out the console issues:
Video Sequencer - wrong icon error #997