### PR TITLE
Node Editor - Group Sockets -- Improve Add Item dialog

### DIFF
--- a/scripts/startup/bl_operators/node.py
+++ b/scripts/startup/bl_operators/node.py
@@ -504,6 +504,46 @@ class NODE_OT_interface_item_new_output(
         name="Item Type", items=(("OUTPUT", "Output", ""),), default="OUTPUT"
     )
 
+# BFA - Create dedicated operator for adding panel checkbox
+class NODE_OT_interface_item_new_panel_toggle(Operator):
+    '''Add a new panel toggle to the currently selected panel'''
+    bl_idname = "node.interface_item_new_panel_toggle"
+    bl_label = "New Panel Checkbox"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        try:
+            snode = context.space_data
+            tree = snode.edit_tree
+            interface = tree.interface
+
+            active_item = interface.active
+
+            if active_item.item_type != 'PANEL':
+                cls.poll_message_set("Active item is not a panel")
+                return False
+            
+            if get_panel_toggle(active_item) is not None:
+                cls.poll_message_set("Panel already has a toggle")
+                return False
+            
+            return True
+        except AttributeError:
+            return False
+
+    def execute(self, context):
+        snode = context.space_data
+        tree = snode.edit_tree
+
+        interface = tree.interface
+        active_panel = interface.active
+
+        item = interface.new_socket(active_panel.name, socket_type='NodeSocketBool', in_out='INPUT')
+        item.is_panel_toggle = True
+        interface.move_to_parent(item, active_panel, 0)
+        return {'FINISHED'}
+
 
 class NODE_OT_interface_item_duplicate(NodeInterfaceOperator, Operator):
     """Add a copy of the active item to the interface"""
@@ -899,6 +939,7 @@ classes = (
     NODE_OT_interface_item_new_input,  # BFA separated add input operator with own description.
     NODE_OT_interface_item_new_output,  # BFA separated add output operator with own description.
     NODE_OT_interface_item_new_panel,  # BFA separated add panel operator with own description.
+    NODE_OT_interface_item_new_panel_toggle, # BFA - Create dedicated operator with separate poll function.
     NODE_OT_interface_item_duplicate,
     NODE_OT_interface_item_remove,
     NODE_OT_interface_item_make_panel_toggle,

--- a/scripts/startup/bl_operators/node.py
+++ b/scripts/startup/bl_operators/node.py
@@ -28,6 +28,32 @@ from bpy.app.translations import (
 )
 
 
+# BFA - Helper function to make socket type matching easier
+def compare_attributes(item, *_, **keywords):
+    for key, value in keywords.items():
+        if getattr(item, key, None) != value:
+            return False
+        
+    return True
+
+
+# BFA - Helper function to make panel toggle checking easier
+def is_panel_toggle(item):
+    return compare_attributes(item, in_out="INPUT", socket_type="NodeSocketBool", is_panel_toggle=True, )
+
+
+# BFA - Helper function to make panel toggle fetching easier
+def get_panel_toggle(panel):
+    try:
+        first_item = panel.interface_items[0]
+        if is_panel_toggle(first_item):
+            return first_item
+        else:
+            return None
+    except (AttributeError, IndexError):
+        return None
+
+    
 class NodeSetting(PropertyGroup):
     value: StringProperty(
         name="Value",

--- a/scripts/startup/bl_ui/space_node.py
+++ b/scripts/startup/bl_ui/space_node.py
@@ -1333,7 +1333,7 @@ class NODE_PT_node_tree_interface(Panel):
         ops_col = split.column(align=True)
         ops_col.alignment = 'RIGHT'
         #ops_col.operator_menu_enum("node.interface_item_new", "item_type", icon='ADD', text="") # bfa - keep as reminder. Blender might add more content!
-        ops_col.popover(panel="NODE_PT_node_tree_interface_new_input", text="")
+        ops_col.popover(panel="NODE_PT_node_tree_interface_new_input", text="", icon='ADD')
 
         ops_col.separator()
         ops_col.operator("node.interface_item_duplicate", text='', icon='DUPLICATE')

--- a/scripts/startup/bl_ui/space_node.py
+++ b/scripts/startup/bl_ui/space_node.py
@@ -1298,7 +1298,7 @@ class NODE_PT_node_tree_interface_new_input(Panel):
         layout.operator('node.interface_item_new_input', text='Input ', icon='GROUPINPUT').item_type='INPUT'
         layout.operator('node.interface_item_new_output', text='Output', icon='GROUPOUTPUT').item_type='OUTPUT'
         layout.operator('node.interface_item_new_panel', text='Panel', icon='MENU_PANEL').item_type='PANEL'
-        layout.operator('node.interface_item_make_panel_toggle', text='Panel Boolean', icon='CHECKBOX_DEHLT')
+        layout.operator('node.interface_item_new_panel_toggle', text='Panel Toggle', icon='CHECKBOX_HLT')
 
 
 class NODE_PT_node_tree_interface(Panel):

--- a/scripts/startup/bl_ui/space_node.py
+++ b/scripts/startup/bl_ui/space_node.py
@@ -1285,7 +1285,7 @@ class NODE_MT_node_tree_interface_context_menu(Menu):
 
 
 class NODE_PT_node_tree_interface_new_input(Panel):
-    '''Add a new Item to the interface list'''
+    '''Add a new item to the interface list'''
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'HEADER'
     bl_label = "New Item"
@@ -1293,7 +1293,7 @@ class NODE_PT_node_tree_interface_new_input(Panel):
 
     def draw(self, context):
         layout = self.layout
-        layout.label(text="Add new Item")
+        layout.label(text="Add New Item")
 
         layout.operator('node.interface_item_new_input', text='Input ', icon='GROUPINPUT').item_type='INPUT'
         layout.operator('node.interface_item_new_output', text='Output', icon='GROUPOUTPUT').item_type='OUTPUT'


### PR DESCRIPTION
Changes made:
- Use `ADD` icon for the popover button
- Create a dedicated "Add Panel Toggle" operator
    - Blender's implementation of having it be a variant of the general "Add Item" operator means that it shares the same poll function as other variants. So for conditions where the other variants are valid, but the panel toggle isn't, the user has to run the operator, have it check whether panel toggles are valid, then it cancels execution and pops a message indicating why it didn't execute.
    - ![image](https://github.com/user-attachments/assets/798d516c-c3bb-401f-b096-82a855db0259) ![image](https://github.com/user-attachments/assets/fc64d98b-cc2f-49b7-b3ea-61c3b91f4e63)
    - This is an anti-pattern, if the operator couldn't run, the button for it should not be clickable. So it makes sense to separate this into a standalone function with its own poll checking.
    - ![image](https://github.com/user-attachments/assets/7a0712cb-58c1-4ce2-836c-ee7f8ee2b61e)
- Added helper functions to simplify a bunch of panel toggle related stuff, this'll come in handy for other operators I'll implement later.
