### PR TITLE
Fix left aligned text at a button in the Vertex Weights panel #2538

### DIFF
--- a/source/blender/editors/space_view3d/view3d_buttons.c
+++ b/source/blender/editors/space_view3d/view3d_buttons.c
@@ -1398,7 +1398,8 @@ static void view3d_panel_vgroup(const bContext *C, Panel *panel)
                               "");
           but_ptr = UI_but_operator_ptr_get(but);
           RNA_int_set(but_ptr, "weight_group", i);
-          UI_but_drawflag_enable(but, UI_BUT_TEXT_RIGHT);
+          /* bfa - middle align text */
+          /*UI_but_drawflag_enable(but, UI_BUT_TEXT_RIGHT);*/
           if (BKE_object_defgroup_active_index_get(ob) != i + 1) {
             UI_but_flag_enable(but, UI_BUT_INACTIVE);
           }


### PR DESCRIPTION
Fixes #2538 
Before
![image](https://user-images.githubusercontent.com/25552173/128629550-1503ec51-e3ff-4e61-b754-f25f70d29030.png)

After
![image](https://user-images.githubusercontent.com/25552173/128629539-40548e3a-a389-4272-9abc-35f79cdad868.png)
