### PR TITLE
Node Editor - Add Menu & Toolshelf - Distinguish nodegroup types with icons and grouping

### DIFF
--- a/scripts/startup/bl_ui/node_add_menu.py
+++ b/scripts/startup/bl_ui/node_add_menu.py
@@ -47,6 +47,7 @@ def add_node_type_with_outputs(context, layout, node_type, subnames, *, label=No
     return props
 
 
+# BFA - Dictionary for sorting order of the different node group icon types
 icon_sorting_order = {
     'NODETREE' : 0,
     'FAKE_USER_ON' : 1,
@@ -56,6 +57,7 @@ icon_sorting_order = {
 }
 
 
+# BFA - Function for determining appropriate icon for node group
 def node_group_icon(group):
     if group.library is not None:
         return 'LIBRARY_DATA_DIRECT'
@@ -68,10 +70,13 @@ def node_group_icon(group):
     else:
         return 'NODETREE'
 
+
+# BFA - Callback function to be used for sorting nodegroups by icon
 def icon_sorting_function(group):
     return icon_sorting_order[node_group_icon(group)]
 
 
+# BFA - Separated function from `draw_node_group_add_menu` so that both the add menu and toolshelf can use this
 def draw_node_groups(context, layout):
     space_node = context.space_data
     node_tree = space_node.edit_tree
@@ -88,6 +93,7 @@ def draw_node_groups(context, layout):
             (show_hidden or not group.name.startswith('.')))
     ]
 
+    # BFA - Group each node group by their type and apply the appropriate icon
     import itertools
     for icon, groups in itertools.groupby(sorted(groups, key=icon_sorting_function), key=node_group_icon):
         if groups:

--- a/scripts/startup/bl_ui/space_node_toolshelf.py
+++ b/scripts/startup/bl_ui/space_node_toolshelf.py
@@ -6,6 +6,8 @@ from bpy import context
 
 #Add tab, Node Group panel
 from nodeitems_builtins import node_tree_group_type
+from .node_add_menu import draw_node_groups
+
 
 # Icon or text buttons in shader editor and compositor in the ADD panel
 class NODES_PT_shader_comp_textoricon_shader_add(bpy.types.Panel):
@@ -3527,23 +3529,10 @@ class NODES_PT_Input_node_group(bpy.types.Panel):
         if not ntree:
             return
 
-        for group in context.blend_data.node_groups:
-            if group.bl_idname != ntree.bl_idname:
-                continue
-            # filter out recursive groups
-            if contains_group(group, ntree):
-                continue
-            # filter out hidden nodetrees
-            if group.name.startswith('.'):
-                continue
-
-            props = layout.operator("node.add_node", text=group.name, icon="NODETREE")
-            props.use_transform = True
-            props.type = node_tree_group_type[group.bl_idname]
-
-            ops = props.settings.add()
-            ops.name = "node_tree"
-            ops.value = "bpy.data.node_groups['{0}']".format(group.name)
+        col = layout.column(align=True)
+        col.scale_y = 1.5
+        draw_node_groups(context, col)
+        return
 
 
 #Relations tab, Layout Panel


### PR DESCRIPTION
Currently, a nodegroup can either be in these various states:
- Normal : No special behaviors.
- Fake User : Will not be deleted even if it has no users.
- Asset : Marked as asset to be that can be detected by the asset browser.
- Linked : Linked from an external blend file.
- Library Override : Similar to linked, but with overrides specific to the current file.

![image](https://github.com/user-attachments/assets/ce5cdbd0-107e-493c-b003-8c5ce71d8a55)

This patch groups each type of nodegroup together and assigns them their corresponding icons. These icons should match the icon being used in the node's group selector. (The one beside the group name).

The change is also applied to the toolshelf panel:
![image](https://github.com/user-attachments/assets/f7fdb494-84de-4460-83d7-3da5fddd7adc)