### PR TITLE
fix for 3925-file-browser-add-thumbnail-button-sizes-to-keep-consiste…

### DIFF
--- a/scripts/startup/bl_ui/space_filebrowser.py
+++ b/scripts/startup/bl_ui/space_filebrowser.py
@@ -109,7 +109,7 @@ class FileBrowserPanel:
 class FILEBROWSER_PT_display(FileBrowserPanel, Panel):
     bl_region_type = 'HEADER'
     bl_label = "Display Settings"  # Shows as tooltip in popover
-    bl_ui_units_x = 10
+    bl_ui_units_x = 16
 
     def draw(self, context):
         layout = self.layout
@@ -121,6 +121,7 @@ class FILEBROWSER_PT_display(FileBrowserPanel, Panel):
         layout.use_property_decorate = False  # No animation.
 
         if params.display_type == 'THUMBNAIL':
+            layout.prop(params, "display_size_discrete", text="Thumbnail Presets", expand=True) # BFA - added quick thumbnail sizes.
             layout.prop(params, "display_size", text="Size")
         else:
 


### PR DESCRIPTION
- added Thumbnail Presets to Filebrowser.

![image](https://github.com/Bforartists/Bforartists/assets/25260650/c0b6b779-07bd-443f-a36f-4ee7ac5aaf73)