### PR TITLE
Transparent background for the toolshelf tools #2398

### DIFF
--- a/release/scripts/startup/bl_ui/space_toolsystem_toolbar.py
+++ b/release/scripts/startup/bl_ui/space_toolsystem_toolbar.py
@@ -2526,7 +2526,7 @@ class IMAGE_PT_tools_active(ToolSelectPanelHelper, Panel):
     bl_region_type = 'TOOLS'
     bl_label = "Tools"
     bl_category = "Tools"
-    bl_options = {'HIDE_BG'}
+    bl_options = {'HIDE_HEADER'}
 
     # Satisfy the 'ToolSelectPanelHelper' API.
     keymap_prefix = "Image Editor Tool:"
@@ -2618,7 +2618,7 @@ class NODE_PT_tools_active(ToolSelectPanelHelper, Panel):
     bl_region_type = 'TOOLS'
     bl_label = "Tools"
     bl_category = "Tools"
-    bl_options = {'HIDE_BG'}
+    bl_options = {'HIDE_HEADER'}
 
     # Satisfy the 'ToolSelectPanelHelper' API.
     keymap_prefix = "Node Editor Tool:"
@@ -2678,7 +2678,7 @@ class VIEW3D_PT_tools_active(ToolSelectPanelHelper, Panel):
     bl_region_type = 'TOOLS'
     bl_label = "Tools"
     bl_category = "Tools"
-    bl_options = {'HIDE_BG'}
+    bl_options = {'HIDE_HEADER'}
 
     # Satisfy the 'ToolSelectPanelHelper' API.
     keymap_prefix = "3D View Tool:"
@@ -3044,7 +3044,7 @@ class SEQUENCER_PT_tools_active(ToolSelectPanelHelper, Panel):
     bl_region_type = 'TOOLS'
     bl_label = "Tools"
     bl_category = "Tools"
-    bl_options = {'HIDE_BG'}
+    bl_options = {'HIDE_HEADER'}
 
     # Satisfy the 'ToolSelectPanelHelper' API.
     keymap_prefix = "Sequence Editor Tool:"

--- a/release/scripts/startup/bl_ui/space_toolsystem_toolbar.py
+++ b/release/scripts/startup/bl_ui/space_toolsystem_toolbar.py
@@ -2526,7 +2526,7 @@ class IMAGE_PT_tools_active(ToolSelectPanelHelper, Panel):
     bl_region_type = 'TOOLS'
     bl_label = "Tools"
     bl_category = "Tools"
-    bl_options = {'HIDE_HEADER'}
+    bl_options = {'HIDE_BG'}
 
     # Satisfy the 'ToolSelectPanelHelper' API.
     keymap_prefix = "Image Editor Tool:"
@@ -2618,7 +2618,7 @@ class NODE_PT_tools_active(ToolSelectPanelHelper, Panel):
     bl_region_type = 'TOOLS'
     bl_label = "Tools"
     bl_category = "Tools"
-    bl_options = {'HIDE_HEADER'}
+    bl_options = {'HIDE_BG'}
 
     # Satisfy the 'ToolSelectPanelHelper' API.
     keymap_prefix = "Node Editor Tool:"
@@ -2678,7 +2678,7 @@ class VIEW3D_PT_tools_active(ToolSelectPanelHelper, Panel):
     bl_region_type = 'TOOLS'
     bl_label = "Tools"
     bl_category = "Tools"
-    bl_options = {'HIDE_HEADER'}
+    bl_options = {'HIDE_BG'}
 
     # Satisfy the 'ToolSelectPanelHelper' API.
     keymap_prefix = "3D View Tool:"
@@ -3044,7 +3044,7 @@ class SEQUENCER_PT_tools_active(ToolSelectPanelHelper, Panel):
     bl_region_type = 'TOOLS'
     bl_label = "Tools"
     bl_category = "Tools"
-    bl_options = {'HIDE_HEADER'}
+    bl_options = {'HIDE_BG'}
 
     # Satisfy the 'ToolSelectPanelHelper' API.
     keymap_prefix = "Sequence Editor Tool:"

