### PR TITLE
fix for 3959-space_toolbarcc-info_blend_write-definded-but-not-used

### DIFF
--- a/source/blender/editors/space_toolbar/space_toolbar.cc
+++ b/source/blender/editors/space_toolbar/space_toolbar.cc
@@ -150,11 +150,6 @@ static void toolbar_blend_write(BlendWriter *writer, SpaceLink *sl)
 
 /********************* registration ********************/
 
-static void info_blend_write(BlendWriter *writer, SpaceLink *sl)
-{
-  BLO_write_struct(writer, SpaceToolbar, sl);
-}
-
 /* only called once, from space/spacetypes.cc */
 void ED_spacetype_toolbar(void)
 {


### PR DESCRIPTION
- removed the info_blend_write code has not used in this file.