### PR TITLE
fix 4128-preferences-autosave-time-interval-missing

### DIFF
--- a/scripts/startup/bl_ui/space_userpref.py
+++ b/scripts/startup/bl_ui/space_userpref.py
@@ -2929,6 +2929,7 @@ classes = (
     USERPREF_PT_file_paths_development,
 
     USERPREF_PT_saveload_blend,
+    USERPREF_PT_saveload_blend_autosave,
     USERPREF_PT_saveload_autorun,
     USERPREF_PT_saveload_file_browser,
 


### PR DESCRIPTION
-- USERPREF_PT_saveload_blend_autosave, was missing.

![image](https://github.com/Bforartists/Bforartists/assets/25260650/60ae39af-4294-4e9a-82f7-0b9157b69774)
