### PR TITLE
fix for 4074-user-preferences-keymap-is-set-to-blender-not-bforartists

### DIFF
--- a/release/datafiles/userdef/userdef_default.c
+++ b/release/datafiles/userdef/userdef_default.c
@@ -108,7 +108,7 @@ const UserDef U_default = {
     .autoexec_paths = {NULL},
     .user_menus = {NULL},
 
-    .keyconfigstr = "bforartists", /*bfa - the active keymap*/
+    .keyconfigstr = "Bforartists", /*bfa - the active keymap*/
     .undosteps = 32,
     .undomemory = 0,
     .gp_manhattandist = 1,


### PR DESCRIPTION
-- Change to uppercase to match Bforartists keymap name (might be a Linux only thing).

Now works
![image](https://github.com/Bforartists/Bforartists/assets/25260650/f30570cb-8e23-46a5-bf00-ad4ddf71c7b9)
