### PR TITLE
Preferences - Add Open Preferences Folder to Preferences save dialogues #1538

### DIFF
--- a/release/scripts/startup/bl_ui/space_topbar.py
+++ b/release/scripts/startup/bl_ui/space_topbar.py
@@ -18,6 +18,8 @@
 
 # <pep8 compliant>
 import bpy
+import os
+
 from bpy.types import Header, Menu, Panel
 
 
@@ -497,6 +499,8 @@ class TOPBAR_MT_edit(Menu):
 
     def draw(self, context):
         layout = self.layout
+        appdata = os.getenv('APPDATA')
+        appdatapath = appdata + "\\Bforartists\\Bforartists\\"
 
         layout.operator("ed.undo", icon='UNDO')
         layout.operator("ed.redo", icon='REDO')
@@ -529,7 +533,7 @@ class TOPBAR_MT_edit(Menu):
         layout.operator("wm.batch_rename", icon='RENAME')
 
         layout.separator()
-       
+
         layout.operator("preferences.app_template_install", text="Install Application Template", icon = "APPTEMPLATE")
 
         layout.separator()
@@ -552,6 +556,7 @@ class TOPBAR_MT_edit(Menu):
         layout.separator()
 
         layout.operator("screen.userpref_show", text="Preferences", icon='PREFERENCES')
+        layout.operator("wm.url_open", text="Open Preferences Folder", icon = "FOLDER_REDIRECT").url = appdatapath
 
 
 class TOPBAR_MT_window(Menu):

--- a/release/scripts/startup/bl_ui/space_topbar.py
+++ b/release/scripts/startup/bl_ui/space_topbar.py
@@ -18,7 +18,6 @@
 
 # <pep8 compliant>
 import bpy
-import os
 
 from bpy.types import Header, Menu, Panel
 
@@ -499,8 +498,6 @@ class TOPBAR_MT_edit(Menu):
 
     def draw(self, context):
         layout = self.layout
-        appdata = os.getenv('APPDATA')
-        appdatapath = appdata + "\\Bforartists\\Bforartists\\"
 
         layout.operator("ed.undo", icon='UNDO')
         layout.operator("ed.redo", icon='REDO')
@@ -533,9 +530,8 @@ class TOPBAR_MT_edit(Menu):
         layout.operator("wm.batch_rename", icon='RENAME')
 
         layout.separator()
-
+       
         layout.operator("preferences.app_template_install", text="Install Application Template", icon = "APPTEMPLATE")
-
         layout.separator()
 
         layout.operator_context = 'INVOKE_AREA'
@@ -554,9 +550,8 @@ class TOPBAR_MT_edit(Menu):
             props.app_template = app_template
 
         layout.separator()
-
         layout.operator("screen.userpref_show", text="Preferences", icon='PREFERENCES')
-        layout.operator("wm.url_open", text="Open Preferences Folder", icon = "FOLDER_REDIRECT").url = appdatapath
+
 
 
 class TOPBAR_MT_window(Menu):

--- a/release/scripts/startup/bl_ui/space_userpref.py
+++ b/release/scripts/startup/bl_ui/space_userpref.py
@@ -18,6 +18,17 @@
 
 # <pep8 compliant>
 import bpy
