### PR TITLE
fix-3572--3d-view---new-transform-keymap---snap-base

### DIFF
--- a/scripts/presets/keyconfig/bforartists-macOS.py
+++ b/scripts/presets/keyconfig/bforartists-macOS.py
@@ -7376,6 +7376,8 @@ keyconfig_data = \
     ("SNAP_INV_OFF", {"type": 'RIGHT_CTRL', "value": 'RELEASE', "any": True}, None),
     ("ADD_SNAP", {"type": 'A', "value": 'PRESS'}, None),
     ("REMOVE_SNAP", {"type": 'A', "value": 'PRESS', "alt": True}, None),
+    ("EDIT_SNAP_SOURCE_ON", {"type": 'B', "value": 'PRESS'}, None),
+    ("EDIT_SNAP_SOURCE_OFF", {"type": 'B', "value": 'PRESS'}, None),
     ("PROPORTIONAL_SIZE_UP", {"type": 'PAGE_UP', "value": 'PRESS', "repeat": True}, None),
     ("PROPORTIONAL_SIZE_DOWN", {"type": 'PAGE_DOWN', "value": 'PRESS', "repeat": True}, None),
     ("PROPORTIONAL_SIZE_UP", {"type": 'PAGE_UP', "value": 'PRESS', "shift": True, "repeat": True}, None),

--- a/scripts/presets/keyconfig/bforartists.py
+++ b/scripts/presets/keyconfig/bforartists.py
@@ -7376,6 +7376,8 @@ keyconfig_data = \
     ("SNAP_INV_OFF", {"type": 'RIGHT_CTRL', "value": 'RELEASE', "any": True}, None),
     ("ADD_SNAP", {"type": 'A', "value": 'PRESS'}, None),
     ("REMOVE_SNAP", {"type": 'A', "value": 'PRESS', "alt": True}, None),
+    ("EDIT_SNAP_SOURCE_ON", {"type": 'B', "value": 'PRESS'}, None),
+    ("EDIT_SNAP_SOURCE_OFF", {"type": 'B', "value": 'PRESS'}, None),
     ("PROPORTIONAL_SIZE_UP", {"type": 'PAGE_UP', "value": 'PRESS', "repeat": True}, None),
     ("PROPORTIONAL_SIZE_DOWN", {"type": 'PAGE_DOWN', "value": 'PRESS', "repeat": True}, None),
     ("PROPORTIONAL_SIZE_UP", {"type": 'PAGE_UP', "value": 'PRESS', "shift": True, "repeat": True}, None),


### PR DESCRIPTION
- Added Snap Base keymap entries that was added in Blender 4.0