### PR TITLE
fix for 4945-need-to-remove-view3d_pt_shading_cavity-from-properties_…

### DIFF
--- a/scripts/startup/bl_ui/properties_render.py
+++ b/scripts/startup/bl_ui/properties_render.py
@@ -8,7 +8,7 @@ from bl_ui.space_view3d import (
     VIEW3D_PT_shading_lighting,
     VIEW3D_PT_shading_color,
     VIEW3D_PT_shading_options,
-    VIEW3D_PT_shading_cavity,
+    # bfa - moved VIEW3D_PT_shading_cavity back into VIEW3D_PT_shading_options.
 )
 from bl_ui.utils import PresetPanel
 
@@ -1381,8 +1381,7 @@ class RENDER_PT_opengl_options(RenderButtonsPanel, Panel):
         VIEW3D_PT_shading_options.draw(self, context)
 
         # Cavity properties.
-        VIEW3D_PT_shading_cavity.draw_header(self, context)
-        VIEW3D_PT_shading_cavity.draw(self, context)
+        # bfa - moved VIEW3D_PT_shading_cavity back into VIEW3D_PT_shading_options.
 
 
 class RENDER_PT_simplify(RenderButtonsPanel, Panel):


### PR DESCRIPTION
- removed VIEW3D_PT_shading_cavity class entries in the propery render tab (since we have the cavity directly in VIEW3D_PT_shading_options)