### PR TITLE
User Interface - uiDefAutoButsRNA -- Draw Boolean properties aligned left by default

### DIFF
--- a/source/blender/editors/interface/interface_utils.cc
+++ b/source/blender/editors/interface/interface_utils.cc
@@ -403,6 +403,7 @@ eAutoPropButsReturn uiDefAutoButsRNA(uiLayout *layout,
           BLI_assert(label_align == UI_BUT_LABEL_ALIGN_SPLIT_COLUMN);
           col = &layout->column(true);
           /* Let uiLayout::prop() create the split layout. */
+          col->use_property_split_set(!is_boolean); /* BFA - align left if boolean prop */
           col->use_property_decorate_set(!is_boolean); /* bfa - align left if boolean prop */
         }
 


### PR DESCRIPTION
Updated the base function that the Redo Panel uses.

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/2eeed48a-3b9b-411a-8cb9-ce65ed73d10f) | ![image](https://github.com/user-attachments/assets/4825084f-9d98-45ef-9b81-a57744662640) |
| ![image](https://github.com/user-attachments/assets/94d98925-0630-45b3-94dd-ee20cb47c92b) | ![image](https://github.com/user-attachments/assets/5a70ac4d-9346-4f0c-9125-8784bba77c5e) |
| ![image](https://github.com/user-attachments/assets/dc2b07db-3286-4be7-a4f5-82624581b286) | ![image](https://github.com/user-attachments/assets/fb95b411-a900-4827-a40f-ba3c15cbeb0d) |

