### PR TITLE
Properties Editor - Add menus hold down ALT to "add" to all #4249

### DIFF
--- a/scripts/startup/bl_ui/properties_data_modifier.py
+++ b/scripts/startup/bl_ui/properties_data_modifier.py
@@ -271,7 +271,7 @@ class OBJECT_MT_modifier_add_color(ModifierAddMenu, Menu):
 
 class OBJECT_MT_modifier_add_assets(ModifierAddMenu, Menu):
     bl_label = "Assets"
-    bl_description = "Add a modifier nodegroup to the active object"
+    bl_description = "Add a modifier nodegroup to all selected objects" #BFA - inversed
     bl_options = {'SEARCH_ON_KEY_PRESS'}
 
     def draw(self, context):
@@ -322,7 +322,7 @@ class OBJECT_MT_modifier_add_color_assets(AssetSubmenu, ModifierAddMenu, Menu):
 class OBJECT_OT_add_asset_modifier_menu(InvokeMenuOperator, Operator):
     bl_idname = "object.add_asset_modifier_menu"
     bl_label = "Add Asset Modifier"
-    bl_description = "Add a modifier nodegroup to the active object"
+    bl_description = "Add a modifier nodegroup to all selected objects" #BFA - inversed
     menu_id = "OBJECT_MT_modifier_add_assets"
     space_type = 'PROPERTIES'
     space_context = 'MODIFIER'
@@ -375,11 +375,11 @@ class OBJECT_OT_add_gpencil_modifier_menu(InvokeMenuOperator, Operator):
     space_type = 'PROPERTIES'
     space_context = 'MODIFIER'
 
-
+# BFA - floating menu for consistency
 class AddModifierMenu(Operator):
     bl_idname = "object.add_modifier_menu"
     bl_label = "Add Modifier"
-    bl_description = "Add a procedural operation/effect to the active object"
+    bl_description = "Add a procedural operation/effect to all selected objects" # BFA - defaults to all
 
     @classmethod
     def poll(cls, context):

--- a/source/blender/editors/object/add_modifier_assets.cc
+++ b/source/blender/editors/object/add_modifier_assets.cc
@@ -339,7 +339,7 @@ static int modifier_add_asset_exec(bContext *C, wmOperator *op)
 static int modifier_add_asset_invoke(bContext *C, wmOperator *op, const wmEvent *event)
 {
   if (event->modifier & KM_ALT || CTX_wm_view3d(C)) {
-    RNA_boolean_set(op->ptr, "use_selected_objects", true);
+    RNA_boolean_set(op->ptr, "use_selected_objects", false); /*BFA - inversed to act on selected, ALT to act on only Active*/
   }
   return modifier_add_asset_exec(C, op);
 }
@@ -362,7 +362,7 @@ static std::string modifier_add_asset_get_description(bContext *C,
 static void OBJECT_OT_modifier_add_node_group(wmOperatorType *ot)
 {
   ot->name = "Add Modifier";
-  ot->description = "Add a procedural operation/effect to the active object";
+  ot->description = "Add a procedural operation/effect to all selected objects"; /*BFA - defaults to all*/
   ot->idname = "OBJECT_OT_modifier_add_node_group";
 
   ot->invoke = modifier_add_asset_invoke;

--- a/source/blender/editors/object/object_modifier.cc
+++ b/source/blender/editors/object/object_modifier.cc
@@ -1301,9 +1301,9 @@ void modifier_register_use_selected_objects_prop(wmOperatorType *ot)
   PropertyRNA *prop = RNA_def_boolean(
       ot->srna,
       "use_selected_objects",
-      false,
-      "Selected Objects",
-      "Affect all selected objects instead of just the active object");
+      true, /*BFA - inversed to act on selected, ALT to act on only Active*/
+      "Active Object", /*BFA - inversed*/
+      "Affect only Active object instead of all the selected objects"); /*BFA - inversed*/
   RNA_def_property_flag(prop, PROP_SKIP_SAVE | PROP_HIDDEN);
 }
 
@@ -1336,7 +1336,7 @@ static int modifier_add_exec(bContext *C, wmOperator *op)
 static int modifier_add_invoke(bContext *C, wmOperator *op, const wmEvent *event)
 {
   if (event->modifier & KM_ALT || CTX_wm_view3d(C)) {
-    RNA_boolean_set(op->ptr, "use_selected_objects", true);
+    RNA_boolean_set(op->ptr, "use_selected_objects", false); /*BFA - inversed to act on selected, ALT to act on only Active*/
   }
   if (!RNA_struct_property_is_set(op->ptr, "type")) {
     return WM_menu_invoke(C, op, event);
@@ -1397,8 +1397,8 @@ void OBJECT_OT_modifier_add(wmOperatorType *ot)
   PropertyRNA *prop;
 
   /* identifiers */
-  ot->name = "Add Modifier";
-  ot->description = "Add a procedural operation/effect to the active object";
+  ot->name = "Add Modifier to Selected"; /*BFA - defaults to all*/
+  ot->description = "Add a procedural operation/effect to all selected objects"; /*BFA - defaults to all*/
   ot->idname = "OBJECT_OT_modifier_add";
 
   /* api callbacks */
@@ -1526,7 +1526,7 @@ static bool edit_modifier_invoke_properties_with_hover(bContext *C,
 {
   if (RNA_struct_find_property(op->ptr, "use_selected_objects")) {
     if (event->modifier & KM_ALT) {
-      RNA_boolean_set(op->ptr, "use_selected_objects", true);
+      RNA_boolean_set(op->ptr, "use_selected_objects", false); /*BFA - inversed to act on selected, ALT to act on only Active*/
     }
   }
 
@@ -1640,8 +1640,8 @@ static int modifier_remove_invoke(bContext *C, wmOperator *op, const wmEvent *ev
 
 void OBJECT_OT_modifier_remove(wmOperatorType *ot)
 {
-  ot->name = "Remove Modifier";
-  ot->description = "Remove a modifier from the active object";
+  ot->name = "Remove Modifier from Selected"; /*BFA - defaults to all*/
+  ot->description = "Remove a modifier from all selected objects \nPress and hold ALT to remove from active object onlyy"; /*BFA - defaults to all*/
   ot->idname = "OBJECT_OT_modifier_remove";
 
   ot->invoke = modifier_remove_invoke;
@@ -1981,8 +1981,8 @@ static int modifier_apply_invoke(bContext *C, wmOperator *op, const wmEvent *eve
 
 void OBJECT_OT_modifier_apply(wmOperatorType *ot)
 {
-  ot->name = "Apply Modifier";
-  ot->description = "Apply modifier and remove from the stack";
+  ot->name = "Apply Modifier to Selected"; /*BFA - defaults to all*/
+  ot->description = "Apply modifier and remove from the stack \nPress and hold ALT to apply to active object only"; /*BFA - defaults to all*/
   ot->idname = "OBJECT_OT_modifier_apply";
 
   ot->invoke = modifier_apply_invoke;


### PR DESCRIPTION
Added tooltips

Inversed the ALT action, so you can add/remove/apply to all common modifiers on selection. You can isolate those three operators by holding down ALT.

You can't isolate add with ALT though, due to the nature of our menus being floaters instead of sub-menus in the editor. I couldn't find a way around it.