### PR TITLE
fix for 4368-3d-view-sculpt-mode-automasking-area-normal-regression-m…

### DIFF
--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -10835,9 +10835,11 @@ class VIEW3D_PT_sculpt_automasking(Panel):
         if sculpt.use_automasking_start_normal:
             col = layout.column(align=True)
             row = col.row()
+            row.use_property_split = True # BFA - label outside
             row.separator(factor=3.5)
             row.prop(sculpt, "automasking_start_normal_limit", text="Limit")
             row = col.row()
+            row.use_property_split = True # BFA - label outside
             row.separator(factor=3.5)
             row.prop(sculpt, "automasking_start_normal_falloff", text="Falloff")
             col.separator()


### PR DESCRIPTION
-- moved labels outside sliders

![image](https://github.com/Bforartists/Bforartists/assets/25260650/0b46ab41-0e6d-49e0-b712-ca7dcb763c11)
