### PR TITLE
fix for 4842-launching-bforartists-from-the-provided-command-scripts-are

### DIFF
--- a/release/windows/batch/blender_debug_cycles.cmd
+++ b/release/windows/batch/blender_debug_cycles.cmd
@@ -1,6 +1,6 @@
 @echo off
-echo Starting blender with Cycles logging options, log files will be created
-echo in your temp folder, windows explorer will open after you close blender
+echo Starting bforartists with Cycles logging options, log files will be created
+echo in your temp folder, windows explorer will open after you close bforartists
 echo to help you find them.
 echo.
 echo If you report a bug on https://projects.blender.org you can attach these files
@@ -9,12 +9,12 @@ echo blender_debug_output.txt and blender_system_info.txt in your report.
 echo.
 pause
 echo.
-echo Starting blender and waiting for it to exit....
+echo Starting bforartists and waiting for it to exit....
 setlocal
 
 set PYTHONPATH=
-set DEBUGLOGS="%temp%\blender\debug_logs"
+set DEBUGLOGS="%temp%\bforartists\debug_logs"
 mkdir "%DEBUGLOGS%" > NUL 2>&1
 
-"%~dp0\blender" --debug --debug-cycles --verbose 8 --log-level -1 --python-expr "import bpy; bpy.context.preferences.filepaths.temporary_directory=r'%DEBUGLOGS%'; bpy.ops.wm.sysinfo(filepath=r'%DEBUGLOGS%\blender_system_info.txt')" > "%DEBUGLOGS%\blender_debug_output.txt" 2>&1 < %0
+"%~dp0\bforartists" --debug --debug-cycles --verbose 8 --log-level -1 --python-expr "import bpy; bpy.context.preferences.filepaths.temporary_directory=r'%DEBUGLOGS%'; bpy.ops.wm.sysinfo(filepath=r'%DEBUGLOGS%\blender_system_info.txt')" > "%DEBUGLOGS%\blender_debug_output.txt" 2>&1 < %0
 explorer "%DEBUGLOGS%"

--- a/release/windows/batch/blender_debug_gpu.cmd
+++ b/release/windows/batch/blender_debug_gpu.cmd
@@ -1,6 +1,6 @@
 @echo off
-echo Starting blender with GPU debugging options, log files will be created
-echo in your temp folder, windows explorer will open after you close blender
+echo Starting bforartists with GPU debugging options, log files will be created
+echo in your temp folder, windows explorer will open after you close bforartists
 echo to help you find them.
 echo.
 echo If you report a bug on https://projects.blender.org you can attach these files
@@ -9,12 +9,12 @@ echo blender_debug_output.txt and blender_system_info.txt in your report.
 echo.
 pause
 echo.
-echo Starting blender and waiting for it to exit....
+echo Starting bforartists and waiting for it to exit....
 setlocal
 
 set PYTHONPATH=
-set DEBUGLOGS="%temp%\blender\debug_logs"
+set DEBUGLOGS="%temp%\bforartists\debug_logs"
 mkdir "%DEBUGLOGS%" > NUL 2>&1
 
-"%~dp0\blender" --debug --debug-gpu --debug-cycles --python-expr "import bpy; bpy.context.preferences.filepaths.temporary_directory=r'%DEBUGLOGS%'; bpy.ops.wm.sysinfo(filepath=r'%DEBUGLOGS%\blender_system_info.txt')" > "%DEBUGLOGS%\blender_debug_output.txt" 2>&1 < %0
+"%~dp0\bforartists" --debug --debug-gpu --debug-cycles --python-expr "import bpy; bpy.context.preferences.filepaths.temporary_directory=r'%DEBUGLOGS%'; bpy.ops.wm.sysinfo(filepath=r'%DEBUGLOGS%\blender_system_info.txt')" > "%DEBUGLOGS%\blender_debug_output.txt" 2>&1 < %0
 explorer "%DEBUGLOGS%"

--- a/release/windows/batch/blender_debug_gpu_glitchworkaround.cmd
+++ b/release/windows/batch/blender_debug_gpu_glitchworkaround.cmd
@@ -1,7 +1,7 @@
 @echo off
-echo Starting blender with GPU debugging and glitch workaround options, log files 
+echo Starting bforartists with GPU debugging and glitch workaround options, log files 
 echo will be created in your temp folder, windows explorer will open after you 
-echo close blender to help you find them.
+echo close bforartists to help you find them.
 echo.
 echo If you report a bug on https://projects.blender.org you can attach these files
 echo by dragging them into the text area of your bug report, please include both
@@ -9,12 +9,12 @@ echo blender_debug_output.txt and blender_system_info.txt in your report.
 echo.
 pause
 echo.
-echo Starting blender and waiting for it to exit....
+echo Starting bforartists and waiting for it to exit....
 setlocal
 
 set PYTHONPATH=
-set DEBUGLOGS="%temp%\blender\debug_logs"
+set DEBUGLOGS="%temp%\bforartists\debug_logs"
 mkdir "%DEBUGLOGS%" > NUL 2>&1
 
