### PR TITLE
fix for 3780-asset-browser-display-mode-thumbnails-add-button-row-for…

### DIFF
--- a/scripts/startup/bl_ui/space_filebrowser.py
+++ b/scripts/startup/bl_ui/space_filebrowser.py
@@ -628,10 +628,11 @@ class ASSETBROWSER_PT_display(asset_utils.AssetBrowserPanel, Panel):
         space = context.space_data
         params = space.params
 
-        layout.use_property_split = True
+        layout.use_property_split = False
         layout.use_property_decorate = False  # No animation.
 
         if params.display_type == 'THUMBNAIL':
+            layout.prop(params, "display_size_discrete", text="Text", expand=True) # BFA - added quick thumbnail sizes.
             layout.prop(params, "display_size", text="Size")
         else:
             col = layout.column(heading="Columns", align=True)

--- a/source/blender/makesrna/intern/rna_space.cc
+++ b/source/blender/makesrna/intern/rna_space.cc
@@ -6821,12 +6821,12 @@ static void rna_def_fileselect_params(BlenderRNA *brna)
       {0, nullptr, 0, nullptr, nullptr},
   };
 
+  /* BFA - Adjused sizes to be more useful in Thumbnail View and match from menus dropdown */
   static const EnumPropertyItem display_size_items[] = {
-      {32, "TINY", 0, "Tiny", ""},
-      {64, "SMALL", 0, "Small", ""},
-      {96, "NORMAL", 0, "Medium", ""},
-      {128, "BIG", 0, "Big", ""},
-      {192, "LARGE", 0, "Large", ""},
+      {48, "TINY", 0, "Tiny", ""},
+      {96, "SMALL", 0, "Small", ""},
+      {128, "NORMAL", 0, "Medium", ""},
+      {256, "LARGE", 0, "Large", ""},
       {0, nullptr, 0, nullptr, nullptr},
   };
 
@@ -7011,7 +7011,7 @@ static void rna_def_fileselect_params(BlenderRNA *brna)
   RNA_def_property_update(prop, NC_SPACE | ND_SPACE_FILE_LIST, nullptr);
   RNA_def_property_int_default(prop, 96);
   RNA_def_property_range(prop, 16, 256);
-  RNA_def_property_ui_range(prop, 24, 256, 1, 0);
+  RNA_def_property_ui_range(prop, 16, 256, 1, 0);
 
   prop = RNA_def_property(srna, "display_size_discrete", PROP_ENUM, PROP_NONE);
   RNA_def_property_enum_sdna(prop, nullptr, "thumbnail_size");


### PR DESCRIPTION
- added quick thumbnail sizes.
- adjust default sizes to match other areas to be consistent (menu drop downs from view header etc.

![Screenshot_20231031_143525](https://github.com/Bforartists/Bforartists/assets/25260650/08f3aef0-505c-4a66-91ed-0e739cc8b677)