--- a/source/blender/blenkernel/BKE_screen.h
+++ b/source/blender/blenkernel/BKE_screen.h
@@ -305,6 +305,8 @@ enum {
   PANEL_TYPE_DRAW_BOX = (1 << 6),
   /** Don't search panels with this type during property search. */
   PANEL_TYPE_NO_SEARCH = (1 << 7),
+  /** Make panel background fully transparent **/
+  PANEL_HIDE_BG = (1 << 8),
 };
 
 /* uilist types */

--- a/source/blender/blenkernel/BKE_screen.h
+++ b/source/blender/blenkernel/BKE_screen.h
@@ -305,7 +305,7 @@ enum {
   PANEL_TYPE_DRAW_BOX = (1 << 6),
   /** Don't search panels with this type during property search. */
   PANEL_TYPE_NO_SEARCH = (1 << 7),
-  /** Make panel background fully transparent **/
+  /** bfa - Make panel background fully transparent **/
   PANEL_HIDE_BG = (1 << 8),
 };
 

--- a/source/blender/editors/interface/interface_panel.c
+++ b/source/blender/editors/interface/interface_panel.c
@@ -1247,6 +1247,7 @@ static void panel_draw_aligned_backdrop(const Panel *panel,
   const bool draw_box_style = panel->type->flag & PANEL_TYPE_DRAW_BOX;
   const bool is_subpanel = panel->type->parent != NULL;
   const bool is_open = !UI_panel_is_closed(panel);
+  const float hide_bg = panel->type->flag & PANEL_HIDE_BG;
 
   if (is_subpanel && !is_open) {
     return;
@@ -1323,7 +1324,13 @@ static void panel_draw_aligned_backdrop(const Panel *panel,
 
     /* Panel backdrop. */
     if (is_open || panel->type->flag & PANEL_TYPE_NO_HEADER) {
-      immUniformThemeColor(is_subpanel ? TH_PANEL_SUB_BACK : TH_PANEL_BACK);
+      /* bfa - transparent toolbar background */
+      if (hide_bg) {
+        immUniformThemeColorAlpha(is_subpanel ? TH_PANEL_SUB_BACK : TH_PANEL_BACK, 0.f);
+      }
+      else {
+        immUniformThemeColor(is_subpanel ? TH_PANEL_SUB_BACK : TH_PANEL_BACK);
+      }
       immRectf(pos, rect->xmin, rect->ymin, rect->xmax, rect->ymax);
     }
 

--- a/source/blender/makesrna/intern/rna_ui.c
+++ b/source/blender/makesrna/intern/rna_ui.c
@@ -1360,6 +1360,7 @@ static void rna_def_panel(BlenderRNA *brna)
        "Expand Header Layout",
        "Allow buttons in the header to stretch and shrink to fill the entire layout width"},
       {PANEL_TYPE_DRAW_BOX, "DRAW_BOX", 0, "Box Style", "Display panel with the box widget theme"},
+      /* bfa - transparent toolsystem panels bg */
       {PANEL_HIDE_BG, "HIDE_BG", 0, "Make panel background fully transparent"},
       {0, NULL, 0, NULL, NULL},
   };

--- a/source/blender/makesrna/intern/rna_ui.c
+++ b/source/blender/makesrna/intern/rna_ui.c
@@ -1360,6 +1360,7 @@ static void rna_def_panel(BlenderRNA *brna)
        "Expand Header Layout",
        "Allow buttons in the header to stretch and shrink to fill the entire layout width"},
       {PANEL_TYPE_DRAW_BOX, "DRAW_BOX", 0, "Box Style", "Display panel with the box widget theme"},
+      {PANEL_HIDE_BG, "HIDE_BG", 0, "Make panel background fully transparent"},
       {0, NULL, 0, NULL, NULL},
   };
 


### PR DESCRIPTION
Fixes #2398 
This adds a new possible value to bl_options, "HIDE_BG", it sets alpha for panel background to 0
This PR also replaces HIDE_HEADER with HIDE_BG for toolsystem panels
![image](https://user-images.githubusercontent.com/25552173/120569716-c8ac6d00-c416-11eb-933a-8f0a161218be.png)
