### PR TITLE
3D View - Grease Pencil - Edit Mode - Remove "Weights" menu from header #4687

### DIFF
--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -7245,7 +7245,7 @@ class VIEW3D_MT_edit_greasepencil(Menu):
 
         #layout.separator()
 
-        layout.menu("VIEW3D_MT_weight_grease_pencil")
+        # layout.menu("VIEW3D_MT_weight_grease_pencil") # BFA - not used
 
         layout.separator()
 


### PR DESCRIPTION
| Before | After |
|---|---|
| ![image](https://github.com/user-attachments/assets/003de72c-c2b5-4c43-9a80-3148f2556611) | ![image](https://github.com/user-attachments/assets/af2e0a00-ffe6-4207-aeb9-8ee32b9fc1a9) |

Removed "Weights" menu from the Edit Mode header menu of Grease Pencil objects.

The menu is commented out of the code, not erased entirely. 
This is in accordance with other UI items disabled in BFA on the same file.