### PR TITLE
fix for 4894-node-groups---sidebar---boolean-default-float-left

### DIFF
--- a/source/blender/editors/space_node/drawnode.cc
+++ b/source/blender/editors/space_node/drawnode.cc
@@ -1545,7 +1545,11 @@ static void std_node_socket_interface_draw(ID *id,
       uiItemR(col, &ptr, "default_value", DEFAULT_FLAGS, IFACE_("Default"), ICON_NONE);
       break;
     }
-    case SOCK_BOOLEAN:
+    case SOCK_BOOLEAN: {
+      uiLayoutSetPropSep(col, false); /* bfa - use_property_split = False */
+      uiItemR(col, &ptr, "default_value", DEFAULT_FLAGS, IFACE_("Default"), 0);
+      break;
+    }
     case SOCK_ROTATION:
     case SOCK_RGBA:
     case SOCK_OBJECT:


### PR DESCRIPTION
--- We did have this set already, but must of got nuked during a merge.

![04-38-17-01-2025](https://github.com/user-attachments/assets/c597dc14-3e16-4b6a-9a99-82bc17422f06)
