### PR TITLE
Properties Editor - Render Tab - Grease Pencil - Clarify the SMAA cryptic labels and tooltips #5037

### DIFF
--- a/scripts/startup/bl_ui/properties_render.py
+++ b/scripts/startup/bl_ui/properties_render.py
@@ -1328,7 +1328,9 @@ class RENDER_PT_grease_pencil_viewport(RenderButtonsPanel, Panel):
         props = scene.grease_pencil_settings
 
         col = layout.column()
-        col.prop(props, "antialias_threshold", text="SMAA Threshold")
+        # BFA - Make clearer labels & descriptions for AA properties
+        col.label(text="Anti-Aliasing")
+        col.prop(props, "antialias_threshold", text="Edge Threshold")
 
 
 class RENDER_PT_grease_pencil_render(RenderButtonsPanel, Panel):
@@ -1350,8 +1352,10 @@ class RENDER_PT_grease_pencil_render(RenderButtonsPanel, Panel):
         props = scene.grease_pencil_settings
 
         col = layout.column()
-        col.prop(props, "antialias_threshold_render", text="SMAA Threshold")
-        col.prop(props, "aa_samples", text="SSAA Samples")
+        # BFA - Make clearer labels & descriptions for AA properties
+        col.label(text="Anti-Aliasing")
+        col.prop(props, "antialias_threshold_render", text="Edge Threshold")
+        col.prop(props, "aa_samples", text="Supersampling")
 
 
 class RENDER_PT_opengl_sampling(RenderButtonsPanel, Panel):

--- a/scripts/startup/bl_ui/properties_render.py
+++ b/scripts/startup/bl_ui/properties_render.py
@@ -1310,7 +1310,8 @@ class RENDER_PT_gpencil(RenderButtonsPanel, Panel):
 
 
 class RENDER_PT_grease_pencil_viewport(RenderButtonsPanel, Panel):
-    bl_label = "Viewport"
+    # BFA - Clarify that the properties under this are anti-aliasing related
+    bl_label = "Viewport Anti-Aliasing" 
     bl_options = {'DEFAULT_CLOSED'}
     bl_parent_id = "RENDER_PT_gpencil"
     COMPAT_ENGINES = {
@@ -1328,13 +1329,12 @@ class RENDER_PT_grease_pencil_viewport(RenderButtonsPanel, Panel):
         props = scene.grease_pencil_settings
 
         col = layout.column()
-        # BFA - Make clearer labels & descriptions for AA properties
-        col.label(text="Anti-Aliasing")
         col.prop(props, "antialias_threshold", text="Edge Threshold")
 
 
 class RENDER_PT_grease_pencil_render(RenderButtonsPanel, Panel):
-    bl_label = "Render"
+    # BFA - Clarify that the properties under this are anti-aliasing related
+    bl_label = "Render Anti-Aliasing"
     bl_options = {'DEFAULT_CLOSED'}
     bl_parent_id = "RENDER_PT_gpencil"
     COMPAT_ENGINES = {
@@ -1352,8 +1352,6 @@ class RENDER_PT_grease_pencil_render(RenderButtonsPanel, Panel):
         props = scene.grease_pencil_settings
 
         col = layout.column()
-        # BFA - Make clearer labels & descriptions for AA properties
-        col.label(text="Anti-Aliasing")
         col.prop(props, "antialias_threshold_render", text="Edge Threshold")
         col.prop(props, "aa_samples", text="Supersampling")
 

--- a/source/blender/makesrna/intern/rna_scene.cc
+++ b/source/blender/makesrna/intern/rna_scene.cc
@@ -8640,27 +8640,30 @@ static void rna_def_scene_gpencil(BlenderRNA *brna)
   RNA_def_property_float_sdna(prop, nullptr, "smaa_threshold");
   RNA_def_property_range(prop, 0.0f, FLT_MAX);
   RNA_def_property_ui_range(prop, 0.0f, 2.0f, 1, 3);
+  /* BFA - Make description of SMAA threshold in tooltip clearer */
   RNA_def_property_ui_text(prop,
-                           "SMAA Threshold Viewport",
-                           "Threshold for edge detection algorithm (higher values might over-blur "
-                           "some part of the image)");
+                           "SMAA Threshold (Viewport)",
+                           "Sensitivity for detecting edges to anti-alias. "
+                           "Lowering this value detects more edges at the cost of performance.");
   RNA_def_property_update(prop, NC_SCENE | ND_RENDER_OPTIONS, nullptr);
 
   prop = RNA_def_property(srna, "antialias_threshold_render", PROP_FLOAT, PROP_NONE);
   RNA_def_property_float_sdna(prop, nullptr, "smaa_threshold_render");
   RNA_def_property_range(prop, 0.0f, FLT_MAX);
   RNA_def_property_ui_range(prop, 0.0f, 2.0f, 1, 3);
+  /* BFA - Make description of SMAA threshold in tooltip clearer */
   RNA_def_property_ui_text(prop,
-                           "SMAA Threshold Render",
-                           "Threshold for edge detection algorithm (higher values might over-blur "
-                           "some part of the image). Only applies to final render");
+                           "SMAA Threshold (Render)",
+                           "Sensitivity for detecting edges to anti-alias. "
+                           "Lowering this value detects more edges at the cost of performance. (Only applies to final render)");
   RNA_def_property_update(prop, NC_SCENE | ND_RENDER_OPTIONS, nullptr);
 
   prop = RNA_def_property(srna, "aa_samples", PROP_INT, PROP_NONE);
