### PR TITLE
fix for 4328-view3d-viewport-gizmos-double-entry

### DIFF
--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -8581,13 +8581,13 @@ class VIEW3D_PT_gizmo_display(Panel):
             row.prop(scene.transform_orientation_slots[1], "type", text="")
             row = col.row()
             row.separator()
-            row.prop(view, "show_gizmo_object_translate", text="Move")
+            row.prop(view, "show_gizmo_object_translate", text="Move", text_ctxt=i18n_contexts.operator_default) # BFA 
             row = col.row()
             row.separator()
-            row.prop(view, "show_gizmo_object_rotate", text="Rotate")
+            row.prop(view, "show_gizmo_object_rotate", text="Rotate", text_ctxt=i18n_contexts.operator_default) # BFA
             row = col.row()
             row.separator()
-            row.prop(view, "show_gizmo_object_scale", text="Scale")
+            row.prop(view, "show_gizmo_object_scale", text="Scale", text_ctxt=i18n_contexts.operator_default) # BFA
 
         # Match order of object type visibility
         col = layout.column(align=True)


### PR DESCRIPTION
-- remove double entry
-- added 'text_ctxt' since the double blender one has it, plus every other prop in the file etc.

![image](https://github.com/Bforartists/Bforartists/assets/25260650/3272f1e2-bea1-4da8-ab70-7821baf63601)
