### PR TITLE
fix for 3687-3d-view---header---view---viewer-no

### DIFF
--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -1520,8 +1520,6 @@ class VIEW3D_MT_view(Menu):
             layout.operator("view3d.render_border", icon="RENDERBORDER")
             layout.operator("view3d.clear_render_border", icon="RENDERBORDER_CLEAR")
 
-        #layout.prop(view, "show_viewer", text="Viewer Node") - bfa hidden due to one already in Overlay Options.
-
         layout.separator()
 
         layout.menu("VIEW3D_MT_view_cameras", text="Cameras")

--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -1520,7 +1520,7 @@ class VIEW3D_MT_view(Menu):
             layout.operator("view3d.render_border", icon="RENDERBORDER")
             layout.operator("view3d.clear_render_border", icon="RENDERBORDER_CLEAR")
 
-        layout.prop(view, "show_viewer", text="Viewer Node")
+        #layout.prop(view, "show_viewer", text="Viewer Node") - bfa hidden due to one already in Overlay Options.
 
         layout.separator()
 


### PR DESCRIPTION
- Hidden the Viewer Node in the 3D View header menu, since one is already in the Overlays Options.