### PR TITLE
task #1813, required projected falloff shape to tooltip of front faces only 

### DIFF
--- a/release/scripts/startup/bl_ui/properties_paint_common.py
+++ b/release/scripts/startup/bl_ui/properties_paint_common.py
@@ -906,7 +906,9 @@ def brush_shared_settings(layout, context, brush, popover=False):
         layout.separator()
         
     if use_frontface:
-        layout.prop(brush, "use_frontface", text="Front Faces Only")
+        col = layout.column()
+        col.prop(brush, "use_frontface", text="Front Faces Only")
+        col.active = False if brush.falloff_shape == "SPHERE" else True
         layout.separator()
 
 

--- a/source/blender/makesrna/intern/rna_brush.c
+++ b/source/blender/makesrna/intern/rna_brush.c
@@ -2369,7 +2369,8 @@ static void rna_def_brush(BlenderRNA *brna)
   RNA_def_property_int_funcs(prop, NULL, "rna_Brush_set_size", NULL);
   RNA_def_property_range(prop, 1, MAX_BRUSH_PIXEL_RADIUS * 10);
   RNA_def_property_ui_range(prop, 1, MAX_BRUSH_PIXEL_RADIUS, 1, -1);
-  RNA_def_property_ui_text(prop, "Radius", "Radius of the brush in pixels\nHotkey in the default keymap: F");
+  RNA_def_property_ui_text(
+      prop, "Radius", "Radius of the brush in pixels\nHotkey in the default keymap: F");
   RNA_def_property_update(prop, 0, "rna_Brush_size_update");
 
   prop = RNA_def_property(srna, "unprojected_radius", PROP_FLOAT, PROP_DISTANCE);
@@ -2449,8 +2450,10 @@ static void rna_def_brush(BlenderRNA *brna)
   RNA_def_property_float_sdna(prop, NULL, "alpha");
   RNA_def_property_range(prop, 0.0f, 10.0f);
   RNA_def_property_ui_range(prop, 0.0f, 1.0f, 0.001, 3);
-  RNA_def_property_ui_text(
-      prop, "Strength", "How powerful the effect of the brush is when applied\nHotkey in the default keymap: Shift F");
+  RNA_def_property_ui_text(prop,
+                           "Strength",
+                           "How powerful the effect of the brush is when applied\nHotkey in the "
+                           "default keymap: Shift F");
   RNA_def_property_update(prop, 0, "rna_Brush_update");
 
   prop = RNA_def_property(srna, "flow", PROP_FLOAT, PROP_FACTOR);
@@ -3088,7 +3091,9 @@ static void rna_def_brush(BlenderRNA *brna)
   prop = RNA_def_property(srna, "use_frontface", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_sdna(prop, NULL, "flag", BRUSH_FRONTFACE);
   RNA_def_property_ui_text(
-      prop, "Use Front-Face", "Brush only affects vertexes that face the viewer");
+      prop,
+      "Use Front-Face",
+      "Brush only affects vertexes that face the viewer. Projected falloff only");
   RNA_def_property_update(prop, 0, "rna_Brush_update");
 
   prop = RNA_def_property(srna, "use_frontface_falloff", PROP_BOOLEAN, PROP_NONE);


### PR DESCRIPTION
Fixes #1813 
new pop up message
"Brush only affects vertexes that face the viewer. Projected falloff only"
it also greys out option if falloff option is Sphere
![image](https://user-images.githubusercontent.com/25552173/96729568-941f0000-13b5-11eb-8b44-b53e1edca4b6.png)
![image](https://user-images.githubusercontent.com/25552173/96729831-dd6f4f80-13b5-11eb-9469-c12ad41e5b42.png)
