### PR TITLE
fix for 3836-properties-editor-modifiers-unassigned-needs-better-icon…

### DIFF
--- a/source/blender/editors/object/add_modifier_assets.cc
+++ b/source/blender/editors/object/add_modifier_assets.cc
@@ -150,7 +150,7 @@ static void unassigned_assets_draw(const bContext *C, Menu *menu)
     uiItemFullO_ptr(layout,
                     ot,
                     IFACE_(asset->get_name().c_str()),
-                    ICON_NONE,
+                    ICON_NODETREE, /*BFA*/
                     nullptr,
                     WM_OP_INVOKE_DEFAULT,
                     UI_ITEM_NONE,


### PR DESCRIPTION
-- Added Icons for the Unassigned (Catalogue) sub menu in the properties editor modifier add menu.

![Screenshot_20231013_164904](https://github.com/Bforartists/Bforartists/assets/25260650/b144adfd-80d4-44f3-8a13-0f86a306aae6)
