### PR TITLE
fix for 4237-dopesheet-view-header-double-entries

### DIFF
--- a/scripts/startup/bl_ui/space_dopesheet.py
+++ b/scripts/startup/bl_ui/space_dopesheet.py
@@ -518,11 +518,6 @@ class DOPESHEET_MT_view(Menu):
         layout.prop(st, "show_region_hud")
         layout.separator()
 
-        layout.operator("action.view_selected")
-        layout.operator("action.view_all")
-        layout.operator("action.view_frame")
-        layout.separator()
-
         layout.operator("anim.previewrange_set", icon='BORDER_RECT')
         layout.operator("anim.previewrange_clear", icon="CLEAR")
         layout.operator("action.previewrange_set", icon='BORDER_RECT')


### PR DESCRIPTION
-- removed double entires without icons.