### PR TITLE
fix for 4856-animation-tab-does-not-obey-tool-shelf-tabs-toggle-when-…

### DIFF
--- a/scripts/addons_core/bfa_power_user_tools/prefs.py
+++ b/scripts/addons_core/bfa_power_user_tools/prefs.py
@@ -37,9 +37,9 @@ class BFA_UI_preferences(bpy.types.AddonPreferences):
         row = layout.row()
         col = row.column(align=True)
         col.label(text="Animation:", icon="TIME")
+        layout.prop(wm.BFA_UI_addon_props, "BFA_PROP_toggle_animationpanel")
         layout.prop(wm.BFA_UI_addon_props, "BFA_PROP_toggle_insertframes")
         layout.prop(wm.BFA_UI_addon_props, "BFA_PROP_toggle_jumpframes")
-        layout.prop(wm.BFA_UI_addon_props, "BFA_PROP_toggle_animationpanel")
 
         row = layout.row()
         col = row.column(align=True)

--- a/scripts/addons_core/bfa_power_user_tools/toolshelf.py
+++ b/scripts/addons_core/bfa_power_user_tools/toolshelf.py
@@ -20,8 +20,10 @@ class BFA_PT_toolshelf_animation(bpy.types.Panel):
     @classmethod
     def poll(cls, context):
         wm = context.window_manager
+        view = context.space_data
+        overlay = view.overlay
         if context.object is not None and context.object.mode in {'OBJECT', 'POSE'}:
-            return wm.BFA_UI_addon_props.BFA_PROP_toggle_animationpanel
+            return overlay.show_toolshelf_tabs == True and wm.BFA_UI_addon_props.BFA_PROP_toggle_animationpanel
         else:
             return False
 
@@ -34,7 +36,7 @@ class BFA_PT_toolshelf_animation(bpy.types.Panel):
         if num_cols == 4:
             col = layout.column(align=True)
             col.scale_y = 2
-            
+
             wm = context.window_manager
             # Animation Operators
             if wm.BFA_UI_addon_props.BFA_PROP_toggle_animationpanel:
@@ -57,7 +59,7 @@ class BFA_PT_toolshelf_animation(bpy.types.Panel):
             #   col = layout.column(align=True)
             #   col.operator("operator.name", text="label", icon="DELETE")
             #   col.operator("operator.name", text="label", icon="DELETE")
-        
+
         # icon buttons
         else:
             col = layout.column(align=True)
@@ -153,8 +155,10 @@ class BFA_PT_toolshelf_frames(bpy.types.Panel):
     @classmethod
     def poll(cls, context):
         wm = context.window_manager
+        view = context.space_data
+        overlay = view.overlay
         if context.object is not None and context.object.mode in {'OBJECT', 'POSE', 'PAINT_GREASE_PENCIL', 'EDIT_GREASE_PENCIL', 'SCULPT_GREASE_PENCIL', 'VERTEX_GREASE_PENCIL'}:
-            return wm.BFA_UI_addon_props.BFA_PROP_toggle_insertframes
+            return overlay.show_toolshelf_tabs == True and wm.BFA_UI_addon_props.BFA_PROP_toggle_insertframes
         else:
             return False
 


### PR DESCRIPTION
-- fixed up the power user tools animation panel not using the toolshelf tab check.