### PR TITLE
fix for 3733-node-editors---group-tab---interface

### DIFF
--- a/scripts/startup/bl_ui/space_node.py
+++ b/scripts/startup/bl_ui/space_node.py
@@ -1162,18 +1162,18 @@ class NODE_PT_node_tree_interface(Panel):
         layout = self.layout
         snode = context.space_data
         tree = snode.edit_tree
-
+        
         split = layout.row()
-
         split.template_node_tree_interface(tree.interface)
-
-        ops_col = split.column(align=True)
-        ops_col.operator_menu_enum("node.interface_item_new", "item_type", icon='ADD', text="")
+        
+        ops_col = split.column(align=False)
+        ops_col.operator('node.interface_item_new', text='', icon='GROUPINPUT').item_type='INPUT'
+        ops_col.operator('node.interface_item_new', text='', icon='MENU_PANEL').item_type='PANEL'
+        ops_col.operator('node.interface_item_new', text='', icon='GROUPOUTPUT').item_type='OUTPUT'
+        
+        ops_col.separator()
+        ops_col.operator("node.interface_item_duplicate", text='', icon='DUPLICATE')
         ops_col.operator("node.interface_item_remove", icon='REMOVE', text="")
-        ops_col.separator()
-        ops_col.menu("NODE_MT_node_tree_interface_context_menu", icon='DOWNARROW_HLT', text="")
-
-        ops_col.separator()
 
         active_item = tree.interface.active
         if active_item is not None:


### PR DESCRIPTION
-- Exposed the add buttons to main level to no need to dig for them. 
-- Also did the same to the Duplicate Item since there was only a single item for that.