### PR TITLE
3D View - Sculpt Mode - Subdivision menu doesn't exist in the GUI but the hotkeys for them exist #3104

### DIFF
--- a/release/scripts/startup/bl_ui/space_view3d.py
+++ b/release/scripts/startup/bl_ui/space_view3d.py
@@ -3819,6 +3819,10 @@ class VIEW3D_MT_sculpt(Menu):
 
         layout.separator()
 
+        layout.menu("VIEW3D_MT_subdivision_set")
+
+        layout.separator()
+
         layout.menu("VIEW3D_MT_sculpt_set_pivot", text="Set Pivot")
 
         layout.separator()


### PR DESCRIPTION
![subdivide](https://user-images.githubusercontent.com/13919702/177502663-e3de202a-25d0-4bef-942b-67e066fba151.jpg)
