### PR TITLE
Node Editor - Add Menu - Relocate non-add operators in Group submenu #…

### DIFF
--- a/scripts/startup/bl_ui/node_add_menu.py
+++ b/scripts/startup/bl_ui/node_add_menu.py
@@ -119,15 +119,6 @@ def draw_node_group_add_menu(context, layout):
     node_tree = space_node.edit_tree
     all_node_groups = context.blend_data.node_groups
 
-    # BFA
-    layout.operator("node.group_make", icon = "NODE_MAKEGROUP")
-    layout.operator("node.group_insert", text = "Insert into Group ", icon = "NODE_GROUPINSERT")
-    layout.operator("node.group_ungroup", icon = "NODE_UNGROUP")
-
-    layout.separator()
-
-    layout.operator("node.group_edit", text = " Toggle Edit Group", icon = "NODE_EDITGROUP").exit = False
-
     if node_tree in all_node_groups.values():
         layout.separator()
         add_node_type(layout, "NodeGroupInput")

--- a/scripts/startup/bl_ui/space_node.py
+++ b/scripts/startup/bl_ui/space_node.py
@@ -676,6 +676,10 @@ class NODE_MT_node(Menu):
         props.keep_open = False
 
         layout.separator()
+        ## BFA - set to sub-menu
+        layout.menu("NODE_MT_node_group")
+
+        layout.separator()
 		## BFA - set to sub-menu
         layout.menu("NODE_MT_node_links")
 
@@ -695,7 +699,21 @@ class NODE_MT_node(Menu):
             layout.operator("node.render_changed", icon='RENDERLAYERS')
 
 
- # BFA - Menu
+# BFA - Menu
+class NODE_MT_node_group(Menu):
+    bl_label = "Group"
+
+    def draw(self, context):
+        layout = self.layout
+
+        layout.operator("node.group_make", icon = "NODE_MAKEGROUP")
+        layout.operator("node.group_insert", text = "Insert into Group ", icon = "NODE_GROUPINSERT")
+        layout.operator("node.group_ungroup", icon = "NODE_UNGROUP")
+        layout.separator()
+        layout.operator("node.group_edit", text = " Toggle Edit Group", icon = "NODE_EDITGROUP").exit = False
+
+
+# BFA - Menu
 class NODE_MT_node_links(Menu):
     bl_label = "Links"
 
