### PR TITLE
Fix #3082

### DIFF
--- a/release/scripts/startup/bl_ui/space_image_uv_toolbar_tabs.py
+++ b/release/scripts/startup/bl_ui/space_image_uv_toolbar_tabs.py
@@ -51,9 +51,9 @@ class toolshelf_calculate( Panel):
 
         if width_scale > 160.0:
             column_count = 4
-        elif width_scale > 120.0:
+        elif width_scale > 130.0:
             column_count = 3
-        elif width_scale > 80:
+        elif width_scale > 90:
             column_count = 2
         else:
             column_count = 1

--- a/release/scripts/startup/bl_ui/space_node_tabs.py
+++ b/release/scripts/startup/bl_ui/space_node_tabs.py
@@ -44,9 +44,9 @@ class toolshelf_calculate(Panel):
 
         if width_scale > 160.0:
             column_count = 4
-        elif width_scale > 120.0:
+        elif width_scale > 130.0:
             column_count = 3
-        elif width_scale > 80:
+        elif width_scale > 90:
             column_count = 2
         else:
             column_count = 1

--- a/release/scripts/startup/bl_ui/space_toolsystem_common.py
+++ b/release/scripts/startup/bl_ui/space_toolsystem_common.py
@@ -634,9 +634,9 @@ class ToolSelectPanelHelper:
         else:
             show_text = False
             # 2 or 3 column layout, disabled
-            if width_scale > 120.0:
+            if width_scale > 130.0:
                 column_count = 3
-            elif width_scale > 80:
+            elif width_scale > 90:
                 column_count = 2
             else:
                 column_count = 1

--- a/release/scripts/startup/bl_ui/space_toolsystem_toolbar_tabs.py
+++ b/release/scripts/startup/bl_ui/space_toolsystem_toolbar_tabs.py
@@ -28,9 +28,9 @@ class toolshelf_calculate( Panel):
 
         if width_scale > 160.0:
             column_count = 4
-        elif width_scale > 120.0:
+        elif width_scale > 140.0:
             column_count = 3
-        elif width_scale > 80:
+        elif width_scale > 90:
             column_count = 2
         else:
             column_count = 1

--- a/source/blender/editors/screen/area.c
+++ b/source/blender/editors/screen/area.c
@@ -2903,8 +2903,10 @@ static int panel_draw_width_from_max_width_get(const ARegion *region,
   /* bfa - With a background, we want some extra padding.
   But not for our no header panel in the tool shelves. So if - else. See #2731*/
   if (region->regiontype == RGN_TYPE_TOOLS) {
-    /*our tool shelf, no extra padding*/
-    return UI_panel_should_show_background(region, panel_type) ? max_width : max_width;
+    /*our tool shelf, fix cutoff panel*/
+    return UI_panel_should_show_background(region, panel_type) ?
+               max_width - UI_PANEL_MARGIN_X * 2.0f :
+               max_width;
   }
   else {
     /* With a background, we want some extra padding*/

--- a/source/blender/editors/screen/area_utils.c
+++ b/source/blender/editors/screen/area_utils.c
@@ -46,7 +46,8 @@ int ED_region_generic_tools_region_snap_size(const ARegion *region, int size, in
   // check if panel has tabs visible
   if (region->panels_category.first &&
       region->panels_category.first != region->panels_category.last) {
-    if (RGN_ALIGN_ENUM_FROM_MASK(region->alignment) != RGN_ALIGN_RIGHT) {
+    /* bfa - allow tools area snapping if region is flipped */
+    if (RGN_ALIGN_ENUM_FROM_MASK(region->alignment) != RGN_ALIGN_LEFT, RGN_ALIGN_RIGHT) {
       offset = 20;
     }
   }
@@ -57,7 +58,8 @@ int ED_region_generic_tools_region_snap_size(const ARegion *region, int size, in
                          (BLI_rcti_size_y(&region->v2d.mask) + 1);
     const float icon_size = ICON_DEFAULT_HEIGHT_TOOLBAR / aspect;
     const float column = 1.25f * icon_size;
-    const float margin = 0.5f * icon_size + offset;
+    /* bfa - margin changed from 0.5f > 0.75f to fix icons size */
+    const float margin = 0.75f * icon_size + offset;
     const float snap_units[] = {
         column + margin,
         (2.0f * column) + margin,


### PR DESCRIPTION
Fixes the Tools Panel being cut issue and icons margin being off, also allow snapping if tools area has been region flipped.