### PR TITLE
Timeline Sidebar - Cache panel - indent the cache types #1572

### DIFF
--- a/release/scripts/startup/bl_ui/space_time.py
+++ b/release/scripts/startup/bl_ui/space_time.py
@@ -378,18 +378,25 @@ class TIME_PT_view_view_cache(TimelinePanelButtons, Panel):
 
         st = context.space_data
 
-        layout.prop(st, "show_cache")
+        row = layout.row()
+        row.use_property_split = False
+        row.prop(st, "show_cache")
+        row.use_property_split = True
+        
+        if st.show_cache:
+            row.label(icon='DISCLOSURE_TRI_DOWN')
+            row = layout.row()
 
-        layout.separator()
-
-        col = layout.column()
-        col.enabled = st.show_cache
-        col.prop(st, "cache_softbody")
-        col.prop(st, "cache_particles")
-        col.prop(st, "cache_cloth")
-        col.prop(st, "cache_smoke")
-        col.prop(st, "cache_dynamicpaint")
-        col.prop(st, "cache_rigidbody")
+            row.separator() #indent
+            col = row.column()
+            col.prop(st, "cache_softbody")
+            col.prop(st, "cache_particles")
+            col.prop(st, "cache_cloth")
+            col.prop(st, "cache_smoke")
+            col.prop(st, "cache_dynamicpaint")
+            col.prop(st, "cache_rigidbody")
+        else:
+            row.label(icon='DISCLOSURE_TRI_RIGHT')
 
 
 class TIME_PT_auto_keyframing(TimelinePanelButtons, Panel):


### PR DESCRIPTION
Fixes #1572 
![image](https://user-images.githubusercontent.com/25552173/97443140-541ac880-1933-11eb-8c71-fec4ee952ec6.png)
