### PR TITLE
fix for 4620-top-bar-edit-group-object-clear-sub-group-missing-in-glo…

### DIFF
--- a/scripts/startup/bl_ui/space_topbar_toolbar.py
+++ b/scripts/startup/bl_ui/space_topbar_toolbar.py
@@ -301,6 +301,7 @@ class TOPBAR_PT_main(Panel):
                 row.prop(addon_prefs, "topbar_edit_objectapply",toggle=addon_prefs.bfa_button_style)
                 row.prop(addon_prefs, "topbar_edit_objectapply2",toggle=addon_prefs.bfa_button_style)
                 row.prop(addon_prefs, "topbar_edit_objectapplydeltas",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_edit_objectclear",toggle=addon_prefs.bfa_button_style)
             else:
                 row = box.row()
                 row.alignment = 'Center'.upper()


### PR DESCRIPTION
-- added missing object clear operators

![image](https://github.com/user-attachments/assets/892ecd30-84ea-49da-b402-210a54714e3b)
