### PR TITLE
Compilation warning - missing format arguments for BLI_sprintfN #2064

### DIFF
--- a/source/blender/editors/interface/interface_region_tooltip.c
+++ b/source/blender/editors/interface/interface_region_tooltip.c
@@ -806,7 +806,7 @@ static uiTooltipData *ui_tooltip_data_from_button(bContext *C, uiBut *but)
     /*It just shows a dot then where the title should be. So we check for those buttons, and skip adding the button title*/
     if (STRPREFIX(but->drawstr, but_label.strinfo))
       {
-      field->text = BLI_sprintfN(but_label.strinfo);
+      field->text = BLI_sprintfN("%s", but_label.strinfo);
     }
     else if (!STRPREFIX(but->drawstr, but_label.strinfo)) {
       field->text = BLI_sprintfN("%s.", but_label.strinfo);


### PR DESCRIPTION
Fixes #2064 
![image](https://user-images.githubusercontent.com/25552173/101342703-9ec12600-388b-11eb-93a3-59f1542da5cd.png)
