### PR TITLE
Fix for 3597-toolbar-snapping-broken-due-to-new-toolbar-defaults-from…

### DIFF
--- a/scripts/startup/bl_ui/space_toolsystem_common.py
+++ b/scripts/startup/bl_ui/space_toolsystem_common.py
@@ -634,7 +634,7 @@ class ToolSelectPanelHelper:
         else:
             show_text = False
             # 2 or 3 column layout, disabled
-            if width_scale > 130.0:
+            if width_scale > 140.0:
                 column_count = 3
             elif width_scale > 90:
                 column_count = 2

--- a/source/blender/editors/screen/area_utils.c
+++ b/source/blender/editors/screen/area_utils.c
@@ -59,10 +59,10 @@ int ED_region_generic_tools_region_snap_size(const ARegion *region, int size, in
     const float column = UI_TOOLBAR_COLUMN / aspect;
     const float margin = UI_TOOLBAR_MARGIN / aspect;
     const float snap_units[] = {
-        column + margin,
-        (2.0f * column) + margin,
-        (2.7f * column) + margin,
-        (3.4f * column) + margin,
+        column + margin + offset, /* need bfa offset for tabs */
+        (2.0f * column) + margin + offset,
+        (2.7f * column) + margin + offset,
+        (3.4f * column) + margin + offset,
     };
     int best_diff = INT_MAX;
     int best_size = size;


### PR DESCRIPTION
- readded tab offset to toolbar snapping due to changes from Blender.