### PR TITLE
Asset Shelf - Add view pre-set sizes for thumbnails #4670

### DIFF
--- a/scripts/startup/bl_ui/asset_shelf.py
+++ b/scripts/startup/bl_ui/asset_shelf.py
@@ -4,8 +4,46 @@
 
 import bpy
 from bpy.types import (
+    Operator,
     Panel,
 )
+
+from bpy.props import EnumProperty
+
+
+# BFA - Preset sizes for asset shelf thumbnails
+thumbnail_sizes = {
+    "TINY" : 48,
+    "SMALL" : 96,
+    "MEDIUM" : 128,
+    "LARGE" : 256,
+}
+
+# BFA - Preset sizes and their corresponding UI labels
+thumbnail_size_labels = tuple((item, item.title(), "") for item in thumbnail_sizes)
+
+
+class ASSETSHELF_OT_change_thumbnail_size(Operator):
+    bl_label = "Change Thumbnail Size"
+    bl_idname = "asset_shelf.change_thumbnail_size"
+    bl_description = "Change the size of thumbnails in discrete steps"
+   
+    size : EnumProperty(
+        name="Thumbnail Size",
+        description="Change the size of thumbnails in discrete steps",
+        default="TINY",
+        items=thumbnail_size_labels
+    )
+
+    def execute(self, context):
+        shelf = context.asset_shelf
+        shelf.preview_size = thumbnail_sizes[self.size]
+
+        return {'FINISHED'}
+
+    @classmethod
+    def poll(cls, context):
+        return context.asset_shelf is not None
 
 
 class ASSETSHELF_PT_display(Panel):
@@ -21,6 +59,14 @@ class ASSETSHELF_PT_display(Panel):
         layout.use_property_decorate = False  # No animation.
 
         shelf = context.asset_shelf
+        
+        # BFA - Thumbnail preset buttons
+        row = layout.row(align=True)
+        row.context_pointer_set("asset_shelf", shelf)
+        # BFA - operator_menu_enum doesn't seem to support horizontal button layout 
+        # in popover panels, so the buttons are created one-by-one instead
+        for value, label, _description in thumbnail_size_labels:
+            row.operator("asset_shelf.change_thumbnail_size", text=label).size = value
 
         layout.prop(shelf, "preview_size", text="Size")
         layout.use_property_split = False
@@ -33,6 +79,7 @@ class ASSETSHELF_PT_display(Panel):
 
 classes = (
     ASSETSHELF_PT_display,
+    ASSETSHELF_OT_change_thumbnail_size
 )
 
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/1ba10c15-808e-4f93-af66-a5168f8f7d15

Added buttons for setting the preview thumbnails of asset shelf to preset sizes.
This is implemented via `ASSETSHELF_OT_change_thumbnail_size` which is a helper operator that edits the current asset shelf's `preview_size` property when executed.

This implementation allows for multiple UI Areas showing the same asset shelf to have different sizes. Other methods I tested such as using an `EnumProperty` stored in `bpy.types.Screen` *(which is the most granular ID type I could use)*, couldn't quite achieve this behavior.

## A Small Compromise
How the buttons are drawn in the UI are different from how the ones in the Asset & File Browser are drawn.
This is a consequence of how the one for asset shelves had to be implemented via operators instead of a built-in enum property like the ones.

| Asset Shelf | Asset Browser | File Browser |
|---|---|---|
 |![image](https://github.com/user-attachments/assets/5bc0e9e3-47bf-4a41-aff3-e139833069a8) | ![image](https://github.com/user-attachments/assets/7de0e7f5-d17a-40a0-ac96-5032ac4d8fc7) | ![image](https://github.com/user-attachments/assets/d6132f6e-c29c-487b-8ff5-990a49d0c3a3) |

Ultimately, I don't think this inconsistency is too bad, and isn't bad enough to warrant not having this feature.
And I think the File Browser is a context different enough that it being different isn't too bad. 

So it's only the difference between asset shelves and the Asset Browser that is mildly jarring.
One option we might have in the future is to use the same implementation used here on the Asset Browser.
