### PR TITLE
fix for 4567-addon-default-addons-has-a-resource-warning

### DIFF
--- a/scripts/addons_core/bfa_default_addons/__init__.py
+++ b/scripts/addons_core/bfa_default_addons/__init__.py
@@ -307,7 +307,7 @@ def register_addons():
     """and when Internet Access is disabled."""
 
     if bpy.context.preferences.system.use_online_access:
-        return {'CANCELLED'}
+        return None # BFA - don't cancel, just return none.
 
     # Redirect stdout and stderr to /dev/null - surpresses terminal messages to not spam on first load.
     sys.stdout = open(os.devnull, 'w')


### PR DESCRIPTION
- don't cancel, just return none.