### PR TITLE
Fix #5148 Assets - Drag and drop confusion between asset browser and asset shelf

### DIFF
--- a/source/blender/editors/space_file/file_draw.cc
+++ b/source/blender/editors/space_file/file_draw.cc
@@ -383,6 +383,8 @@ static void file_but_enable_drag(uiBut *but,
            (import_method == ASSET_IMPORT_LINK ?
                 FILE_ASSET_IMPORT_INSTANCE_COLLECTIONS_ON_LINK :
                 FILE_ASSET_IMPORT_INSTANCE_COLLECTIONS_ON_APPEND)) != 0;
+      import_settings.drop_instances_to_origin = sfile->asset_params->import_flags & FILE_ASSET_IMPORT_DROP_COLLECTIONS_TO_ORIGIN; /* BFA */
+      import_settings.is_from_browser = true; /* BFA - asset shelf */
 
       UI_but_drag_set_asset(but, file->asset, import_settings, icon, file->preview_icon_id);
     }

--- a/source/blender/editors/space_view3d/view3d_dropboxes.cc
+++ b/source/blender/editors/space_view3d/view3d_dropboxes.cc
@@ -502,9 +502,7 @@ static void view3d_collection_drop_copy_external_asset(bContext *C, wmDrag *drag
   asset_drag->import_settings.use_instance_collections = false;
 
   /* start bfa asset shelf props*/
-  bool use_instance = asset_drag->import_settings.use_instance_collections;
-  bool use_override = false;
-  bool drop_instances_to_origin = asset_drag->import_settings.drop_instances_to_origin;
+  bool use_instance, use_override, drop_instances_to_origin;
 
   // use is_from_browser to differentiate between asset browser and asset shelf drag.
   if (!asset_drag->import_settings.is_from_browser) {
@@ -523,8 +521,8 @@ static void view3d_collection_drop_copy_external_asset(bContext *C, wmDrag *drag
       use_override = import_method_prop == ASSET_IMPORT_LINK_OVERRIDE;
     }
   } else {
-    asset_drag->import_settings.use_instance_collections = use_instance_collections;
-    asset_drag->import_settings.drop_instances_to_origin = drop_instances_to_origin;
+    use_instance = use_instance_collections;
+    drop_instances_to_origin = asset_drag->import_settings.drop_instances_to_origin;
     use_override = asset_drag->import_settings.method == ASSET_IMPORT_LINK_OVERRIDE;
   }
 

--- a/source/blender/windowmanager/intern/wm_dragdrop.cc
+++ b/source/blender/windowmanager/intern/wm_dragdrop.cc
@@ -893,7 +893,7 @@ void WM_drag_add_asset_list_item(wmDrag *drag,
     import_settings.method = ASSET_IMPORT_APPEND;
     import_settings.use_instance_collections = false;
     import_settings.drop_instances_to_origin = false; /* BFA */
-    import_settings.is_from_browser = false; /* BFA - asset shelf */
+    import_settings.is_from_browser = true; /* BFA - asset shelf */
 
     drag_asset->asset_data.external_info = WM_drag_create_asset_data(asset, import_settings);
   }


### PR DESCRIPTION
Initialize the asset browser settings to separate from the asset shelf
Fix #5148