### PR TITLE
Default Library - Move Grease Pencil node group to own category

### DIFF
--- a/scripts/addons_core/bfa_default_library/Default Library/blender_assets.cats.txt
+++ b/scripts/addons_core/bfa_default_library/Default Library/blender_assets.cats.txt
@@ -38,8 +38,10 @@ fe2efd2a-b482-4543-b917-8222f6f1cabf:Collections/Lights:Collections-Lights
 2047f9d0-6fd3-4fb8-9227-8e7b125895bf:Collections/Static Meshes:Collections-Static Meshes
 7330e2d1-25b0-4fa6-8ab4-1f7f6d41d5e1:Collections/Static Meshes/Backgrounds:Collections-Static Meshes-Backgrounds
 4bb18048-62ea-4868-951c-31e08f6e9dd9:Collections/Static Meshes/Utility:Collections-Static Meshes-Utility
-c19d5a02-5874-4a4a-8e65-e1710c15a9c6:Curve:Curve
-fae56923-cd12-49fb-8396-1b87a93e60ba:Curve/Grease Pencil:Curve-Grease Pencil
+c19d5a02-5874-4a4a-8e65-e1710c15a9c6:Grease Pencil:Grease Pencil
+fae56923-cd12-49fb-8396-1b87a93e60ba:Grease Pencil/Operations:Grease Pencil-Operations
+998d2417-ab0f-4cfc-8aac-cdaad9c19f27:Grease Pencil/Read:Grease Pencil-Read
+062d724f-7875-4ce2-9263-515a511770f9:Grease Pencil/Write:Grease Pencil-Write
 6ff6c13c-f193-48d8-8e43-fcdf0a403640:Material:Material
 95c38dad-af82-4c27-a7d3-ed8670ffb1f1:Primitives:Primitives
 058c0130-cb9f-4251-8afa-2a0291534297:Shader Nodegroups:Shader Nodegroups


### PR DESCRIPTION
Addresses #5007

Grease pencil assets are moved into the `Grease Pencil` category. 
They are then placed into corresponding subcategories (`Read, Write, or Operations`)

| Read | Write | Operations |
| --- | --- | --- |
| ![image](https://github.com/user-attachments/assets/270a7d32-ce5c-43e7-8b6c-298aa643b53c) | ![image](https://github.com/user-attachments/assets/dd537ee0-53c0-4697-be30-408e09c268ec) | ![image](https://github.com/user-attachments/assets/f1dbfe24-c242-4d84-9edb-db304f62b3f4) |