### PR TITLE
Interface - Context Menu - Online Python Reference needs an icon #5189

### DIFF
--- a/source/blender/editors/interface/interface_context_menu.cc
+++ b/source/blender/editors/interface/interface_context_menu.cc
@@ -1243,7 +1243,7 @@ bool ui_popup_context_menu_for_button(bContext *C, uiBut *but, const wmEvent *ev
         ptr_props = layout->op(
             "WM_OT_doc_view",
             CTX_IFACE_(BLT_I18NCONTEXT_OPERATOR_DEFAULT, "Online Python Reference"),
-            ICON_NONE,
+            ICON_URL,
             WM_OP_EXEC_DEFAULT,/* bfa - turned off the link to the online manual*/
             UI_ITEM_NONE);
         RNA_string_set(&ptr_props, "doc_id", manual_id.value().c_str());


### PR DESCRIPTION
| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/96a5be4a-5ef9-48ad-9c1f-ff6e642961f5) | ![image](https://github.com/user-attachments/assets/20d3cebb-b2a9-4585-b3c0-1f745f8f62c5) |

Used the same icon that `"Online Manual"` uses.