### PR TITLE
Fix: 5124-blender-messing-with-our-repo-at-pull-request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,0 @@
-This repository is only used as a mirror. Blender development happens on projects.blender.org.
-
-To get started with contributing code, please see:
-https://developer.blender.org/docs/handbook/contributing/


### PR DESCRIPTION
> This repository is only used as a mirror. Blender development happens on projects.blender.org.
> 
> To get started with contributing code, please see:
> https://developer.blender.org/docs/handbook/contributing/

-- This PR will removed the above PR template code from blender
