### PR TITLE
fix for 4808-goo-engine-option-to-disable-material-icon-rendering

### DIFF
--- a/scripts/startup/bl_ui/properties_material.py
+++ b/scripts/startup/bl_ui/properties_material.py
@@ -36,7 +36,10 @@ class MATERIAL_UL_matslots(UIList):
 
         if self.layout_type in {'DEFAULT', 'COMPACT'}:
             if ma:
-                layout.prop(ma, "name", text="", emboss=False, icon_value=icon)
+                if bpy.context.preferences.disable_material_icon: # bfa - just show material icon when enabled.
+                    layout.prop(ma, "name", text="", emboss=False, icon="MATERIAL")
+                else:
+                    layout.prop(ma, "name", text="", emboss=False, icon_value=icon)
             else:
                 layout.label(text="", icon_value=icon)
         elif self.layout_type == 'GRID':

--- a/scripts/startup/bl_ui/space_userpref.py
+++ b/scripts/startup/bl_ui/space_userpref.py
@@ -236,6 +236,8 @@ class USERPREF_PT_interface_display(InterfacePanel, CenterAlignMixIn, Panel):
         flow.prop(prefs, "use_recent_searches", text="Sort search by Most Recent")
         # bfa - gooengine disable_search_on_keypress
         flow.prop(prefs, "disable_search_on_keypress", text="Disable search on Key press")
+        # bfa - gooengine disable_material_icon
+        flow.prop(prefs, "disable_material_icon", text="Disable Material Icon Rendering")
 
 
 class USERPREF_PT_interface_text(InterfacePanel, CenterAlignMixIn, Panel):

--- a/source/blender/editors/interface/interface_icons.cc
+++ b/source/blender/editors/interface/interface_icons.cc
@@ -1148,6 +1148,10 @@ static void icon_set_image(const bContext *C,
                            enum eIconSizes size,
                            const bool use_job)
 {
+  /* bfa - disable material icons rendering */
+  if (U.flag & USER_DISABLE_MATERIAL_ICON && GS(id->name) == ID_MA) {
+    return;
+  }
   if (!prv_img) {
     if (G.debug & G_DEBUG) {
       printf("%s: no preview image for this ID: %s\n", __func__, id->name);
@@ -1729,6 +1733,10 @@ int ui_id_icon_get(const bContext *C, ID *id, const bool big)
     case ID_IM: /* fall through */
     case ID_WO: /* fall through */
     case ID_LA: /* fall through */
+      /* bfa - disable material icons rendering, just show Material icon when enabled */
+      if (GS(id->name) == ID_MA && U.flag & USER_DISABLE_MATERIAL_ICON) {
+        return ICON_MATERIAL;
+      }
       iconid = BKE_icon_id_ensure(id);
       /* checks if not exists, or changed */
       UI_icon_render_id(C, nullptr, id, big ? ICON_SIZE_PREVIEW : ICON_SIZE_ICON, true);

--- a/source/blender/makesdna/DNA_userdef_types.h
+++ b/source/blender/makesdna/DNA_userdef_types.h
@@ -1213,6 +1213,7 @@ typedef enum eUserPref_Flag {
   USER_TOOLTIPS_PYTHON = (1 << 26),
   USER_FLAG_UNUSED_27 = (1 << 27), /* dirty */
   USER_FLAG_DISABLE_SEARCH_ON_KEYPRESS = (1 << 28), /* bfa - gooengine disable_search_on_keypress */
+  USER_DISABLE_MATERIAL_ICON = (1 << 29), /* bfa - gooengine disable material icon rendering */
 } eUserPref_Flag;
 
 /** #UserDef.extension_flag */

--- a/source/blender/makesrna/intern/rna_userdef.cc
+++ b/source/blender/makesrna/intern/rna_userdef.cc
@@ -7527,7 +7527,7 @@ static void rna_def_userdef_experimental(BlenderRNA *brna)
   RNA_def_property_boolean_sdna(prop, nullptr, "use_new_point_cloud_type", 1);
   RNA_def_property_ui_text(
       prop, "New Point Cloud Type", "Enable the new point cloud type in the ui");
-
+  
   prop = RNA_def_property(srna, "use_new_curves_tools", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_sdna(prop, nullptr, "use_new_curves_tools", 1);
   RNA_def_property_ui_text(
@@ -7737,6 +7737,17 @@ void RNA_def_userdef(BlenderRNA *brna)
       "Ignore menus tagged with Search On Key Press, and fallback to using accelerator keys instead");
    /* BFA - GooEngine end */
 
+  /* BFA - GooEngine disable_material_icon */
+  prop = RNA_def_property(srna, "disable_material_icon", PROP_BOOLEAN, PROP_NONE);
+  RNA_def_property_boolean_sdna(prop, nullptr, "flag", USER_DISABLE_MATERIAL_ICON);
+  RNA_def_property_ui_text(
+      prop,
+      "Disable Material Icon Rendering",
+      "If true, Material Preview Icons will NOT be rendered. "
+      "This can prevent stuttering from opening the material ID menu");
+  RNA_def_property_update(prop, 0, "rna_userdef_ui_update");
+   /* BFA - GooEngine end */
+  
   /* nested structs */
   prop = RNA_def_property(srna, "view", PROP_POINTER, PROP_NONE);
   RNA_def_property_flag(prop, PROP_NEVER_NULL);


### PR DESCRIPTION
-- added a user pref toggle to disable material icons from rendering, helps when a object with lot of materials can stutter or freeze the UI for long periods.

When enabled a material icon will be shown instead.


https://github.com/user-attachments/assets/e8453dc3-7a88-442e-976c-4ab230eb985a

