### PR TITLE
fix for #4054-3d-view-object-mode-animation-missing-icon-to-clear-acti…

### DIFF
--- a/source/blender/editors/animation/keyingsets.cc
+++ b/source/blender/editors/animation/keyingsets.cc
@@ -562,6 +562,7 @@ static const EnumPropertyItem *keyingset_set_active_enum_itemf(bContext *C,
     item_tmp.identifier = "__ACTIVE__";
     item_tmp.name = "Clear Active Keying Set";
     item_tmp.value = 0;
+    item_tmp.icon = ICON_CLEAN_CHANNELS;
     RNA_enum_item_add(&item, &totitem, &item_tmp);
 
     RNA_enum_item_add_separator(&item, &totitem);

--- a/source/blender/editors/animation/keyingsets.cc
+++ b/source/blender/editors/animation/keyingsets.cc
@@ -508,7 +508,6 @@ static void build_keyingset_enum(bContext *C, EnumPropertyItem **item, int *toti
         item_tmp.name = keyingset->name;
         item_tmp.description = keyingset->description;
         item_tmp.value = enum_index;
-        item_tmp.icon = ICON_KEYINGSET;
         RNA_enum_item_add(item, totitem, &item_tmp);
       }
     }

--- a/source/blender/editors/animation/keyingsets.cc
+++ b/source/blender/editors/animation/keyingsets.cc
@@ -508,6 +508,7 @@ static void build_keyingset_enum(bContext *C, EnumPropertyItem **item, int *toti
         item_tmp.name = keyingset->name;
         item_tmp.description = keyingset->description;
         item_tmp.value = enum_index;
+        item_tmp.icon = ICON_KEYINGSET;
         RNA_enum_item_add(item, totitem, &item_tmp);
       }
     }


### PR DESCRIPTION
-- added icon CLEAN_CHANNELS (CLEAN_KEYS might be another)

![image](https://github.com/Bforartists/Bforartists/assets/25260650/f4e1d704-9a35-411c-8f19-8aa2e53206b5)
