### PR TITLE
fix for 4799-outliner_drawcc-missing-declarations-for-calculate_hiera…

### DIFF
--- a/source/blender/editors/space_outliner/outliner_intern.hh
+++ b/source/blender/editors/space_outliner/outliner_intern.hh
@@ -379,6 +379,15 @@ void outliner_item_mode_toggle(bContext *C,
                                TreeElement *te,
                                bool do_extend);
 
+/**
+ * Calculates the depth of the hierarchy for a given tree element.
+ */ 
+int calculate_hierarchy_depth(const TreeElement *te);
+/**
+ * Computes the total height occupied by all child elements of a given tree element.
+ */
+int calculate_children_height(const TreeElement *te, const SpaceOutliner *space_outliner);
+
 /* `outliner_edit.cc` */
 using outliner_operation_fn = blender::FunctionRef<void(bContext *C,
                                                         ReportList *reports,


### PR DESCRIPTION
-- added calculate_hierarchy_depth and calculate_children_height