### PR TITLE
fix for 3828-preference-s-viewport-indend-playback-samples-checkbox-a…

### DIFF
--- a/scripts/startup/bl_ui/space_userpref.py
+++ b/scripts/startup/bl_ui/space_userpref.py
@@ -814,14 +814,12 @@ class USERPREF_PT_viewport_display(ViewportPanel, CenterAlignMixIn, Panel):
         row = col.row()
         row.separator()
         row.prop(view, "show_playback_fps", text="Playback Frame Rate (FPS)")
-        row = col.row()
-        row.prop(view, "show_playback_fps", text="")
-        subrow = row.row()
-        subrow.active = view.show_playback_fps
-        subrow.prop(view, "playback_fps_samples", text="Samples")
+        
+        if view.show_playback_fps == True:
+            row.active = view.show_playback_fps
+            row.prop(view, "playback_fps_samples", text="Samples")
 
         flow = layout.grid_flow(row_major=False, columns=0, even_columns=True, even_rows=False, align=False)
-
 
         layout.separator()
 

--- a/scripts/startup/bl_ui/space_userpref.py
+++ b/scripts/startup/bl_ui/space_userpref.py
@@ -813,14 +813,17 @@ class USERPREF_PT_viewport_display(ViewportPanel, CenterAlignMixIn, Panel):
         row.prop(view, "show_view_name", text="View Name")
         row = col.row()
         row.separator()
-        row.prop(view, "show_playback_fps", text="Playback Frame Rate (FPS)")
         
-        if view.show_playback_fps == True:
-            row.active = view.show_playback_fps
-            row.prop(view, "playback_fps_samples", text="Samples")
-
-        flow = layout.grid_flow(row_major=False, columns=0, even_columns=True, even_rows=False, align=False)
-
+        split = row.split()
+        col = split.column()
+        col.use_property_split = False
+        col.prop(view, "show_playback_fps", text="Playback Frame Rate (FPS)")
+        
+        if view.show_playback_fps:
+            split.prop(view, "playback_fps_samples", text="Samples")
+        else:
+            split.label(icon='DISCLOSURE_TRI_RIGHT')
+            
         layout.separator()
 
         flow = layout.grid_flow(row_major=False, columns=0, even_columns=True, even_rows=False, align=False)


### PR DESCRIPTION
-- removed the extra prop and moved next to show_playback_fps prop since it's to be used with it, hide if disabled.

![Screenshot_20231013_173131](https://github.com/Bforartists/Bforartists/assets/25260650/d5ce39c6-40a2-4826-8cc2-3aa23d117bb0)
