### PR TITLE
Fix: Node Editor - Group Sockets -- Properties not aligned left

### DIFF
--- a/source/blender/editors/space_node/drawnode.cc
+++ b/source/blender/editors/space_node/drawnode.cc
@@ -1405,15 +1405,17 @@ static void std_node_socket_interface_draw(ID *id,
     case SOCK_VECTOR: {
       col->prop(&ptr, "subtype", DEFAULT_FLAGS, IFACE_("Subtype"), ICON_NONE);
       col->prop(&ptr, "dimensions", DEFAULT_FLAGS, IFACE_("Dimensions"), ICON_NONE);
+      col->use_property_split_set(false); /* bfa - use_property_split = False */
       col->prop(&ptr, "default_value", UI_ITEM_R_EXPAND, IFACE_("Default"), ICON_NONE);
+      col->separator(); /* bfa - Add slight spacing between these items */
       uiLayout *sub = &col->column(true);
       sub->prop(&ptr, "min_value", DEFAULT_FLAGS, IFACE_("Min"), ICON_NONE);
       sub->prop(&ptr, "max_value", DEFAULT_FLAGS, IFACE_("Max"), ICON_NONE);
       break;
     }
     case SOCK_STRING: {
-      col->use_property_split_set(false); /* bfa - use_property_split = False */
       col->prop(&ptr, "subtype", DEFAULT_FLAGS, IFACE_("Subtype"), ICON_NONE);
+      col->use_property_split_set(false); /* bfa - use_property_split = False */
       col->prop(&ptr, "default_value", DEFAULT_FLAGS, IFACE_("Default"), ICON_NONE);
       break;
     }
@@ -1434,6 +1436,7 @@ static void std_node_socket_interface_draw(ID *id,
     }
     case SOCK_MENU: {
       col->prop(&ptr, "default_value", DEFAULT_FLAGS, IFACE_("Default"), ICON_NONE);
+      col->use_property_split_set(false); /* bfa - use_property_split = False */
       col->prop(&ptr, "menu_expanded", DEFAULT_FLAGS, IFACE_("Expanded"), ICON_NONE);
       break;
     }
@@ -1462,6 +1465,7 @@ static void std_node_socket_interface_draw(ID *id,
   {
     uiLayout *sub = &col->column(false);
     sub->active_set(interface_socket->default_input == NODE_DEFAULT_INPUT_VALUE);
+    sub->use_property_split_set(false); /* bfa - use_property_split = False */
     sub->prop(&ptr, "hide_value", DEFAULT_FLAGS, std::nullopt, ICON_NONE);
   }
 


### PR DESCRIPTION
Addresses issue #5173 and other inconsistencies in the Group Socket UI.

|  | Before | After |
| --- | --- | --- |
| Menu |  | ![image](https://github.com/user-attachments/assets/a5e4aee7-b176-4061-9961-86a237387130) |
| Vector |  | ![image](https://github.com/user-attachments/assets/c5945315-e3f2-4b3a-8fe2-6e3f6737cfc5) |
| Others *(All sockets have Hide Value so this applies)* |  | ![Uploading image.png…]() |
