### PR TITLE
fix for 4675-properties-editor-grease-pencil-layers-expose-move-to-to…

### DIFF
--- a/scripts/startup/bl_ui/properties_data_grease_pencil.py
+++ b/scripts/startup/bl_ui/properties_data_grease_pencil.py
@@ -211,6 +211,10 @@ class GREASE_PENCIL_MT_grease_pencil_add_layer_extra(Menu):
             layout.operator("grease_pencil.layer_group_remove", text="Ungroup", icon = 'NODE_UNGROUP').keep_children = True
 
         layout.separator()
+        layout.operator("grease_pencil.layer_move_top", text="Move to Top", icon='TRIA_UP_BAR') # bfa - added move up/down operators
+        layout.operator("grease_pencil.layer_move_bottom", text="Move to Bottom", icon='TRIA_DOWN_BAR') # bfa - added move up/down operators
+
+        layout.separator()
         layout.operator("grease_pencil.layer_duplicate", text="Duplicate", icon='DUPLICATE').empty_keyframes = False
         layout.operator("grease_pencil.layer_duplicate", text="Duplicate Empty Keyframes", icon='DUPLICATE' ).empty_keyframes = True
 

--- a/source/blender/editors/grease_pencil/intern/grease_pencil_layers.cc
+++ b/source/blender/editors/grease_pencil/intern/grease_pencil_layers.cc
@@ -951,6 +951,78 @@ static void GREASE_PENCIL_OT_layer_duplicate_object(wmOperatorType *ot)
   ot->prop = RNA_def_enum(ot->srna, "mode", copy_mode, 0, "Mode", "");
 }
 
+/* bfa - added move up/down operators */
+static int grease_pencil_layer_move_top_exec(bContext *C, wmOperator *)
+{
+  using namespace blender::bke::greasepencil;
+  Object *object = CTX_data_active_object(C);
+  GreasePencil &grease_pencil = *static_cast<GreasePencil *>(object->data);
+
+  if (!grease_pencil.has_active_layer()) {
+    return OPERATOR_CANCELLED;
+  }
+
+  Layer &active_layer = *grease_pencil.get_active_layer();
+  grease_pencil.move_node_top(active_layer.as_node());
+
+  DEG_id_tag_update(&grease_pencil.id, ID_RECALC_GEOMETRY);
+  WM_event_add_notifier(C, NC_GPENCIL | ND_DATA | NA_SELECTED, &grease_pencil);
+
+  return OPERATOR_FINISHED;
+}
+
+/* bfa - added move up/down operators */
+static void GREASE_PENCIL_OT_layer_move_top(wmOperatorType *ot)
+{
+  /* identifiers */
+  ot->name = "Move Layer to Top";
+  ot->idname = "GREASE_PENCIL_OT_layer_move_top";
+  ot->description = "Move the active Grease Pencil layer to the top";
+
+  /* api callbacks */
+  ot->exec = grease_pencil_layer_move_top_exec;
+  ot->poll = active_grease_pencil_layer_poll;
+
+  /* flags */
+  ot->flag = OPTYPE_REGISTER | OPTYPE_UNDO;
+}
+
+/* bfa - added move up/down operators */
+static int grease_pencil_layer_move_bottom_exec(bContext *C, wmOperator *)
+{
+  using namespace blender::bke::greasepencil;
+  Object *object = CTX_data_active_object(C);
+  GreasePencil &grease_pencil = *static_cast<GreasePencil *>(object->data);
+
+  if (!grease_pencil.has_active_layer()) {
+    return OPERATOR_CANCELLED;
+  }
+
+  Layer &active_layer = *grease_pencil.get_active_layer();
+  grease_pencil.move_node_bottom(active_layer.as_node());
+
+  DEG_id_tag_update(&grease_pencil.id, ID_RECALC_GEOMETRY);
+  WM_event_add_notifier(C, NC_GPENCIL | ND_DATA | NA_SELECTED, &grease_pencil);
+
+  return OPERATOR_FINISHED;
+}
+
+/* bfa - added move up/down operators */
+static void GREASE_PENCIL_OT_layer_move_bottom(wmOperatorType *ot)
+{
+  /* identifiers */
+  ot->name = "Move Layer to Bottom";
+  ot->idname = "GREASE_PENCIL_OT_layer_move_bottom";
+  ot->description = "Move the active Grease Pencil layer to the bottom";
+
+  /* api callbacks */
+  ot->exec = grease_pencil_layer_move_bottom_exec;
+  ot->poll = active_grease_pencil_layer_poll;
+
+  /* flags */
+  ot->flag = OPTYPE_REGISTER | OPTYPE_UNDO;
+}
+
 }  // namespace blender::ed::greasepencil
 
 void ED_operatortypes_grease_pencil_layers()
@@ -975,4 +1047,7 @@ void ED_operatortypes_grease_pencil_layers()
   WM_operatortype_append(GREASE_PENCIL_OT_layer_mask_reorder);
   WM_operatortype_append(GREASE_PENCIL_OT_layer_group_color_tag);
   WM_operatortype_append(GREASE_PENCIL_OT_layer_duplicate_object);
+
+  WM_operatortype_append(GREASE_PENCIL_OT_layer_move_top); /* bfa - added move up/down operators */
+  WM_operatortype_append(GREASE_PENCIL_OT_layer_move_bottom); /* bfa - added move up/down operators */
 }


### PR DESCRIPTION
-- added move up and down operators.

![image](https://github.com/user-attachments/assets/b596d50e-13a7-4402-bc25-f4a0ae9cb707)
