### PR TITLE
UV Editor - Options - hide pixel snap mode in Image editor #1907

### DIFF
--- a/release/scripts/startup/bl_ui/space_image.py
+++ b/release/scripts/startup/bl_ui/space_image.py
@@ -1053,10 +1053,11 @@ class IMAGE_PT_image_options(Panel):
         col.prop(sima, "use_realtime_update")
         col.prop(uv, "show_metadata")
 
-        col = layout.column()
-        col.label(text = "Pixel Snap Mode")
-        row = col.row()
-        row.prop(uv, "pixel_snap_mode", expand = True)
+        if sima.mode == 'UV':
+            col = layout.column()
+            col.label(text = "Pixel Snap Mode")
+            row = col.row()
+            row.prop(uv, "pixel_snap_mode", expand = True)
 
         if paint.brush and (context.image_paint_object or sima.mode == 'PAINT'):
             layout.prop(uv, "show_texpaint")


### PR DESCRIPTION
Fixes #1907 
![image](https://user-images.githubusercontent.com/25552173/97081129-a345be00-1600-11eb-9a32-856c1d4907c2.png)
