### PR TITLE
fix for 3835-3d-view-armature-bone-collection-new-solo-visibility-and…

### DIFF
--- a/scripts/startup/bl_ui/properties_data_armature.py
+++ b/scripts/startup/bl_ui/properties_data_armature.py
@@ -185,9 +185,9 @@ class ARMATURE_MT_collection_context_menu(Menu):
         arm = context.armature
         active_bcoll = arm.collections.active
 
-        props = layout.operator("armature.collection_solo_visibility")
+        props = layout.operator("armature.collection_solo_visibility", icon='HIDE_UNSELECTED')
         props.name = active_bcoll.name if active_bcoll else ""
-        layout.operator("armature.collection_show_all")
+        layout.operator("armature.collection_show_all", icon='SHOW_UNSELECTED')
 
 
 class DATA_PT_iksolver_itasc(ArmatureButtonsPanel, Panel):


### PR DESCRIPTION
-- adjusted only in the Properties Bone Collection Panel, since the 3dview bone collection menu already have icons.

![Screenshot_20231013_171750](https://github.com/Bforartists/Bforartists/assets/25260650/ebf9d4ee-dc79-4a66-a65a-a4ad6d50c43e)
