### PR TITLE
fix 4929-text-editor---float-search-properties-left

### DIFF
--- a/scripts/startup/bl_ui/space_text.py
+++ b/scripts/startup/bl_ui/space_text.py
@@ -195,7 +195,7 @@ class TEXT_PT_find(Panel):
         row.operator("text.replace", text="Replace All").all = True
 
         # settings
-        layout.use_property_split = True
+        layout.use_property_split = False # bfa - align left
         col = layout.column(heading="Search")
         if not st.text:
             col.active = False


### PR DESCRIPTION
- align search options left

![image](https://github.com/user-attachments/assets/fbcb7d70-ac94-499d-b673-1d0603eb8785)
