### PR TITLE
fix for 4362-im-and-export-menus-missing-icons

### DIFF
--- a/scripts/addons_core/io_anim_bvh/__init__.py
+++ b/scripts/addons_core/io_anim_bvh/__init__.py
@@ -350,11 +350,11 @@ class BVH_PT_export_animation(bpy.types.Panel):
 
 
 def menu_func_import(self, context):
-    self.layout.operator(ImportBVH.bl_idname, text="Motion Capture (.bvh)")
+    self.layout.operator(ImportBVH.bl_idname, text="Motion Capture (.bvh)", icon='LOAD_BVH') # BFA - Icon Added
 
 
 def menu_func_export(self, context):
-    self.layout.operator(ExportBVH.bl_idname, text="Motion Capture (.bvh)")
+    self.layout.operator(ExportBVH.bl_idname, text="Motion Capture (.bvh)", icon='SAVE_BVH') # BFA - Icon Added
 
 
 classes = (

--- a/scripts/addons_core/io_curve_svg/__init__.py
+++ b/scripts/addons_core/io_curve_svg/__init__.py
@@ -45,7 +45,7 @@ class ImportSVG(bpy.types.Operator, ImportHelper):
 
 def menu_func_import(self, context):
     self.layout.operator(ImportSVG.bl_idname,
-                         text="Scalable Vector Graphics (.svg)")
+                         text="Scalable Vector Graphics (.svg)", icon='LOAD_SVG') # BFA - Icon Added
 
 
 def register():

--- a/scripts/addons_core/io_scene_fbx/__init__.py
+++ b/scripts/addons_core/io_scene_fbx/__init__.py
@@ -699,11 +699,11 @@ class IO_FH_fbx(bpy.types.FileHandler):
 
 
 def menu_func_import(self, context):
-    self.layout.operator(ImportFBX.bl_idname, text="FBX (.fbx)")
+    self.layout.operator(ImportFBX.bl_idname, text="FBX (.fbx)", icon = "LOAD_FBX") # BFA - Icon Added
 
 
 def menu_func_export(self, context):
-    self.layout.operator(ExportFBX.bl_idname, text="FBX (.fbx)")
+    self.layout.operator(ExportFBX.bl_idname, text="FBX (.fbx)", icon = "SAVE_FBX") # BFA - Icon Added
 
 
 classes = (

--- a/scripts/addons_core/io_scene_gltf2/__init__.py
+++ b/scripts/addons_core/io_scene_gltf2/__init__.py
@@ -1699,7 +1699,7 @@ class ExportGLTF2(bpy.types.Operator, ExportGLTF2_Base, ExportHelper):
 
 
 def menu_func_export(self, context):
-    self.layout.operator(ExportGLTF2.bl_idname, text='glTF 2.0 (.glb/.gltf)')
+    self.layout.operator(ExportGLTF2.bl_idname, text='glTF 2.0 (.glb/.gltf)', icon='SAVE_GLTF') # BFA - Icon Added
 
 
 class ImportGLTF2(Operator, ConvertGLTF2_Base, ImportHelper):
@@ -1986,7 +1986,7 @@ class IO_FH_gltf2(bpy.types.FileHandler):
 
 
 def menu_func_import(self, context):
-    self.layout.operator(ImportGLTF2.bl_idname, text='glTF 2.0 (.glb/.gltf)')
+    self.layout.operator(ImportGLTF2.bl_idname, text='glTF 2.0 (.glb/.gltf)', icon='LOAD_GLTF') # BFA - Icon Added
 
 
 classes = (


### PR DESCRIPTION
- added missing icons back.

![image](https://github.com/Bforartists/Bforartists/assets/25260650/60fb6f6c-755f-4ad8-b455-7ec1a2bfcd44)
