### PR TITLE
fix for 4233-preferences-linux-trackpad-direction-option-for-wayland-…

### DIFF
--- a/scripts/startup/bl_ui/space_userpref.py
+++ b/scripts/startup/bl_ui/space_userpref.py
@@ -2008,6 +2008,10 @@ class USERPREF_PT_input_touchpad(InputPanel, CenterAlignMixIn, Panel):
         from _bpy import _wm_capabilities
         capabilities = _wm_capabilities()
         if not capabilities['TRACKPAD_PHYSICAL_DIRECTION']:
+
+            layout.use_property_split = True # BFA - float left
+            col = layout.column() # BFA - float left
+
             row = col.row()
             row.active = inputs.use_multitouch_gestures
             row.prop(inputs, "touchpad_scroll_direction", text="Scroll Direction")


### PR DESCRIPTION
-- floated left

![image](https://github.com/user-attachments/assets/f485de03-b357-404b-9a2a-59345106b5f0)
