### PR TITLE
Image Editor - hide disfunctional tools and settings for render result #2142

### DIFF
--- a/release/scripts/startup/bl_ui/space_image.py
+++ b/release/scripts/startup/bl_ui/space_image.py
@@ -333,8 +333,33 @@ class IMAGE_MT_image(Menu):
             if not show_render:
                 layout.operator("image.replace", text="Replace", icon='FILE_FOLDER')
                 layout.operator("image.reload", text="Reload",icon = "FILE_REFRESH")
+            
+            # bfa TODO: move this to image.external_edit poll
+            # bfa - hide disfunctional tools and settings for render result
+            import os
 
-            layout.operator("image.external_edit", text="Edit Externally", icon = "EDIT_EXTERNAL")
+            can_edit = True
+
+            if ima.packed_file:
+                can_edit = False
+
+            if sima.type == 'IMAGE_EDITOR':
+                filepath = ima.filepath_from_user(image_user=sima.image_user)
+            else:
+                filepath = ima.filepath
+
+            filepath = bpy.path.abspath(filepath, library=ima.library)
+
+            filepath = os.path.normpath(filepath)
+
+            if not filepath:
+                can_edit = False
+            
+            if not os.path.exists(filepath) or not os.path.isfile(filepath):
+                can_edit = False
+            
+            if can_edit:
+                layout.operator("image.external_edit", text="Edit Externally", icon = "EDIT_EXTERNAL")
 
         layout.separator()
 

--- a/release/scripts/startup/bl_ui/space_image.py
+++ b/release/scripts/startup/bl_ui/space_image.py
@@ -348,25 +348,26 @@ class IMAGE_MT_image(Menu):
 
         layout.operator("image.save_all_modified", text="Save All Images", icon = "SAVE_ALL")
 
+        # bfa - hide disfunctional tools and settings for render result
         if ima:
-            layout.separator()
-
-            layout.menu("IMAGE_MT_image_invert")
-            layout.operator("image.resize", text="Resize", icon = "MAN_SCALE")
-
-        if ima and not show_render:
-            if ima.packed_file:
-                if ima.filepath:
-                    layout.separator()
-                    layout.operator("image.unpack", text="Unpack", icon = "PACKAGE")
-            else:
+            if ima.type != 'RENDER_RESULT':
                 layout.separator()
-                layout.operator("image.pack", text="Pack", icon = "PACKAGE")
 
-        if ima:
-            layout.separator()
-            layout.operator("palette.extract_from_image", text="Extract Palette")
-            layout.operator("gpencil.image_to_grease_pencil", text="Generate Grease Pencil")
+                layout.menu("IMAGE_MT_image_invert")
+                layout.operator("image.resize", text="Resize", icon = "MAN_SCALE")
+
+                if not show_render:
+                    if ima.packed_file:
+                        if ima.filepath:
+                            layout.separator()
+                            layout.operator("image.unpack", text="Unpack", icon = "PACKAGE")
+                    else:
+                        layout.separator()
+                        layout.operator("image.pack", text="Pack", icon = "PACKAGE")
+
+                layout.separator()
+                layout.operator("palette.extract_from_image", text="Extract Palette")
+                layout.operator("gpencil.image_to_grease_pencil", text="Generate Grease Pencil")
 
 
 class IMAGE_MT_image_invert(Menu):
@@ -868,8 +869,16 @@ class IMAGE_HT_header(Header):
 
         ALL_MT_editormenu.draw_hidden(context, layout) # bfa - show hide the editormenu
 
+        # bfa - hide disfunctional tools and settings for render result
+        is_render = False
+        if ima:
+            is_render = ima.type == 'RENDER_RESULT'
+
         if sima.mode != 'UV':
-            layout.prop(sima, "ui_mode", text="")
+            if is_render:
+                layout.prop(sima, "ui_non_render_mode", text="")
+            else:
+                layout.prop(sima, "ui_mode", text="")
 
         # UV editing.
         if show_uvedit:

--- a/source/blender/makesrna/intern/rna_space.c
+++ b/source/blender/makesrna/intern/rna_space.c
@@ -285,6 +285,13 @@ static const EnumPropertyItem rna_enum_space_image_mode_ui_items[] = {
     {0, NULL, 0, NULL, NULL},
 };
 
+/* bfa - hide disfunctional tools and settings for render result */
+static const EnumPropertyItem rna_enum_space_image_mode_non_render_items[] = {
+    SI_ITEM_VIEW("VIEW", "View", ICON_FILE_IMAGE),
+    SI_ITEM_MASK,
+    {0, NULL, 0, NULL, NULL},
+};
+
 const EnumPropertyItem rna_enum_space_image_mode_items[] = {
     SI_ITEM_VIEW("IMAGE_EDITOR", "Image Editor", ICON_IMAGE),
     SI_ITEM_UV,
@@ -5009,6 +5016,13 @@ static void rna_def_space_image(BlenderRNA *brna)
   prop = RNA_def_property(srna, "ui_mode", PROP_ENUM, PROP_NONE);
   RNA_def_property_enum_sdna(prop, NULL, "mode");
   RNA_def_property_enum_items(prop, rna_enum_space_image_mode_ui_items);
+  RNA_def_property_ui_text(prop, "Mode", "Editing context being displayed");
+  RNA_def_property_update(prop, NC_SPACE | ND_SPACE_IMAGE, "rna_SpaceImageEditor_mode_update");
+
+  /* bfa - hide disfunctional tools and settings for render result */
+  prop = RNA_def_property(srna, "ui_non_render_mode", PROP_ENUM, PROP_NONE);
+  RNA_def_property_enum_sdna(prop, NULL, "mode");
+  RNA_def_property_enum_items(prop, rna_enum_space_image_mode_non_render_items);
   RNA_def_property_ui_text(prop, "Mode", "Editing context being displayed");
   RNA_def_property_update(prop, NC_SPACE | ND_SPACE_IMAGE, "rna_SpaceImageEditor_mode_update");
 


### PR DESCRIPTION
Fixes #2142 
another task is for Edit Externally, many cases the operator is available, but will error out..., it should have a poll function
TODO Task: implement poll function for image.external_edit operator
![image](https://user-images.githubusercontent.com/25552173/107131046-f146af00-68db-11eb-8087-4c949a9e1aef.png)
![image](https://user-images.githubusercontent.com/25552173/107131048-fc99da80-68db-11eb-8768-2404268b84f1.png)
