### PR TITLE
# 4570 : Extensions - Add ability to also toggle addon extensions from the Extension tab

### DIFF
--- a/scripts/addons_core/bl_pkg/bl_extension_ui.py
+++ b/scripts/addons_core/bl_pkg/bl_extension_ui.py
@@ -1359,6 +1359,15 @@ def extension_draw_item(
     if pkg_block or item_warnings:
         sub.label(text=item.name, icon='ERROR', translate=False)
     else:
+        # BFA - Add ability to toggle extension from Extension tab
+        if is_installed and item.type == "add-on":
+            module_name = pkg_repo_module_prefix(repo_item) + pkg_id
+            sub.operator(
+                "preferences.addon_disable" if is_enabled else "preferences.addon_enable",
+                icon='CHECKBOX_HLT' if is_enabled else 'CHECKBOX_DEHLT', text="",
+                emboss=False,
+            ).module = module_name 
+        
         sub.label(text=item.name, icon=icon, translate=False) # BFA - Add visual indicators to listings
     del sub
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/007d9f51-41cb-48d8-88b1-5c0fe27014bd

Opted to not try doing anything clever here and just copied how it's implemented in the Addons tab.
As for the layout, felt intuitive to place it in-between the side arrow and the extension name & icon.

It only appears if the extension is an addon and is installed because:

1. a checkbox interface doesn't make sense for themes where only one can be enabled.
2. the operator that the checkbox calls requires a module to already be installed to be able to enable/disable it.