### PR TITLE
Adjust last operation - middle aligned props when called with hotkey …

### DIFF
--- a/source/blender/windowmanager/intern/wm_operators.c
+++ b/source/blender/windowmanager/intern/wm_operators.c
@@ -1323,7 +1323,7 @@ static uiBlock *wm_block_create_redo(bContext *C, ARegion *region, void *arg_op)
 
   uiLayout *col = uiLayoutColumn(layout, false);
   uiTemplateOperatorPropertyButs(
-      C, col, op, UI_BUT_LABEL_ALIGN_NONE, UI_TEMPLATE_OP_PROPS_SHOW_TITLE);
+      C, col, op, UI_BUT_LABEL_ALIGN_SPLIT_COLUMN, UI_TEMPLATE_OP_PROPS_SHOW_TITLE);
 
   UI_block_bounds_set_popup(block, 6 * U.dpi_fac, NULL);
 


### PR DESCRIPTION
…and from the toolbar
Fixes #2032 
![image](https://user-images.githubusercontent.com/25552173/100544404-57181a00-324d-11eb-85e3-e32faaecf322.png)

![image](https://user-images.githubusercontent.com/25552173/100544408-5da69180-324d-11eb-91bc-bb5ab5ecf410.png)
