### PR TITLE
fix for 4072-3d-view-object-mode-animation-missing-icon-for-keyring-e…

### DIFF
--- a/source/blender/editors/animation/keyingsets.cc
+++ b/source/blender/editors/animation/keyingsets.cc
@@ -508,6 +508,7 @@ static void build_keyingset_enum(bContext *C, EnumPropertyItem **item, int *toti
         item_tmp.name = keyingset->name;
         item_tmp.description = keyingset->description;
         item_tmp.value = enum_index;
+        item_tmp.icon = ICON_KEYINGSET;
         RNA_enum_item_add(item, totitem, &item_tmp);
       }
     }


### PR DESCRIPTION
-- added keyring set icons to 3D View menu.

![image](https://github.com/Bforartists/Bforartists/assets/25260650/2f1af860-2414-4dc4-bd1f-614ca85e9dcb)