### PR TITLE
fix for 4933-compositor---float-output-node-save-as-render-toggle

### DIFF
--- a/source/blender/nodes/composite/nodes/node_composite_file_output.cc
+++ b/source/blender/nodes/composite/nodes/node_composite_file_output.cc
@@ -339,7 +339,7 @@ static void node_composit_buts_file_output_ex(uiLayout *layout, bContext *C, Poi
 
   {
     uiLayout *column = uiLayoutColumn(layout, true);
-    uiLayoutSetPropSep(column, true);
+    uiLayoutSetPropSep(column, false); /* bfa - align left */
     uiLayoutSetPropDecorate(column, false);
     uiItemR(column, ptr, "save_as_render", UI_ITEM_R_SPLIT_EMPTY_NAME, std::nullopt, ICON_NONE);
   }


### PR DESCRIPTION
- aligned **Save as Render** to the left

![image](https://github.com/user-attachments/assets/bb406505-4e34-43dd-a74a-3fa98dd1d705)
