### PR TITLE
fix for 4680-dopesheet-drop-down-icon-in-channels-is-the-wrong-icon

### DIFF
--- a/source/blender/editors/animation/anim_channels_defines.cc
+++ b/source/blender/editors/animation/anim_channels_defines.cc
@@ -5528,8 +5528,9 @@ static void draw_setting_widget(bAnimContext *ac,
       break;
 
     case ACHANNEL_SETTING_EXPAND: /* expanded triangle */
-      // icon = (enabled ? ICON_TRIA_DOWN : ICON_TRIA_RIGHT);
-      icon = ICON_TRIA_RIGHT;
+      icon = (enabled ? ICON_TRIA_DOWN : ICON_TRIA_RIGHT); /* BFA - use proper icons */
+      usetoggle = false; /* BFA - use proper icons */
+      // icon = ICON_TRIA_RIGHT;
       tooltip = TIP_("Expand\nMake channels grouped under this channel visible");
       break;
 


### PR DESCRIPTION
-- Fix drop down icon in the channels.

![2024-10-03_15-02](https://github.com/user-attachments/assets/5956b9a8-250f-467a-9aa0-3af391c46131)
