### PR TITLE
3564 Process name is "blender" on Linux

### DIFF
--- a/intern/ghost/intern/GHOST_SystemWayland.cc
+++ b/intern/ghost/intern/GHOST_SystemWayland.cc
@@ -6959,7 +6959,7 @@ static const char *ghost_wl_app_id = (
 #ifdef WITH_GHOST_WAYLAND_APP_ID
     STRINGIFY(WITH_GHOST_WAYLAND_APP_ID)
 #else
-    "blender"
+    "bforartists"
 #endif
 );
 


### PR DESCRIPTION
Change to bforartists otherwise process name will be blender.