### PR TITLE
fix 4129-timeline-mute-is-now-inversed-to-be-play-sound

### DIFF
--- a/scripts/startup/bl_ui/space_time.py
+++ b/scripts/startup/bl_ui/space_time.py
@@ -273,7 +273,7 @@ class TIME_PT_playback(TimelinePanelButtons, Panel):
         row.prop(scene, "use_audio_scrub", text="Scrubbing")
         row = col.row()
         row.separator()
-        row.prop(scene, "use_audio", text="Mute")
+        row.prop(scene, "use_audio", text="Mute", invert_checkbox=True)
 
         col = layout.column(align = True)
         col.label(text = "Playback")

--- a/source/blender/makesrna/intern/rna_scene.cc
+++ b/source/blender/makesrna/intern/rna_scene.cc
@@ -2159,14 +2159,14 @@ static int rna_Scene_transform_orientation_slots_length(PointerRNA * /*ptr*/)
 static bool rna_Scene_use_audio_get(PointerRNA *ptr)
 {
   Scene *scene = (Scene *)ptr->data;
-  return (scene->audio.flag & AUDIO_MUTE) == 0;
+  return (scene->audio.flag & AUDIO_MUTE) != 0; /* bfa - we use checkbox to mute audio, not to play audio */
 }
 
 static void rna_Scene_use_audio_set(PointerRNA *ptr, bool value)
 {
   Scene *scene = (Scene *)ptr->data;
 
-  if (!value) {
+  if (value) { /* bfa - we use checkbox to mute audio, not to play audio */
     scene->audio.flag |= AUDIO_MUTE;
   }
   else {
@@ -8821,7 +8821,7 @@ void RNA_def_scene(BlenderRNA *brna)
   prop = RNA_def_property(srna, "use_audio", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_funcs(prop, "rna_Scene_use_audio_get", "rna_Scene_use_audio_set");
   RNA_def_property_ui_text(
-      prop, "Play Audio", "Play back of audio from Sequence Editor, otherwise mute audio");
+      prop, "Mute Audio", "Mute audio from Sequence Editor, otherwise play audio"); /* bfa - we use checkbox to mute audio, not to play audio */
   RNA_def_property_update(prop, NC_SCENE, "rna_Scene_use_audio_update");
 
 #  if 0 /* XXX: Is this actually needed? */

--- a/source/blender/makesrna/intern/rna_scene.cc
+++ b/source/blender/makesrna/intern/rna_scene.cc
@@ -2159,14 +2159,14 @@ static int rna_Scene_transform_orientation_slots_length(PointerRNA * /*ptr*/)
 static bool rna_Scene_use_audio_get(PointerRNA *ptr)
 {
   Scene *scene = (Scene *)ptr->data;
-  return (scene->audio.flag & AUDIO_MUTE) != 0; /* bfa - we use checkbox to mute audio, not to play audio */
+  return (scene->audio.flag & AUDIO_MUTE) == 0; 
 }
 
 static void rna_Scene_use_audio_set(PointerRNA *ptr, bool value)
 {
   Scene *scene = (Scene *)ptr->data;
 
-  if (value) { /* bfa - we use checkbox to mute audio, not to play audio */
+  if (!value) { 
     scene->audio.flag |= AUDIO_MUTE;
   }
   else {
@@ -8821,7 +8821,7 @@ void RNA_def_scene(BlenderRNA *brna)
   prop = RNA_def_property(srna, "use_audio", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_funcs(prop, "rna_Scene_use_audio_get", "rna_Scene_use_audio_set");
   RNA_def_property_ui_text(
-      prop, "Mute Audio", "Mute audio from Sequence Editor, otherwise play audio"); /* bfa - we use checkbox to mute audio, not to play audio */
+      prop, "Mute Audio", "Mutes the audio from Sequence Editor"); 
   RNA_def_property_update(prop, NC_SCENE, "rna_Scene_use_audio_update");
 
 #  if 0 /* XXX: Is this actually needed? */


### PR DESCRIPTION
-- Changed the Mute audio checkbox to off by default, so users don't wonder why strips audio ain't playing sound.
-- Updated Description to match checkbox.