### PR TITLE
Rename UX to Label - task #2084

### DIFF
--- a/release/scripts/startup/bl_ui/space_topbar.py
+++ b/release/scripts/startup/bl_ui/space_topbar.py
@@ -714,7 +714,7 @@ class TOPBAR_PT_name(Panel):
             item = context.active_node
             if item:
                 row = row_with_icon(layout, 'NODE')
-                row.prop(item, "name", text="")
+                row.prop(item, "label", text="")
                 found = True
         else:
             if mode == 'POSE' or (mode == 'WEIGHT_PAINT' and context.pose_object):


### PR DESCRIPTION
- Changed to set to Label instead of Name, based on a differential from Blender