### PR TITLE
Fix: Preferences - Interface - Duplicated Border Width property

### DIFF
--- a/scripts/startup/bl_ui/space_userpref.py
+++ b/scripts/startup/bl_ui/space_userpref.py
@@ -308,7 +308,6 @@ class USERPREF_PT_interface_editors(InterfacePanel, CenterAlignMixIn, Panel):
         flow.use_property_split = False
         flow.prop(system, "use_region_overlap")
         flow.prop(view, "show_navigate_ui")
-        flow.prop(view, "border_width")
 
         flow.use_property_split = True
         flow.prop(view, "border_width")


### PR DESCRIPTION
Bit of a mistake in https://github.com/Bforartists/Bforartists/pull/5082 that I missed.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/5d0b2e63-e4c8-49b1-8548-164edd05d95c) | ![image](https://github.com/user-attachments/assets/efe61914-77b7-442b-bb5b-3ba32b2ea2c8) |

