### PR TITLE
Bforartists keymaps error after latest merge (6/13/2023) #3584

### DIFF
--- a/scripts/presets/keyconfig/bforartists-macOS.py
+++ b/scripts/presets/keyconfig/bforartists-macOS.py
@@ -1,4 +1,4 @@
-keyconfig_version = (4, 0, 1)
+keyconfig_version = (4, 0, 6)
 keyconfig_data = \
 [("3D View",
   {"space_type": 'VIEW_3D', "region_type": 'WINDOW'},

--- a/scripts/presets/keyconfig/bforartists.py
+++ b/scripts/presets/keyconfig/bforartists.py
@@ -1,4 +1,4 @@
-keyconfig_version = (4, 0, 1)
+keyconfig_version = (4, 0, 6)
 keyconfig_data = \
 [("3D View",
   {"space_type": 'VIEW_3D', "region_type": 'WINDOW'},


### PR DESCRIPTION
Fixed by writing a new custom map from blender, then copied and pasted the BFA maps in. They no-longer error. Issue was the version numbering.