### PR TITLE
fix for 4277-extensions-add-icons-to-install-and-uninstall-buttons

### DIFF
--- a/scripts/addons_core/bl_pkg/bl_extension_ui.py
+++ b/scripts/addons_core/bl_pkg/bl_extension_ui.py
@@ -561,13 +561,13 @@ def extensions_panel_draw_impl(
                         
                         # BFA - Move Uninstall next to Install
                         row_right2.active = True
-                        props = row_right2.operator("bl_pkg.pkg_uninstall", text="Uninstall")
+                        props = row_right2.operator("bl_pkg.pkg_uninstall", text="Uninstall", icon='CANCEL')
                         props.repo_index = repo_index
                         props.pkg_id = pkg_id
                         del props, row_right2
                         
                 else:
-                    props = row_right.operator("bl_pkg.pkg_install", text="Install")
+                    props = row_right.operator("bl_pkg.pkg_install", text="Install", icon='IMPORT')
                     props.repo_index = repo_index
                     props.pkg_id = pkg_id
                     del props


### PR DESCRIPTION
bfa - added import and cancel icons to the Install and Uninstall extension buttons.

![image](https://github.com/Bforartists/Bforartists/assets/25260650/47626641-b9ba-4df4-8ae6-61002f94a457)
