### PR TITLE
Node Editor - "New Group" operator for adding empty nodegroups

### DIFF
--- a/scripts/startup/bl_ui/node_add_menu.py
+++ b/scripts/startup/bl_ui/node_add_menu.py
@@ -173,7 +173,7 @@ def add_closure_zone(layout, label):
 
 
 def add_empty_group(layout):
-    props = layout.operator("node.add_empty_group", text="New Group", text_ctxt=i18n_contexts.default)
+    props = layout.operator("node.add_empty_group", text="New Group", text_ctxt=i18n_contexts.default, icon='ADD') #BFA - added icon to Add Menu
     props.use_transform = True
     return props
 

--- a/scripts/startup/bl_ui/space_node_toolshelf.py
+++ b/scripts/startup/bl_ui/space_node_toolshelf.py
@@ -6,6 +6,8 @@ from bpy import context
 
 #Add tab, Node Group panel
 from nodeitems_builtins import node_tree_group_type
+from .node_add_menu import add_empty_group
+
 
 # Icon or text buttons in shader editor and compositor in the ADD panel
 class NODES_PT_shader_comp_textoricon_shader_add(bpy.types.Panel):
@@ -3517,6 +3519,10 @@ class NODES_PT_Input_node_group(bpy.types.Panel):
         layout = self.layout
 
         layout.label( text = "Add Node Group:")
+
+        col = layout.column()
+        col.scale_y = 1.5
+        add_empty_group(col)
 
         if context is None:
             return


### PR DESCRIPTION
- Added icon to operator in Add Menu
![image](https://github.com/user-attachments/assets/42dd4e33-ac0f-4457-a6e1-16d3f29703db)

- Added operator to the sidebar Toolshelf
![image](https://github.com/user-attachments/assets/4762046e-bc39-4556-82fe-d8f66393328d)
