### PR TITLE
Interface - Context Menu - Open Drivers Editor missing icon #5190

### DIFF
--- a/source/blender/editors/interface/interface_context_menu.cc
+++ b/source/blender/editors/interface/interface_context_menu.cc
@@ -777,7 +777,7 @@ bool ui_popup_context_menu_for_button(bContext *C, uiBut *but, const wmEvent *ev
 
       layout->op("SCREEN_OT_drivers_editor_show",
                  CTX_IFACE_(BLT_I18NCONTEXT_OPERATOR_DEFAULT, "Open Drivers Editor"),
-                 ICON_NONE);
+                 ICON_DRIVER); /*BFA*/
     }
 
     /* Keying Sets */


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/cea0e335-9d41-4be0-bb92-89b385ef8679) | ![image](https://github.com/user-attachments/assets/e086e6d4-e312-42f4-8b0f-3536455cf087) |

Another chunk of the code was using this as the icon for `"Open Drivers Editor"` so I just copied that.