@@ -1594,7 +1612,8 @@ classes = (
     NODE_MT_select_legacy,  # BFA - Menu
     NODE_MT_node_group_separate,  # BFA - Menu
     NODE_MT_node,
-    NODE_MT_node_links,  # BFA - Menu
+    NODE_MT_node_group, # BFA - Menu
+    NODE_MT_node_links, # BFA - Menu
     NODE_MT_node_color_context_menu,
     NODE_MT_context_menu_show_hide_menu,
     NODE_MT_context_menu_select_menu,

--- a/scripts/startup/bl_ui/space_node_tabs.py
+++ b/scripts/startup/bl_ui/space_node_tabs.py
@@ -259,7 +259,7 @@ class NODE_PT_node_tools(toolshelf_calculate, Panel):
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'TOOLS'
     bl_category = "Node"
-    bl_options = {'HIDE_BG', 'DEFAULT_CLOSED'}
+    bl_options = {'HIDE_BG'}
 
      # just show when the toolshelf tabs toggle in the view menu is on.
     @classmethod
@@ -319,11 +319,86 @@ class NODE_PT_node_tools(toolshelf_calculate, Panel):
                 col.operator("node.parent_set", text = "", icon = "PARENT_SET")
 
 
+class NODE_PT_group(toolshelf_calculate, Panel):
+    bl_label = "Group"
+    bl_space_type = 'NODE_EDITOR'
+    bl_region_type = 'TOOLS'
+    bl_category = "Node"
+    bl_options = {'HIDE_BG'}
+
+     # just show when the toolshelf tabs toggle in the view menu is on.
+    @classmethod
+    def poll(cls, context):
+        preferences = context.preferences
+        addon_prefs = preferences.addons["bforartists_toolbar_settings"].preferences
+
+        #view = context.space_data
+        #overlay = view.overlay
+        #return overlay.show_toolshelf_tabs == True and sima.mode == 'UV'
+        return addon_prefs.node_show_toolshelf_tabs
+
+    def draw(self, context):
+        layout = self.layout
+
+        column_count = self.ts_width(layout, context.region, scale_y= 1.75)
+
+        obj = context.object
+
+        #text buttons
+        if column_count == 4:
+
+            col = layout.column(align=True)
+            col.scale_y = 2
+
+            col.operator("node.group_make", text = " Make Group      ", icon = "NODE_MAKEGROUP")
+            col.operator("node.group_insert", text = " Insert into Group ", icon = "NODE_GROUPINSERT")
+            col.operator("node.group_ungroup", text = " Ungroup           ", icon = "NODE_UNGROUP")
+
+            col = layout.column(align=True)
+            col.operator("node.group_edit", text = " Toggle Edit Group", icon = "NODE_EDITGROUP").exit = False
+
+        # icon buttons
+        else:
+
+            col = layout.column(align=True)
+            col.scale_x = 2
+            col.scale_y = 2
+
+            if column_count == 3:
+
+                row = col.row(align=True)
+                row.operator("node.group_make", text="", icon="NODE_MAKEGROUP")
+                row.operator("node.group_insert", text="", icon="NODE_GROUPINSERT")
+                row.operator("node.group_ungroup", text="", icon="NODE_UNGROUP")
+
+                row = col.row(align=True)
+                row.operator("node.group_edit", text="", icon="NODE_EDITGROUP").exit = False
+
+
+            elif column_count == 2:
+
+                row = col.row(align=True)
+                row.operator("node.group_make", text="", icon="NODE_MAKEGROUP")
+                row.operator("node.group_insert", text="", icon="NODE_GROUPINSERT")
+
+                row = col.row(align=True)
+                row.operator("node.group_ungroup", text="", icon="NODE_UNGROUP")
+                row.operator("node.group_edit", text="", icon="NODE_EDITGROUP").exit = False
+
+            elif column_count == 1:
+
+                col.operator("node.group_make", text="", icon="NODE_MAKEGROUP")
+                col.operator("node.group_insert", text="", icon="NODE_GROUPINSERT")
+                col.operator("node.group_ungroup", text="", icon="NODE_UNGROUP")
+                col.operator("node.group_edit", text="", icon="NODE_EDITGROUP").exit = False
+
+
 classes = (
     NODE_PT_transform,
     NODE_PT_links,
     NODE_PT_separate,
     NODE_PT_node_tools,
+    NODE_PT_group,
 )
 
 if __name__ == "__main__":  # only for live edit.

--- a/scripts/startup/bl_ui/space_node_tabs.py
+++ b/scripts/startup/bl_ui/space_node_tabs.py
@@ -355,6 +355,7 @@ class NODE_PT_group(toolshelf_calculate, Panel):
             col.operator("node.group_ungroup", text = " Ungroup           ", icon = "NODE_UNGROUP")
 
             col = layout.column(align=True)
+            col.scale_y = 2
             col.operator("node.group_edit", text = " Toggle Edit Group", icon = "NODE_EDITGROUP").exit = False
 
         # icon buttons

--- a/scripts/startup/bl_ui/space_node_toolshelf.py
+++ b/scripts/startup/bl_ui/space_node_toolshelf.py
@@ -3440,17 +3440,6 @@ class NODES_PT_Relations_group(bpy.types.Panel):
             col = layout.column(align=True)
             col.scale_y = 1.5
 
-            col.operator("node.group_make", text = " Make Group      ", icon = "NODE_MAKEGROUP")
-            col.operator("node.group_insert", text = " Insert into Group ", icon = "NODE_GROUPINSERT")
-            col.operator("node.group_ungroup", text = " Ungroup           ", icon = "NODE_UNGROUP")
-
-            col = layout.column(align=True)
-            col.scale_y = 1.5
-            col.operator("node.group_edit", text = " Toggle Edit Group", icon = "NODE_EDITGROUP").exit = False
-
-            col = layout.column(align=True)
-            col.scale_y = 1.5
-
             space_node = context.space_data
             node_tree = space_node.edit_tree
             all_node_groups = context.blend_data.node_groups
@@ -3464,6 +3453,7 @@ class NODES_PT_Relations_group(bpy.types.Panel):
                 props.use_transform = True
                 props.type = "NodeGroupOutput"
 
+            add_empty_group(col)
 
         #### Icon Buttons
 
@@ -3472,12 +3462,6 @@ class NODES_PT_Relations_group(bpy.types.Panel):
             flow = layout.grid_flow(row_major=True, columns=0, even_columns=True, even_rows=True, align=True)
             flow.scale_x = 1.5
             flow.scale_y = 1.5
-
-            flow.operator("node.group_make", text = "", icon = "NODE_MAKEGROUP")
-            flow.operator("node.group_insert", text = "", icon = "NODE_GROUPINSERT")
-            flow.operator("node.group_ungroup", text = "", icon = "NODE_UNGROUP")
-
-            flow.operator("node.group_edit", text = "", icon = "NODE_EDITGROUP").exit = False
 
             space_node = context.space_data
             node_tree = space_node.edit_tree
@@ -3491,6 +3475,10 @@ class NODES_PT_Relations_group(bpy.types.Panel):
                 props = flow.operator("node.add_node", text = "", icon = "GROUPOUTPUT")
                 props.use_transform = True
                 props.type = "NodeGroupOutput"
+
+            # Add empty group without label
+            props = flow.operator("node.add_empty_group", text="", icon="ADD")
+            props.use_transform = True
 
 
 #Shader Editor - Relations tab, Node Group Panel
@@ -3506,7 +3494,7 @@ def contains_group(nodetree, group):
     return False
 
 class NODES_PT_Input_node_group(bpy.types.Panel):
-    bl_label = "Node Group"
+    bl_label = "Nodegroups"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
     bl_category = "Relations"
@@ -3517,12 +3505,6 @@ class NODES_PT_Input_node_group(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
-
-        layout.label( text = "Add Node Group:")
-
-        col = layout.column()
-        col.scale_y = 1.5
-        add_empty_group(col)
 
         if context is None:
             return

--- a/scripts/startup/bl_ui/space_toolsystem_common.py
+++ b/scripts/startup/bl_ui/space_toolsystem_common.py
@@ -653,10 +653,6 @@ class ToolSelectPanelHelper:
         )
         width_scale = region.width * view2d_scale / system.ui_scale
 
-        # BFA - WIP - fix the width snapping issue
-        #if bpy.context.space_data.show_toolshelf_tabs:
-        #    width_scale -= 40  # Adjust this value based on the actual width of the toolshelf tabs, as this will subtract the width if the tabs are "on"
-
         # BFA - change to 3 column        
         if width_scale > 160.0:
             show_text = True


### PR DESCRIPTION
…5170

Now exposed to the toolshelf and node header menu in their own sub-group in a consistent way.
Moved the add empty node group to the group panel in the add shelf.