-"%~dp0\blender" --debug --debug-gpu --debug-gpu-force-workarounds --python-expr "import bpy; bpy.context.preferences.filepaths.temporary_directory=r'%DEBUGLOGS%'; bpy.ops.wm.sysinfo(filepath=r'%DEBUGLOGS%\blender_system_info.txt')" > "%DEBUGLOGS%\blender_debug_output.txt" 2>&1 < %0
+"%~dp0\bforartists" --debug --debug-gpu --debug-gpu-force-workarounds --python-expr "import bpy; bpy.context.preferences.filepaths.temporary_directory=r'%DEBUGLOGS%'; bpy.ops.wm.sysinfo(filepath=r'%DEBUGLOGS%\blender_system_info.txt')" > "%DEBUGLOGS%\blender_debug_output.txt" 2>&1 < %0
 explorer "%DEBUGLOGS%"

--- a/release/windows/batch/blender_debug_log.cmd
+++ b/release/windows/batch/blender_debug_log.cmd
@@ -1,6 +1,6 @@
 @echo off
-echo Starting blender with debug logging options, log files will be created
-echo in your temp folder, windows explorer will open after you close blender
+echo Starting bforartists with debug logging options, log files will be created
+echo in your temp folder, windows explorer will open after you close bforartists
 echo to help you find them.
 echo.
 echo If you report a bug on https://projects.blender.org you can attach these files
@@ -9,12 +9,12 @@ echo blender_debug_output.txt and blender_system_info.txt in your report.
 echo.
 pause
 echo.
-echo Starting blender and waiting for it to exit....
+echo Starting bforartists and waiting for it to exit....
 setlocal
 
 set PYTHONPATH=
-set DEBUGLOGS="%temp%\blender\debug_logs"
+set DEBUGLOGS="%temp%\bforartists\debug_logs"
 mkdir "%DEBUGLOGS%" > NUL 2>&1
 
-"%~dp0\blender" --debug --debug-cycles --python-expr "import bpy; bpy.context.preferences.filepaths.temporary_directory=r'%DEBUGLOGS%'; bpy.ops.wm.sysinfo(filepath=r'%DEBUGLOGS%\blender_system_info.txt')" > "%DEBUGLOGS%\blender_debug_output.txt" 2>&1 < %0
+"%~dp0\bforartists" --debug --debug-cycles --python-expr "import bpy; bpy.context.preferences.filepaths.temporary_directory=r'%DEBUGLOGS%'; bpy.ops.wm.sysinfo(filepath=r'%DEBUGLOGS%\blender_system_info.txt')" > "%DEBUGLOGS%\blender_debug_output.txt" 2>&1 < %0
 explorer "%DEBUGLOGS%"

--- a/release/windows/batch/blender_factory_startup.cmd
+++ b/release/windows/batch/blender_factory_startup.cmd
@@ -1,6 +1,6 @@
 @echo off
-echo Starting blender with factory settings, log files will be created
-echo in your temp folder, windows explorer will open after you close blender
+echo Starting bforartists with factory settings, log files will be created
+echo in your temp folder, windows explorer will open after you close bforartists
 echo to help you find them.
 echo.
 echo If you report a bug on https://projects.blender.org you can attach these files
@@ -9,12 +9,12 @@ echo blender_debug_output.txt and blender_system_info.txt in your report.
 echo.
 pause
 echo.
-echo Starting blender and waiting for it to exit....
+echo Starting bforartists and waiting for it to exit....
 setlocal
 
 set PYTHONPATH=
-set DEBUGLOGS="%temp%\blender\debug_logs"
+set DEBUGLOGS="%temp%\bforartists\debug_logs"
 mkdir "%DEBUGLOGS%" > NUL 2>&1
 
-"%~dp0\blender" --factory-startup --python-expr "import bpy; bpy.context.preferences.filepaths.temporary_directory=r'%DEBUGLOGS%'; bpy.ops.wm.sysinfo(filepath=r'%DEBUGLOGS%\blender_system_info.txt')" > "%DEBUGLOGS%\blender_debug_output.txt" 2>&1 < %0
+"%~dp0\bforartists" --factory-startup --python-expr "import bpy; bpy.context.preferences.filepaths.temporary_directory=r'%DEBUGLOGS%'; bpy.ops.wm.sysinfo(filepath=r'%DEBUGLOGS%\blender_system_info.txt')" > "%DEBUGLOGS%\blender_debug_output.txt" 2>&1 < %0
 explorer "%DEBUGLOGS%"

--- a/release/windows/batch/blender_oculus.cmd
+++ b/release/windows/batch/blender_oculus.cmd
@@ -3,7 +3,7 @@
 REM Helper setting hints to get the OpenXR preview support enabled for Oculus.
 REM Of course this is not meant as a permanent solution. Oculus will likely provide a better setup at some point.
 
-echo Starting Blender with Oculus OpenXR support. This assumes the Oculus runtime
+echo Starting Bforartists with Oculus OpenXR support. This assumes the Oculus runtime
 echo is installed in the default location. If this is not the case, please adjust
 echo the path inside oculus.json.
 echo.
@@ -11,4 +11,4 @@ echo Note that OpenXR support in Oculus is considered a preview. Use with care!
 echo.
 pause
 set XR_RUNTIME_JSON=%~dp0oculus.json
-"%~dp0\blender"
+"%~dp0\bforartists"


### PR DESCRIPTION
-- make the debug logs to use the bforartists executable instead of blender
-- updated echo messages to say bforartists instead of blender