### PR TITLE
Grease Pencil - Vertex Paint Mode - Make color picker UI in header and sidebar consistent

### DIFF
--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -483,7 +483,12 @@ class _draw_tool_settings_context_mode:
             layout.separator(factor=0.4)
             ups = context.tool_settings.unified_paint_settings
             prop_owner = ups if ups.use_unified_color else brush
-            layout.prop_with_popover(prop_owner, "color", text="", panel="TOPBAR_PT_grease_pencil_vertex_color")
+
+            sub = layout.row(align=True)
+            sub.prop_with_popover(prop_owner, "color", text="", panel="TOPBAR_PT_grease_pencil_vertex_color")
+            sub.prop(prop_owner, "secondary_color", text="")
+            sub.operator("paint.brush_colors_flip", icon='FILE_REFRESH', text="")
+
 
         brush_basic_grease_pencil_vertex_settings(layout, context, brush, compact=True)
 

--- a/scripts/startup/bl_ui/space_view3d_toolbar.py
+++ b/scripts/startup/bl_ui/space_view3d_toolbar.py
@@ -2344,7 +2344,7 @@ class VIEW3D_PT_tools_grease_pencil_brush_vertex_color(View3DPanel, Panel):
         sub_row.prop(brush, "color", text="")
         sub_row.prop(brush, "secondary_color", text="")
 
-        sub_row.operator("gpencil.tint_flip", icon='FILE_REFRESH', text="")
+        sub_row.operator("paint.brush_colors_flip", icon='FILE_REFRESH', text="")
 
 
 class VIEW3D_PT_tools_grease_pencil_brush_vertex_falloff(GreasePencilBrushFalloff, Panel, View3DPaintPanel):


### PR DESCRIPTION

https://github.com/user-attachments/assets/840e023c-db21-4ac2-b698-d53219fc3db4

- Added secondary color prop and "Swap Colors" operator to header
- Updated "Swap Colors" operator in sidebar panel to the new version

Opted to not shrink the color swatches the same way as they are in Draw mode, as that requires a lot more layout code and we still have plenty of header space in Vertex Paint mode.

