### PR TITLE
fix for 4797-view-area-menu-horizontal-and-vertical-split-and-its-icons

### DIFF
--- a/release/datafiles/icons_svg/split_horizontal.svg
+++ b/release/datafiles/icons_svg/split_horizontal.svg
@@ -8,7 +8,7 @@
    height="1600"
    viewBox="0 0 1600 1600"
    sodipodi:docname="split_horizontal.svg"
-   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -43,32 +43,32 @@
      id="namedview4"
      showgrid="false"
      inkscape:zoom="0.5"
-     inkscape:cx="371"
-     inkscape:cy="364"
+     inkscape:cx="384"
+     inkscape:cy="862"
      inkscape:window-x="-8"
      inkscape:window-y="-8"
      inkscape:window-maximized="1"
-     inkscape:current-layer="SPLIT_HORIZONTAL"
+     inkscape:current-layer="SPLIT_VERTICAL"
      inkscape:showpageshadow="0"
      inkscape:pagecheckerboard="true"
      inkscape:deskcolor="#d1d1d1" />
   <g
-     id="SPLIT_HORIZONTAL"
+     id="SPLIT_VERTICAL"
      transform="matrix(100,0,0,100,0,4.9999997e-5)"
      style="stroke-width:0.0114286">
     <path
        style="fill:none;stroke-width:0.000357143"
-       d="M 1,12.5 V 10 H 0.5 0 V 8 6 H 0.5 1 V 3.5 1 H 3.5 6 V 3.5 6 H 6.5 7 v 2 2 H 6.5 6 V 12.5 15 H 3.5 1 Z m 8,0 V 10 H 8.5 8 V 8 6 H 8.5 9 V 3.5 1 h 3 3 V 3.5 6 h 0.5 0.5 v 2 2 H 15.5 15 V 12.5 15 H 12 9 Z"
+       d="M 6,15.5 V 15 H 3.5 1 V 12 9 H 3.5 6 V 8.5 8 h 2 2 V 8.5 9 h 2.5 2.5 v 3 3 H 12.5 10 V 15.5 16 H 8 6 Z m 0,-9 V 6 H 3.5 1 V 3.5 1 H 3.5 6 V 0.5 0 h 2 2 V 0.5 1 H 12.5 15 V 3.5 6 H 12.5 10 V 6.5 7 H 8 6 Z"
        id="path823"
        inkscape:connector-curvature="0" />
     <path
        style="fill:#fefefe;stroke-width:0.000357143"
-       d="M 0,13 V 10 H 0.5 1 V 12.5 15 H 3.5 6 V 12.5 10 H 6.5 7 v 3 3 H 3.5 0 Z m 8,0 V 10 H 8.5 9 v 2.5 2.5 h 3 3 V 12.5 10 h 0.5 0.5 v 3 3 H 12 8 Z M 0,3 V 0 H 3.5 7 V 3 6 H 6.5 6 V 3.5 1 H 3.5 1 V 3.5 6 H 0.5 0 Z M 8,3 V 0 h 4 4 V 3 6 H 15.5 15 V 3.5 1 H 12 9 V 3.5 6 H 8.5 8 Z"
+       d="M 0,12 V 8 H 3 6 V 8.5 9 H 3.5 1 v 3 3 H 3.5 6 V 15.5 16 H 3 0 Z m 10,3.5 V 15 H 12.5 15 V 12 9 H 12.5 10 V 8.5 8 h 3 3 v 4 4 H 13 10 Z M 0,3.5 V 0 H 3 6 V 0.5 1 H 3.5 1 V 3.5 6 H 3.5 6 V 6.5 7 H 3 0 Z m 10,3 V 6 H 12.5 15 V 3.5 1 H 12.5 10 V 0.5 0 h 3 3 V 3.5 7 h -3 -3 z"
        id="path821"
        inkscape:connector-curvature="0" />
     <path
-       style="fill:#fe0000;stroke-width:0.000357143"
-       d="M 7,8 V 0 H 7.5 8 v 8 8 H 7.5 7 Z"
+       style="fill:#fd0000;stroke-width:0.000357143"
+       d="M 0,7.5 V 7 h 8 8 V 7.5 8 H 8 0 Z"
        id="path819"
        inkscape:connector-curvature="0" />
   </g>

