### PR TITLE
fix for 4461-shader-editor-world-mode-missing-icon-for-wave-length-node

### DIFF
--- a/release/datafiles/icons_svg/node_wavelength.svg
+++ b/release/datafiles/icons_svg/node_wavelength.svg
@@ -54,7 +54,7 @@
      inkscape:deskcolor="#d1d1d1" />
   <g
      id="NODE_WAVELENGTH"
-     transform="translate(100,1484)">
+     transform="scale(100)">
     <path
        style="fill:none;stroke-width:0.03125"
        d="M 0,8 V 0 h 8 8 v 8 8 H 8 0 Z"


### PR DESCRIPTION
same issue has #4457

![image](https://github.com/Bforartists/Bforartists/assets/25260650/a1106993-7978-4625-9b8e-c94855737a30)
