### PR TITLE
fix 3 for 4863-bforartists-about-shows-wrong-version-number

### DIFF
--- a/scripts/startup/bl_operators/wm.py
+++ b/scripts/startup/bl_operators/wm.py
@@ -3458,7 +3458,7 @@ class WM_MT_splash_about(Menu):
 
         col = split.column(align=True)
         col.scale_y = 0.8
-        col.label(text=iface_("Version: {:s}").format(bpy.app.bfa_version_string), translate=False) # bfa - show our version
+        col.label(text=iface_("Version: {:s}").format(bpy.app.version_string), translate=False)
         col.separator(factor=2.5)
         col.label(text=iface_("Date: {:s} {:s}").format(
             bpy.app.build_commit_date.decode("utf-8", "replace"),

--- a/scripts/startup/bl_operators/wm.py
+++ b/scripts/startup/bl_operators/wm.py
@@ -3458,7 +3458,7 @@ class WM_MT_splash_about(Menu):
 
         col = split.column(align=True)
         col.scale_y = 0.8
-        col.label(text=iface_("Version: {:s}").format(bpy.app.version_string), translate=False)
+        col.label(text=iface_("Version: {:s}").format(bpy.app.bfa_version_string), translate=False) # bfa - show our version
         col.separator(factor=2.5)
         col.label(text=iface_("Date: {:s} {:s}").format(
             bpy.app.build_commit_date.decode("utf-8", "replace"),


### PR DESCRIPTION
show our version, instead of blender.

![image](https://github.com/user-attachments/assets/da7573e7-ed5b-404e-b7be-402d0d7b1829)

(3 commits on this, submodule got pushed accidently, so reverted and pushed again)