### PR TITLE
fix for 4285-extension-rename-the-install-from-disk-to-install-extension

### DIFF
--- a/scripts/addons_contrib/bl_pkg/bl_extension_ops.py
+++ b/scripts/addons_contrib/bl_pkg/bl_extension_ops.py
@@ -1433,9 +1433,9 @@ class BlPkgPkgUninstallMarked(Operator, _BlPkgCmdMixIn):
 
 
 class BlPkgPkgInstallFiles(Operator, _BlPkgCmdMixIn):
-    """Install an extension from a file into a locally managed repository"""
+    """Install an local extension addon into a user managed repository"""
     bl_idname = "bl_pkg.pkg_install_files"
-    bl_label = "Install from Disk"
+    bl_label = "Install Extension"
     __slots__ = _BlPkgCmdMixIn.cls_slots + (
         "repo_directory",
         "pkg_id_sequence"

--- a/scripts/addons_contrib/bl_pkg/bl_extension_ui.py
+++ b/scripts/addons_contrib/bl_pkg/bl_extension_ui.py
@@ -622,7 +622,7 @@ class USERPREF_MT_extensions_bl_pkg_settings(Menu):
         layout.separator()
 
         layout.operator("bl_pkg.pkg_upgrade_all", text="Install Available Updates", icon='IMPORT')
-        layout.operator("bl_pkg.pkg_install_files", text="Install from Disk")
+        layout.operator("bl_pkg.pkg_install_files", text="Install Extension")
         layout.operator("preferences.addon_install", text="Install Legacy Add-on")
 
         if context.preferences.experimental.use_extension_utils:

--- a/scripts/addons_core/bl_pkg/bl_extension_ops.py
+++ b/scripts/addons_core/bl_pkg/bl_extension_ops.py
@@ -1434,9 +1434,9 @@ class BlPkgPkgUninstallMarked(Operator, _BlPkgCmdMixIn):
 
 
 class BlPkgPkgInstallFiles(Operator, _BlPkgCmdMixIn):
-    """Install an extension from a file into a locally managed repository"""
+    """Install an local extension addon into a user managed repository"""
     bl_idname = "bl_pkg.pkg_install_files"
-    bl_label = "Install from Disk"
+    bl_label = "Install Extension"
     __slots__ = _BlPkgCmdMixIn.cls_slots + (
         "repo_directory",
         "pkg_id_sequence"

--- a/scripts/addons_core/bl_pkg/bl_extension_ui.py
+++ b/scripts/addons_core/bl_pkg/bl_extension_ui.py
@@ -698,7 +698,7 @@ class USERPREF_MT_extensions_bl_pkg_settings(Menu):
         layout.separator()
 
         layout.operator("bl_pkg.pkg_upgrade_all", text="Install Available Updates", icon='IMPORT')
-        layout.operator("bl_pkg.pkg_install_files", text="Install from Disk")
+        layout.operator("bl_pkg.pkg_install_files", text="Install Extension")
         layout.operator("preferences.addon_install", text="Install Legacy Add-on")
 
         if prefs.experimental.use_extension_utils:


### PR DESCRIPTION
-- Renamed 'Install from Disk' to  'Install Extension' 
-- Clarify the tool tip.

![2024-05-19-112310_1920x1080_scrot](https://github.com/Bforartists/Bforartists/assets/25260650/8a3064b5-7bfe-43e1-b0f1-995d6af35cfa)
