### PR TITLE
3D View - Object - Library Override menu needs iconography #3207

### DIFF
--- a/release/scripts/startup/bl_ui/space_view3d.py
+++ b/release/scripts/startup/bl_ui/space_view3d.py
@@ -2583,7 +2583,8 @@ class VIEW3D_MT_object_relations(Menu):
     def draw(self, _context):
         layout = self.layout
 
-        layout.operator("object.make_override_library", text="Make Library Override", icon="LIBRARY_DATA_OVERRIDE")
+        ## BFA - removed because it is now redundant
+        #layout.operator("object.make_override_library", text="Make Library Override", icon="LIBRARY_DATA_OVERRIDE")
         layout.operator("object.make_dupli_face", icon="MAKEDUPLIFACE")
 
         layout.separator()
@@ -2619,9 +2620,9 @@ class VIEW3D_MT_object_liboverride(Menu):
     def draw(self, _context):
         layout = self.layout
 
-        layout.operator("object.make_override_library", text="Make")
-        layout.operator("object.reset_override_library", text="Reset")
-        layout.operator("object.clear_override_library", text="Clear")
+        layout.operator("object.make_override_library", text="Make", icon = "LIBRARY")
+        layout.operator("object.reset_override_library", text="Reset", icon = "RESET")
+        layout.operator("object.clear_override_library", text="Clear", icon = "CLEAR")
 
 
 class VIEW3D_MT_object(Menu):

--- a/source/blender/editors/space_outliner/outliner_tools.cc
+++ b/source/blender/editors/space_outliner/outliner_tools.cc
@@ -1703,18 +1703,18 @@ enum eOutlinerLibOverrideOpTypes {
 static const EnumPropertyItem prop_liboverride_op_types[] = {
     {OUTLINER_LIBOVERRIDE_OP_CREATE_HIERARCHY,
      "OVERRIDE_LIBRARY_CREATE_HIERARCHY",
-     ICON_HIERARCHY,
+     0,
      "Make",
      "Create a local override of the selected linked data-blocks, and their hierarchy of "
      "dependencies"},
     {OUTLINER_LIBOVERRIDE_OP_RESET,
      "OVERRIDE_LIBRARY_RESET",
-     ICON_HIERARCHY,
+     0,
      "Reset",
      "Reset the selected local overrides to their linked references values"},
     {OUTLINER_LIBOVERRIDE_OP_CLEAR_SINGLE,
      "OVERRIDE_LIBRARY_CLEAR_SINGLE",
-     ICON_HIERARCHY,
+     0,
      "Clear",
      "Delete the selected local overrides and relink their usages to the linked data-blocks if "
      "possible, else reset them and mark them as non editable"},


### PR DESCRIPTION
- cleaned up unused library override iconography
- removed a redundant library override operator
- added icons to the 3D View library overrides operators