### PR TITLE
3D View - Grease Pencil - Edit Mode - Update Cleanup operators #4688

### DIFF
--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -7194,9 +7194,9 @@ class VIEW3D_MT_edit_greasepencil_cleanup(Menu):
         layout.operator("grease_pencil.clean_loose", icon="DELETE_LOOSE")
         layout.operator("grease_pencil.frame_clean_duplicate", icon="DELETE_DUPLICATE")
 
-        layout.operator("grease_pencil.stroke_merge_by_distance", text="Merge by Distance", icon="REMOVE_DOUBLES") # BFA - should only show in edit mode
-
-        layout.operator("grease_pencil.reproject") # BFA - should only show in edit mode
+        if ob.mode == "EDIT": # BFA - should only show in edit mode
+            layout.operator("grease_pencil.stroke_merge_by_distance", text="Merge by Distance", icon="REMOVE_DOUBLES")
+            layout.operator("grease_pencil.reproject", icon="REPROJECT")
 
 
 # BFA menu - legacy


### PR DESCRIPTION
| Edit Mode | Draw Mode |
|---|---|
| ![image](https://github.com/user-attachments/assets/45410fd1-d590-4ea5-be32-72e4f0daaea5) | ![image](https://github.com/user-attachments/assets/a8447460-4ed0-4322-aa23-e4cd254d9aa5) |

Added a conditional to only draw `Reproject Strokes` and `Merge By Distance` operators when in Edit Mode.
Also added `'REPROJECT'` icon to `Reproject Strokes` operator. 