### PR TITLE
4888 sequencer   preview   duplicate operator now possible from the preview mode

### DIFF
--- a/scripts/presets/keyconfig/Bforartists-macOS.py
+++ b/scripts/presets/keyconfig/Bforartists-macOS.py
@@ -1,4 +1,4 @@
-keyconfig_version = (4, 4, 23)
+keyconfig_version = (4, 5, 3)
 keyconfig_data = \
 [("3D View",
   {"space_type": 'VIEW_3D', "region_type": 'WINDOW'},
@@ -8624,6 +8624,8 @@ keyconfig_data = \
       },
      ),
     ("sequencer.text_edit_mode_toggle", {"type": 'LEFTMOUSE', "value": 'DOUBLE_CLICK'}, None),
+    ("sequencer.delete", {"type": 'DEL', "value": 'PRESS'}, None),
+    ("sequencer.preview_duplicate_move", {"type": 'D', "value": 'PRESS', "shift": True}, None),
     ],
    },
   ),

--- a/scripts/presets/keyconfig/Bforartists.py
+++ b/scripts/presets/keyconfig/Bforartists.py
@@ -1,4 +1,4 @@
-keyconfig_version = (4, 4, 23)
+keyconfig_version = (4, 5, 3)
 keyconfig_data = \
 [("3D View",
   {"space_type": 'VIEW_3D', "region_type": 'WINDOW'},
@@ -7254,6 +7254,8 @@ keyconfig_data = \
       },
      ),
     ("sequencer.text_edit_mode_toggle", {"type": 'LEFTMOUSE', "value": 'DOUBLE_CLICK'}, None),
+    ("sequencer.delete", {"type": 'DEL', "value": 'PRESS'}, None),
+    ("sequencer.preview_duplicate_move", {"type": 'D', "value": 'PRESS', "shift": True}, None),
     ],
    },
   ),

--- a/scripts/startup/bl_ui/space_sequencer.py
+++ b/scripts/startup/bl_ui/space_sequencer.py
@@ -1592,7 +1592,7 @@ class SEQUENCER_MT_strip(Menu):
 
         if has_preview:
             layout.separator()
-            layout.operator("sequencer.preview_duplicate_move", text="Duplicate")
+            layout.operator("sequencer.preview_duplicate_move", text="Duplicate", icon = "DUPLICATE")
             layout.separator()
             # BFA - moved to top header level
             # if strip and strip.type == "TEXT":


### PR DESCRIPTION
The hotkeys are worth further investigation. I added them manually. It is not possible to add them from the menu. I will check Blender now, and make a bug report. I expect that Blender is not different.

EDIT, forget about it. Blender has the shortcuts also manually added. When you remove it then you cannot readd it back. Which is of course a bug. But i have reported such issues one time too often.