### PR TITLE
Fix: 5107-spreadsheet---move-built-in-attributes-property-to-header-a…

### DIFF
--- a/scripts/startup/bl_ui/space_spreadsheet.py
+++ b/scripts/startup/bl_ui/space_spreadsheet.py
@@ -36,7 +36,7 @@ class SPREADSHEET_HT_header(bpy.types.Header):
         sub.active = self._selection_filter_available(space)
         sub.prop(space, "show_only_selected", text="")
         row.prop(space, "use_filter", toggle=True, icon='FILTER', icon_only=True)
-        row.prop(space, "show_internal_attributes", toggle=True, icon='INFO', icon_only=True) # bfa - moved from view menu, temp icon
+        row.prop(space, "show_internal_attributes", toggle=True, icon='NODE_ATTRIBUTE', icon_only=True) # bfa - moved from view menu, temp icon
 
     @staticmethod
     def _selection_filter_available(space):

--- a/scripts/startup/bl_ui/space_spreadsheet.py
+++ b/scripts/startup/bl_ui/space_spreadsheet.py
@@ -26,7 +26,6 @@ class SPREADSHEET_HT_header(bpy.types.Header):
         layout = self.layout
         space = context.space_data
 
-        layout.template_header()
         ALL_MT_editormenu_spreadsheet.draw_hidden(context, layout) # bfa - show hide the editormenu, editor suffix is needed.
 
         SPREADSHEET_MT_editor_menus.draw_collapsible(context, layout)
@@ -37,6 +36,7 @@ class SPREADSHEET_HT_header(bpy.types.Header):
         sub.active = self._selection_filter_available(space)
         sub.prop(space, "show_only_selected", text="")
         row.prop(space, "use_filter", toggle=True, icon='FILTER', icon_only=True)
+        row.prop(space, "show_internal_attributes", toggle=True, icon='INFO', icon_only=True) # bfa - moved from view menu, temp icon
 
     @staticmethod
     def _selection_filter_available(space):


### PR DESCRIPTION
-- removed double template header
-- added show internal attributes toggle to header

used info icon for now/temp if needs changing.

![image](https://github.com/user-attachments/assets/5f5cf53e-4221-48f3-83b2-5aad0a1b0500)

will update manual when merged