### PR TITLE
fix 4139-properties-editor-light-object-data-properties-close-the-ope…

### DIFF
--- a/scripts/startup/bl_ui/properties_data_light.py
+++ b/scripts/startup/bl_ui/properties_data_light.py
@@ -253,6 +253,7 @@ class DATA_PT_EEVEE_shadow_contact(DataButtonsPanel, Panel):
 class DATA_PT_spot(DataButtonsPanel, Panel):
     bl_label = "Spot Shape"
     bl_parent_id = "DATA_PT_EEVEE_light"
+    bl_options = {'DEFAULT_CLOSED'}
     COMPAT_ENGINES = {
         'BLENDER_RENDER',
         'BLENDER_EEVEE_NEXT',


### PR DESCRIPTION
-- Set the Spot Shape Panel to Default Closed