+
+#work
+import os 
+from pathlib import Path
+
+user_path = Path(bpy.utils.resource_path('USER')).parent
+local_path = Path(bpy.utils.resource_path('LOCAL')).parent
+
+
+
+
 from bpy.types import (
     Header,
     Menu,
@@ -125,6 +136,15 @@ class USERPREF_MT_save_load(Menu):
         layout.operator_context = 'INVOKE_AREA'
         layout.operator("wm.read_factory_userpref", text="Load Factory Preferences")
 
+#work        
+        layout.separator()
+
+        if os.path.isdir(Path(bpy.utils.resource_path('USER'))): 
+            layout.operator("wm.path_open", text="Open Appdata Folder", icon = "FOLDER_REDIRECT").filepath = str(user_path)
+        else:
+            layout.operator("wm.path_open", text="Open Appdata Folder", icon = "FOLDER_REDIRECT").filepath = str(local_path)
+        
+        
 
 class USERPREF_PT_save_preferences(Panel):
     bl_label = "Save Preferences"

--- a/release/scripts/startup/bl_ui/space_userpref.py
+++ b/release/scripts/startup/bl_ui/space_userpref.py
@@ -20,11 +20,14 @@
 import bpy
 
 #work
-import os
+import os 
 from pathlib import Path
 
 user_path = Path(bpy.utils.resource_path('USER')).parent
 local_path = Path(bpy.utils.resource_path('LOCAL')).parent
+
+
+
 
 from bpy.types import (
     Header,
@@ -133,15 +136,15 @@ class USERPREF_MT_save_load(Menu):
         layout.operator_context = 'INVOKE_AREA'
         layout.operator("wm.read_factory_userpref", text="Load Factory Preferences")
 
-#work
+#work        
         layout.separator()
 
-        if os.path.isdir(Path(bpy.utils.resource_path('USER'))):
+        if os.path.isdir(Path(bpy.utils.resource_path('USER'))): 
             layout.operator("wm.path_open", text="Open Appdata Folder", icon = "FOLDER_REDIRECT").filepath = str(user_path)
         else:
             layout.operator("wm.path_open", text="Open Appdata Folder", icon = "FOLDER_REDIRECT").filepath = str(local_path)
-
-
+        
+        
 
 class USERPREF_PT_save_preferences(Panel):
     bl_label = "Save Preferences"
@@ -291,8 +294,8 @@ class USERPREF_PT_interface_editors(InterfacePanel, CenterAlignMixIn, Panel):
         flow.prop(system, "use_region_overlap")
         flow.prop(view, "show_layout_ui", text="Corner Splitting")
         flow.prop(view, "show_navigate_ui")
-
-        flow.use_property_split = True
+        
+        flow.use_property_split = True      
         flow.prop(view, "color_picker_type")
         flow.row().prop(view, "header_align")
         flow.prop(view, "factor_display_type")
@@ -1432,7 +1435,7 @@ class USERPREF_PT_input_keyboard(InputPanel, CenterAlignMixIn, Panel):
     def draw_centered(self, context, layout):
         prefs = context.preferences
         inputs = prefs.inputs
-
+        
         layout.use_property_split = False
         layout.prop(inputs, "use_emulate_numpad")
         layout.prop(inputs, "use_numeric_input_advanced")
@@ -1447,7 +1450,7 @@ class USERPREF_PT_input_mouse(InputPanel, CenterAlignMixIn, Panel):
         inputs = prefs.inputs
 
         flow = layout.grid_flow(row_major=False, columns=0, even_columns=True, even_rows=False, align=False)
-
+        
         flow.use_property_split = False
         flow.prop(inputs, "use_mouse_emulate_3_button")
         if sys.platform[:3] != "win":
@@ -1456,7 +1459,7 @@ class USERPREF_PT_input_mouse(InputPanel, CenterAlignMixIn, Panel):
             rowsub.prop(inputs, "mouse_emulate_3_button_modifier")
         flow.prop(inputs, "use_mouse_continuous")
         flow.prop(inputs, "use_drag_immediately")
-
+        
         flow.use_property_split = True
         flow.prop(inputs, "mouse_double_click_time", text="Double Click Speed")
         flow.prop(inputs, "drag_threshold_mouse")


### PR DESCRIPTION
This had a chunk of messy commits, but now it's ok. I have tested it by delete/adding the appdata folder, and things are conditionally going to LOCAL or USER accordingly. 

The messy commits was due to leaving in comments, first conditional was not working, and the first commit for the idea wasn't quite right. 

This may need testing in Linux and Mac to make sure it's ok, but according to:
[This link](https://docs.blender.org/manual/en/2.79/getting_started/installing/configuration/directories.html), it shoooould be relative to the OS according to how Blender works internally with paths. 

### Note
The USER goes to parent folder, showing all bforartists preferences. Though this might not be necessary. 