### PR TITLE
Update workflows for Windows path for artifact upload

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -34,4 +34,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: Bforartists-Release-${{ runner.os }}
-        path: C:/Users/runneradmin/bforartistsrepo/bfa_build_windows_x64_vc17_Release/bin
+        path: | 
+          C:/Users/runneradmin/bforartistsrepo/bfa_build_windows_x64_vc17_Release/bin
+          D:/a/Bforartists/Bforartists/bfa_build_windows_x64_vc17_Release/bin
+                


### PR DESCRIPTION
Based on issue #4530 and the PR https://github.com/Bforartists/Bforartists/pull/4538 didn't work as expected.
![image](https://github.com/user-attachments/assets/2cdf876c-c919-46ad-a6c3-faa6c7d3bf44)
