### PR TITLE
Fix #3106 Property Editor - World- New Light Group button is hidden w…

### DIFF
--- a/intern/cycles/blender/addon/ui.py
+++ b/intern/cycles/blender/addon/ui.py
@@ -1839,7 +1839,7 @@ class CYCLES_WORLD_PT_settings_light_group(CyclesButtonsPanel, Panel):
         )
 
         sub = row.column(align=True)
-        sub.active = not(bool(world.lightgroup) and any(lg.name == ob.lightgroup for lg in view_layer.lightgroups)) #BFA - Changed to activate this operator
+        sub.active = not(bool(world.lightgroup) and any(lg.name == world.lightgroup for lg in view_layer.lightgroups)) #BFA - Changed to activate this operator
         sub.operator("scene.view_layer_add_lightgroup", icon='ADD', text="").name = world.lightgroup
 
 


### PR DESCRIPTION
…hen a light group is selected