### PR TITLE
fix for 4854-3d-view-header-overlays-toggle-ground-grid-only-toggles-ortho-grid

### DIFF
--- a/source/blender/draw/engines/overlay/overlay_next_grid.hh
+++ b/source/blender/draw/engines/overlay/overlay_next_grid.hh
@@ -219,25 +219,58 @@ class Grid : Overlay {
 
     /* If perspective view or non-axis aligned view. */
     if (rv3d->is_persp || rv3d->view == RV3D_VIEW_USER) {
-      if (show_axis_x) {
-        grid_flag_ |= PLANE_XY | SHOW_AXIS_X;
-      }
-      if (show_axis_y) {
-        grid_flag_ |= PLANE_XY | SHOW_AXIS_Y;
-      }
-      if (show_floor) {
-        grid_flag_ |= PLANE_XY | SHOW_GRID;
+      /*bfa - we show or hide the grid in all views with the ortho grid flag*/
+      if (show_ortho_grid) {
+        if (show_axis_x) {
+          grid_flag_ |= PLANE_XY | SHOW_AXIS_X;
+        }
+        if (show_axis_y) {
+          grid_flag_ |= PLANE_XY | SHOW_AXIS_Y;
+        }
+        if (show_floor) {
+          grid_flag_ |= PLANE_XY | SHOW_GRID;
+        }
       }
     }
     else {
-      if (show_ortho_grid && ELEM(rv3d->view, RV3D_VIEW_RIGHT, RV3D_VIEW_LEFT)) {
-        grid_flag_ = PLANE_YZ | SHOW_AXIS_Y | SHOW_AXIS_Z | SHOW_GRID | GRID_BACK;
+      if (show_ortho_grid && (rv3d->view == RV3D_VIEW_RIGHT || rv3d->view == RV3D_VIEW_LEFT)) {
+        grid_flag_ = PLANE_YZ;
+        if (show_floor) {
+          grid_flag_ |= SHOW_GRID | GRID_BACK;
+        }
+        /*bfa - toggles axis y/z in ortho left/right views*/
+        if (show_axis_y) {
+          grid_flag_ |= SHOW_AXIS_Y;
+        }
+        if (show_axis_z) {
+          grid_flag_ |= SHOW_AXIS_Z;
+        }
       }
-      else if (show_ortho_grid && ELEM(rv3d->view, RV3D_VIEW_TOP, RV3D_VIEW_BOTTOM)) {
-        grid_flag_ = PLANE_XY | SHOW_AXIS_X | SHOW_AXIS_Y | SHOW_GRID | GRID_BACK;
+      else if (show_ortho_grid && (rv3d->view == RV3D_VIEW_TOP || rv3d->view == RV3D_VIEW_BOTTOM)) {
+        grid_flag_ = PLANE_XY;
+        if (show_floor) {
+          grid_flag_ |= SHOW_GRID | GRID_BACK;
+        }
+        /*bfa - toggles axis x/y in ortho top/bottom views*/
+        if (show_axis_x) {
+          grid_flag_ |= SHOW_AXIS_X;
+        }
+        if (show_axis_y) {
+          grid_flag_ |= SHOW_AXIS_Y;
+        }
       }
-      else if (show_ortho_grid && ELEM(rv3d->view, RV3D_VIEW_FRONT, RV3D_VIEW_BACK)) {
-        grid_flag_ = PLANE_XZ | SHOW_AXIS_X | SHOW_AXIS_Z | SHOW_GRID | GRID_BACK;
+      else if (show_ortho_grid && (rv3d->view == RV3D_VIEW_FRONT || rv3d->view == RV3D_VIEW_BACK)) {
+        grid_flag_ = PLANE_XZ;
+        if (show_floor) {
+          grid_flag_ |= SHOW_GRID | GRID_BACK;
+        }
+        /*bfa - toggles axis x/z in ortho front/back views*/
+        if (show_axis_x) {
+          grid_flag_ |= SHOW_AXIS_X;
+        }
+        if (show_axis_z) {
+          grid_flag_ |= SHOW_AXIS_Z;
+        }
       }
     }
 
@@ -246,7 +279,8 @@ class Grid : Overlay {
     grid_axes_[2] = float((grid_flag_ & (PLANE_YZ | PLANE_XZ)) != 0);
 
     /* Z axis if needed */
-    if (((rv3d->view == RV3D_VIEW_USER) || (rv3d->persp != RV3D_ORTHO)) && show_axis_z) {
+    /*bfa - also hides the Axis Z*/
+    if (show_ortho_grid && ((rv3d->view == RV3D_VIEW_USER) || (rv3d->persp != RV3D_ORTHO)) && show_axis_z) {
       zpos_flag_ = SHOW_AXIS_Z;
     }
     else {


### PR DESCRIPTION
-- added back our changes to the grid/floor/axes that got removed with the new overlay next code merge.


https://github.com/user-attachments/assets/6d66cb88-22ae-4972-9a5f-d9c8779773e2