+  /* BFA - Make description of SSAA in tooltip more succinct */
   RNA_def_property_ui_text(
       prop,
       "Anti-Aliasing Samples",
-      "Number of supersampling anti-aliasing samples per pixel for final render");
+      "Number of supersamples done per pixel in final render");
   RNA_def_property_range(prop, 1, INT_MAX);
   RNA_def_property_ui_range(prop, 1, 256, 1, 3);
   RNA_def_property_override_flag(prop, PROPOVERRIDE_OVERRIDABLE_LIBRARY);

--- a/source/blender/makesrna/intern/rna_scene.cc
+++ b/source/blender/makesrna/intern/rna_scene.cc
@@ -8663,7 +8663,7 @@ static void rna_def_scene_gpencil(BlenderRNA *brna)
   RNA_def_property_ui_text(
       prop,
       "Anti-Aliasing Samples",
-      "Number of supersamples done per pixel in final render");
+      "Number of anti-aliasing supersamples done per pixel in final render");
   RNA_def_property_range(prop, 1, INT_MAX);
   RNA_def_property_ui_range(prop, 1, 256, 1, 3);
   RNA_def_property_override_flag(prop, PROPOVERRIDE_OVERRIDABLE_LIBRARY);


### PR DESCRIPTION
- Added an `"Anti-Aliasing"` label on top of the AA properties, as it was too long to put in the property labels themselves, but too important in explaining the nature of the props that IMO it shouldn't be left out.
- Renamed `"SMAA Threshold"` to `"Edge Threshold"` & `"SSAA Samples"` to `"Supersampling"`
- Rephrased the tooltip descriptions.

## Panels
![image](https://github.com/user-attachments/assets/cc67cfbb-6ba4-44c0-9e60-c82eb2cd23ff)

## Tooltips
|||
| --- | --- |
| SMAA Threshold (Viewport) | ![image](https://github.com/user-attachments/assets/7e3e7f2c-4ba7-4314-b259-134c8d3d5070) |
| SMAA Threshold (Render) | ![image](https://github.com/user-attachments/assets/416a5896-20cd-4538-a262-3590a15b84a8) |
| SSAA Samples | ![image](https://github.com/user-attachments/assets/05d4134d-f266-4769-85c5-5bfb71c92a89) |