### PR TITLE
fix for 4078-3d-view-camera-lock-widget-icon-is-inversed

### DIFF
--- a/source/blender/editors/space_view3d/view3d_gizmo_navigate.cc
+++ b/source/blender/editors/space_view3d/view3d_gizmo_navigate.cc
@@ -121,13 +121,13 @@ static NavigateGizmoInfo g_navigate_params[GZ_INDEX_TOTAL] = {
     {
         "WM_OT_context_toggle",
         "GIZMO_GT_button_2d",
-        ICON_LOCK_TO_CAMVIEW,
+        ICON_LOCK_TO_CAMVIEW_ON,
         navigate_context_toggle_camera_lock_init,
     },
     {
         "WM_OT_context_toggle",
         "GIZMO_GT_button_2d",
-        ICON_LOCK_TO_CAMVIEW_ON,
+        ICON_LOCK_TO_CAMVIEW,
         navigate_context_toggle_camera_lock_init,
     },
 };


### PR DESCRIPTION
-- swapped the icon codes, since they didn't match the operations when clicked.

https://github.com/Bforartists/Bforartists/assets/25260650/ad3b0a65-b13a-4e81-b691-58178dd48f7a

