### PR TITLE
 Properties Editor - Cycles - Scambling Distance is greyed out #3157

### DIFF
--- a/intern/cycles/blender/addon/ui.py
+++ b/intern/cycles/blender/addon/ui.py
@@ -323,7 +323,6 @@ class CYCLES_RENDER_PT_sampling_advanced(CyclesButtonsPanel, Panel):
         col.prop(cscene, "sample_offset")
 
         col = layout.column(align=True)
-        col.active = not (cscene.use_adaptive_sampling and cscene.use_preview_adaptive_sampling)
         col.label(text="Scrambling Distance")
         row = col.row()
         row.use_property_split = False


### PR DESCRIPTION
reenable Scambling Distance in Properties Editor - Cycles