--- a/release/datafiles/icons_svg/split_vertical.svg
+++ b/release/datafiles/icons_svg/split_vertical.svg
@@ -8,7 +8,7 @@
    height="1600"
    viewBox="0 0 1600 1600"
    sodipodi:docname="split_vertical.svg"
-   inkscape:version="1.2.2 (732a01da63, 2022-12-09)"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns="http://www.w3.org/2000/svg"
@@ -43,32 +43,32 @@
      id="namedview4"
      showgrid="false"
      inkscape:zoom="0.5"
-     inkscape:cx="383"
-     inkscape:cy="862"
+     inkscape:cx="372"
+     inkscape:cy="364"
      inkscape:window-x="-8"
      inkscape:window-y="-8"
      inkscape:window-maximized="1"
-     inkscape:current-layer="SPLIT_VERTICAL"
+     inkscape:current-layer="SPLIT_HORIZONTAL"
      inkscape:showpageshadow="0"
      inkscape:pagecheckerboard="true"
      inkscape:deskcolor="#d1d1d1" />
   <g
-     id="SPLIT_VERTICAL"
+     id="SPLIT_HORIZONTAL"
      transform="matrix(100,0,0,100,0,4.9999997e-5)"
      style="stroke-width:0.0114286">
     <path
        style="fill:none;stroke-width:0.000357143"
-       d="M 6,15.5 V 15 H 3.5 1 V 12 9 H 3.5 6 V 8.5 8 h 2 2 V 8.5 9 h 2.5 2.5 v 3 3 H 12.5 10 V 15.5 16 H 8 6 Z m 0,-9 V 6 H 3.5 1 V 3.5 1 H 3.5 6 V 0.5 0 h 2 2 V 0.5 1 H 12.5 15 V 3.5 6 H 12.5 10 V 6.5 7 H 8 6 Z"
+       d="M 1,12.5 V 10 H 0.5 0 V 8 6 H 0.5 1 V 3.5 1 H 3.5 6 V 3.5 6 H 6.5 7 v 2 2 H 6.5 6 V 12.5 15 H 3.5 1 Z m 8,0 V 10 H 8.5 8 V 8 6 H 8.5 9 V 3.5 1 h 3 3 V 3.5 6 h 0.5 0.5 v 2 2 H 15.5 15 V 12.5 15 H 12 9 Z"
        id="path823"
        inkscape:connector-curvature="0" />
     <path
        style="fill:#fefefe;stroke-width:0.000357143"
-       d="M 0,12 V 8 H 3 6 V 8.5 9 H 3.5 1 v 3 3 H 3.5 6 V 15.5 16 H 3 0 Z m 10,3.5 V 15 H 12.5 15 V 12 9 H 12.5 10 V 8.5 8 h 3 3 v 4 4 H 13 10 Z M 0,3.5 V 0 H 3 6 V 0.5 1 H 3.5 1 V 3.5 6 H 3.5 6 V 6.5 7 H 3 0 Z m 10,3 V 6 H 12.5 15 V 3.5 1 H 12.5 10 V 0.5 0 h 3 3 V 3.5 7 h -3 -3 z"
+       d="M 0,13 V 10 H 0.5 1 V 12.5 15 H 3.5 6 V 12.5 10 H 6.5 7 v 3 3 H 3.5 0 Z m 8,0 V 10 H 8.5 9 v 2.5 2.5 h 3 3 V 12.5 10 h 0.5 0.5 v 3 3 H 12 8 Z M 0,3 V 0 H 3.5 7 V 3 6 H 6.5 6 V 3.5 1 H 3.5 1 V 3.5 6 H 0.5 0 Z M 8,3 V 0 h 4 4 V 3 6 H 15.5 15 V 3.5 1 H 12 9 V 3.5 6 H 8.5 8 Z"
        id="path821"
        inkscape:connector-curvature="0" />
     <path
-       style="fill:#fd0000;stroke-width:0.000357143"
-       d="M 0,7.5 V 7 h 8 8 V 7.5 8 H 8 0 Z"
+       style="fill:#fe0000;stroke-width:0.000357143"
+       d="M 7,8 V 0 H 7.5 8 v 8 8 H 7.5 7 Z"
        id="path819"
        inkscape:connector-curvature="0" />
   </g>


### PR DESCRIPTION
-- renamed split_vertical to split_horizontal
-- renamed split_horizontal to split_vertical


https://github.com/user-attachments/assets/db9fc65f-d372-4f1e-86e2-6d1ec8875c4a

