### PR TITLE
fix for 3646-linux---change-the-targetfolder-nam

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,5 +36,5 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: Bforartists-Release-${{ runner.os }}
-        path: /home/runner/bforartistsrepo/build_linux/bin/
+        path: /home/runner/bforartistsrepo/bfa_build_linux/bin/
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -174,7 +174,7 @@ BLENDER_IS_PYTHON_MODULE:=
 CMAKE_CONFIG_ARGS := $(BUILD_CMAKE_ARGS)
 
 ifndef BUILD_DIR
-	BUILD_DIR:=$(shell dirname "$(BLENDER_DIR)")/build_$(OS_NCASE)
+	BUILD_DIR:=$(shell dirname "$(BLENDER_DIR)")/bfa_build_$(OS_NCASE)
 endif
 
 # Dependencies DIR's


### PR DESCRIPTION
-- added bfa to linux build folder name.