### PR TITLE
Sequencer: Update 3D Sequencer & Story Pencil Sequence to Strip

### DIFF
--- a/scripts/addons_core/bfa_3Dsequencer/editorial/vse_io/ops.py
+++ b/scripts/addons_core/bfa_3Dsequencer/editorial/vse_io/ops.py
@@ -294,7 +294,7 @@ class EXPORT_OT_otio(bpy.types.Operator, ExportHelper):
     def track_kind_from_strip(strip: bpy.types.Strip) -> otio.schema.TrackKind:
         """Return otio track kind based on strip type."""
         match type(strip):
-            case bpy.types.SoundSequence:
+            case bpy.types.SoundStrip:
                 return otio.schema.TrackKind.Audio
             case _:
                 return otio.schema.TrackKind.Video
@@ -379,13 +379,13 @@ class EXPORT_OT_otio(bpy.types.Operator, ExportHelper):
 
         # Retrieve filepath based on strip type.
         match type(strip):
-            case bpy.types.SoundSequence:
+            case bpy.types.SoundStrip:
                 media_filepath = strip.sound.filepath
-            case bpy.types.ImageSequence:
+            case bpy.types.ImageStrip:
                 media_filepath = os.path.join(
                     strip.directory, strip.elements[0].filename
                 )
-            case bpy.types.MovieSequence:
+            case bpy.types.MovieStrip:
                 media_filepath = strip.filepath
                 media_fps = strip.fps or timeline_fps
             case _:

--- a/scripts/addons_core/bfa_3Dsequencer/render/ops.py
+++ b/scripts/addons_core/bfa_3Dsequencer/render/ops.py
@@ -48,7 +48,7 @@ class SEQUENCER_OT_batch_render(bpy.types.Operator):
         self.active_task: Optional[BaseTask] = None
 
         self.output_channel_offset: int = 0
-        self.output_sound_strips: list[bpy.types.SoundSequence] = []
+        self.output_sound_strips: list[bpy.types.SoundStrip] = []
 
         self.cancelled: bool = False
 
@@ -88,7 +88,7 @@ class SEQUENCER_OT_batch_render(bpy.types.Operator):
         seqs = [
             seq
             for seq in self.scene.sequence_editor.sequences
-            if isinstance(seq, bpy.types.Strip)
+            if isinstance(seq, bpy.types.SceneStrip)
             and (seq.select or not self.render_options.selection_only)
         ]
 
@@ -105,7 +105,7 @@ class SEQUENCER_OT_batch_render(bpy.types.Operator):
             sound_strips = [
                 seq
                 for seq in self.scene.sequence_editor.sequences
-                if isinstance(seq, bpy.types.SoundSequence)
+                if isinstance(seq, bpy.types.SoundStrip)
                 and (seq.select or not self.render_options.selection_only)
             ]
             self.output_sound_strips = sorted(

--- a/scripts/addons_core/bfa_3Dsequencer/render/tasks.py
+++ b/scripts/addons_core/bfa_3Dsequencer/render/tasks.py
@@ -139,7 +139,7 @@ StripRenderTask callback:
  - returns:
     - path to the new media filepath
 """
-StripRenderTaskCallback = Callable[[bpy.types.Strip, str], str]
+StripRenderTaskCallback = Callable[[bpy.types.SceneStrip, str], str]
 
 
 @dataclass
@@ -147,7 +147,7 @@ class StripRenderTask(BaseRenderTask):
     """Strip render task."""
 
     # The strip to render.
-    strip: Optional[bpy.types.Strip] = None
+    strip: Optional[bpy.types.SceneStrip] = None
     # Viewport area.
     viewport_area: Optional[bpy.types.Area] = None
     # Window containing the viewport area.
@@ -285,7 +285,7 @@ class StripRenderTask(BaseRenderTask):
 
     def create_output_media_strip(
         self,
-        scene_strip: bpy.types.Strip,
+        scene_strip: bpy.types.SceneStrip,
         scene: bpy.types.Scene,
         media_type: str,
         frames_handles: int,
@@ -299,7 +299,7 @@ class StripRenderTask(BaseRenderTask):
         sed = scene.sequence_editor
 
         # List created strips and corresponding source frame start/end in scene
-        strips: list[tuple[bpy.types.Strip, int, int]] = []
+        strips: list[tuple[bpy.types.SceneStrip, int, int]] = []
 
         if media_type == "IMAGES":
             for idx in range(scene_strip.frame_final_duration):
@@ -358,7 +358,7 @@ class StripRenderTask(BaseRenderTask):
 class CopySoundStripsTask(BaseTask):
     src_scene: Optional[bpy.types.Scene] = None
     dst_scene: Optional[bpy.types.Scene] = None
-    sound_strips: list[bpy.types.SoundSequence] = field(default_factory=list)
+    sound_strips: list[bpy.types.SoundStrip] = field(default_factory=list)
 
     def run(self, context: bpy.types.Context, render_options: BatchRenderOptions):
         self.status = TaskStatus.FINISHED
@@ -454,7 +454,7 @@ class FitResolutionToContentTask(BaseTask):
         img_seqs = [
             s
             for s in self.scene.sequence_editor.sequences
-            if isinstance(s, (bpy.types.MovieSequence, bpy.types.ImageSequence))
+            if isinstance(s, (bpy.types.MovieStrip, bpy.types.ImageStrip))
         ]
 
         if not img_seqs:
@@ -496,7 +496,7 @@ class SequenceRenderTask(BaseRenderTask):
         sequences = [
             s
             for s in self.scene.sequence_editor.sequences
-            if isinstance(s, (bpy.types.MovieSequence, bpy.types.ImageSequence))
+            if isinstance(s, (bpy.types.MovieStrip, bpy.types.ImageStrip))
         ]
 
         self.scene.frame_start = min(s.frame_final_start for s in sequences)

--- a/scripts/addons_core/bfa_3Dsequencer/scene/core.py
+++ b/scripts/addons_core/bfa_3Dsequencer/scene/core.py
@@ -484,7 +484,7 @@ def reload_strip(strip: bpy.types.Strip):
             strip.select_right_handle = right
 
 
-def adapt_scene_range(strip: bpy.types.Strip):
+def adapt_scene_range(strip: bpy.types.SceneStrip):
     """Ensure `strip`'s internel range is fully contained in the scene its using."""
     # Update internal scene's end frame if exceeding the original one
     new_frame_end = remap_frame_value(strip.frame_final_end - 1, strip)
@@ -496,7 +496,7 @@ def adapt_scene_range(strip: bpy.types.Strip):
 
 
 def adjust_shot_duration(
-    strip: bpy.types.Strip,
+    strip: bpy.types.SceneStrip,
     frame_offset: int,
     from_frame_start: bool = False,
 ) -> bool:
@@ -595,7 +595,7 @@ def adjust_shot_duration(
 
 
 def slip_shot_content(
-    strip: bpy.types.Strip, frame_offset: int, clamp_start: bool = False
+    strip: bpy.types.SceneStrip, frame_offset: int, clamp_start: bool = False
 ):
     """
     Slip `strip` content by `frame_offset`.

--- a/scripts/addons_core/bfa_3Dsequencer/scene/naming.py
+++ b/scripts/addons_core/bfa_3Dsequencer/scene/naming.py
@@ -213,7 +213,7 @@ class ShotNaming:
 
     def get_all_shot_strips(
         self, sed: bpy.types.SequenceEditor
-    ) -> list[bpy.types.Strip]:
+    ) -> list[bpy.types.SceneStrip]:
         """
         Get all scene strips in the given sequence editor matching the scene naming
         convention.
@@ -224,7 +224,7 @@ class ShotNaming:
         return [
             s
             for s in sed.sequences
-            if isinstance(s, bpy.types.Strip) and self.match_name(s.name)
+            if isinstance(s, bpy.types.SceneStrip) and self.match_name(s.name)
         ]
 
     def next_shot_name_from_sequences(

--- a/scripts/addons_core/bfa_3Dsequencer/scene/ops.py
+++ b/scripts/addons_core/bfa_3Dsequencer/scene/ops.py
@@ -39,7 +39,7 @@ def get_last_used_frame(
     scene_sequences = [
         s
         for s in sequences
-        if isinstance(s, bpy.types.Strip) and s.scene == scene
+        if isinstance(s, bpy.types.SceneStrip) and s.scene == scene
     ]
 
     if not scene_sequences:
@@ -50,12 +50,12 @@ def get_last_used_frame(
 
 def get_selected_scene_sequences(
     sequences: list[bpy.types.Strip],
-) -> list[bpy.types.Strip]:
+) -> list[bpy.types.SceneStrip]:
     """
     :param sequences: The sequences to consider.
     :return: The list of selected scene sequence strips.
     """
-    return [s for s in sequences if isinstance(s, bpy.types.Strip) and s.select]
+    return [s for s in sequences if isinstance(s, bpy.types.SceneStrip) and s.select]
 
 
 def ensure_sequencer_frame_visible(context: bpy.types.Context, frame: int):
@@ -268,10 +268,10 @@ class SEQUENCER_OT_shot_duplicate(bpy.types.Operator):
     @staticmethod
     def duplicate_shot(
         context: bpy.types.Context,
-        strip: bpy.types.Strip,
+        strip: bpy.types.SceneStrip,
         name: str,
         duplicate_scene: bool,
-    ) -> bpy.types.Strip:
+    ) -> bpy.types.SceneStrip:
         sed = strip.id_data.sequence_editor
         if duplicate_scene:
             shot_scene = duplicate_scene(context, strip.scene, name)
@@ -446,12 +446,12 @@ class SEQUENCER_OT_shot_timing_adjust(bpy.types.Operator):
     @staticmethod
     def get_active_strip(
         context: bpy.types.Context,
-    ) -> Optional[bpy.types.Strip]:
+    ) -> Optional[bpy.types.SceneStrip]:
         if context.area.type == "DOPESHEET_EDITOR":
             strip = get_sync_master_strip(use_cache=True)[0]
             return strip if strip and strip.scene == context.window.scene else None
         elif context.scene.sequence_editor and isinstance(
-            context.scene.sequence_editor.active_strip, bpy.types.Strip
+            context.scene.sequence_editor.active_strip, bpy.types.SceneStrip
         ):
             return context.scene.sequence_editor.active_strip
 
@@ -598,11 +598,11 @@ class SEQUENCER_OT_shot_rename(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         return context.scene.sequence_editor and isinstance(
-            cls.active_shot(context), bpy.types.Strip
+            cls.active_shot(context), bpy.types.SceneStrip
         )
 
     @staticmethod
-    def active_shot(context) -> bpy.types.Strip:
+    def active_shot(context) -> bpy.types.SceneStrip:
         return context.scene.sequence_editor.active_strip
 
     def invoke(self, context: bpy.types.Context, event: bpy.types.Event):
@@ -733,7 +733,7 @@ class SEQUENCER_OT_shot_chronological_numbering(bpy.types.Operator):
         scene_strips = [
             strip
             for strip in context.scene.sequence_editor.sequences
-            if isinstance(strip, bpy.types.Strip)
+            if isinstance(strip, bpy.types.SceneStrip)
         ]
 
         if not scene_strips:
@@ -742,7 +742,7 @@ class SEQUENCER_OT_shot_chronological_numbering(bpy.types.Operator):
         tmp_suffix = ".tmp.rename"
         current_name = ""
         scenes_to_rename = set()
-        items_to_rename: dict[bpy.types.Strip, tuple[str, bool]] = dict()
+        items_to_rename: dict[bpy.types.SceneStrip, tuple[str, bool]] = dict()
 
         # Go through the shots chronologically (sorted by the start frame)
         sorted_scene_strips = sorted(scene_strips, key=lambda x: x.frame_final_start)

--- a/scripts/addons_core/bfa_3Dsequencer/sequence/ops.py
+++ b/scripts/addons_core/bfa_3Dsequencer/sequence/ops.py
@@ -55,7 +55,7 @@ class DOPESHEET_OT_sequence_navigate(bpy.types.Operator):
         strips = [
             s
             for s in master_scene.sequence_editor.sequences
-            if isinstance(s, bpy.types.Strip) and s.scene == bpy.context.scene
+            if isinstance(s, bpy.types.SceneStrip) and s.scene == bpy.context.scene
         ]
 
         candidates = [

--- a/scripts/addons_core/bfa_3Dsequencer/sequence/overlay.py
+++ b/scripts/addons_core/bfa_3Dsequencer/sequence/overlay.py
@@ -55,7 +55,7 @@ def shot_baseline_y_pos(context):
 def draw_shot_strip(
     region: bpy.types.Region,
     drawer: OverlayDrawer,
-    strip: bpy.types.Strip,
+    strip: bpy.types.SceneStrip,
     active: bool = False,
 ):
     """
@@ -144,7 +144,7 @@ def draw_sequence_overlay_cb(drawer: OverlayDrawer):
     scene_strips = [
         s
         for s in sync_settings.master_scene.sequence_editor.sequences
-        if isinstance(s, bpy.types.Strip)
+        if isinstance(s, bpy.types.SceneStrip)
         and s.scene == context.scene
         and s != master_strip
     ]

--- a/scripts/addons_core/bfa_3Dsequencer/sequence/ui.py
+++ b/scripts/addons_core/bfa_3Dsequencer/sequence/ui.py
@@ -101,7 +101,7 @@ class SEQUENCE_UL_shot(bpy.types.UIList):
 
         # Keep only scene strips.
         flt_flags = [
-            self.bitflag_filter_item if isinstance(obj, bpy.types.Strip) else 0
+            self.bitflag_filter_item if isinstance(obj, bpy.types.SceneStrip) else 0
             for obj in objects
         ]
         flt_neworder = []

--- a/scripts/addons_core/bfa_3Dsequencer/shared_collections/core.py
+++ b/scripts/addons_core/bfa_3Dsequencer/shared_collections/core.py
@@ -165,7 +165,7 @@ def get_scene_users(collection: bpy.types.Collection) -> list[bpy.types.Scene]:
 
 def get_scene_sequence_users(
     collection: bpy.types.Collection, sed: bpy.types.SequenceEditor
-) -> list[bpy.types.Strip]:
+) -> list[bpy.types.SceneStrip]:
     """Get all scene sequence strips with scenes that uses `collection`.
 
     :param collection: The shared collection.
@@ -175,7 +175,7 @@ def get_scene_sequence_users(
     return [
         s
         for s in sed.sequences
-        if isinstance(s, bpy.types.Strip) and s.scene in scene_users
+        if isinstance(s, bpy.types.SceneStrip) and s.scene in scene_users
     ]
 
 

--- a/scripts/addons_core/bfa_3Dsequencer/shared_collections/ops.py
+++ b/scripts/addons_core/bfa_3Dsequencer/shared_collections/ops.py
@@ -29,7 +29,7 @@ def get_scenes_from_selected_sequences(
     return [
         s.scene
         for s in sed.sequences
-        if isinstance(s, bpy.types.Strip) and s.select and s.scene
+        if isinstance(s, bpy.types.SceneStrip) and s.select and s.scene
     ]
 
 

--- a/scripts/addons_core/bfa_3Dsequencer/sync/core.py
+++ b/scripts/addons_core/bfa_3Dsequencer/sync/core.py
@@ -201,7 +201,7 @@ def get_scene_strip_at_frame(
     frame: int,
     sequence_editor: bpy.types.SequenceEditor,
     skip_muted: bool = True,
-) -> tuple[Union[bpy.types.Strip, None], int]:
+) -> tuple[Union[bpy.types.SceneStrip, None], int]:
     """
     Get the scene strip at `frame` in `sequence_editor`'s strips with the highest
     channel number.
@@ -220,15 +220,15 @@ def get_scene_strip_at_frame(
         muted_channels = [idx for idx, channel in enumerate(channels) if channel.mute]
         strips = [strip for strip in strips if not strip.channel in muted_channels]
 
-    strips = get_strips_at_frame(frame, strips, bpy.types.Strip, skip_muted)
+    strips = get_strips_at_frame(frame, strips, bpy.types.SceneStrip, skip_muted)
 
     if not strips:
         return None, frame
     # Sort strips by channel
     strip = sorted(strips, key=lambda x: x.channel)[-1]
 
-    # Help type checking: strip can only be a SceneSequence here
-    assert isinstance(strip, bpy.types.Strip)
+    # Help type checking: strip can only be a SceneStrip here
+    assert isinstance(strip, bpy.types.SceneStrip)
 
     # Only consider scene strips with a valid scene
     if not strip.scene:
@@ -607,7 +607,7 @@ def on_load_post(*args):
         ):
             seq_editor = area.spaces.active.scene_override.sequence_editor
             if seq_editor and any(
-                isinstance(s, bpy.types.Strip) for s in seq_editor.sequences
+                isinstance(s, bpy.types.SceneStrip) for s in seq_editor.sequences
             ):
                 sync_settings.master_scene = area.spaces.active.scene_override
                 sync_settings.enabled = True

--- a/scripts/addons_core/bfa_default_addons/Default_Addons/storypencil/synchro.py
+++ b/scripts/addons_core/bfa_default_addons/Default_Addons/storypencil/synchro.py
@@ -11,10 +11,10 @@ from bpy.app.handlers import persistent
 
 from bpy.types import (
     Context,
-    MetaSequence,
+    MetaStrip,
     Operator,
     PropertyGroup,
-    SceneSequence,
+    SceneStrip,
     Window,
     WindowManager,
 )
@@ -307,7 +307,7 @@ def get_not_main_window(wm: WindowManager) -> Window:
     return None
 
 
-def get_main_strip(wm: WindowManager) -> SceneSequence:
+def get_main_strip(wm: WindowManager) -> SceneStrip:
     """Get Scene Strip at current time in Main window
 
     :param wm: the WindowManager instance
@@ -391,10 +391,10 @@ def get_sequence_at_frame(
 
     # consider higher strip in stack
     strip = sorted(strips, key=lambda x: x.channel)[-1]
-    # go deeper when current strip is a MetaSequence
-    if isinstance(strip, MetaSequence):
+    # go deeper when current strip is a MetaStrip
+    if isinstance(strip, MetaStrip):
         return get_sequence_at_frame(frame, strip.sequences, skip_muted)
-    if isinstance(strip, SceneSequence):
+    if isinstance(strip, SceneStrip):
         # apply time offset to get in sequence's referential
         frame = frame - strip.frame_start + strip.scene.frame_start
         # enter scene's sequencer if used as input
@@ -420,7 +420,7 @@ def set_scene_frame(scene, frame, force_update_main=False):
                 bpy.context, bpy.context.window_manager.storypencil_settings.main_window_id)
 
 
-def setup_window_from_scene_strip(window: Window, strip: SceneSequence):
+def setup_window_from_scene_strip(window: Window, strip: SceneStrip):
     """Change the Scene and camera of `window` based on `strip`.
 
     :param window: [description]
@@ -487,7 +487,7 @@ def update_sync(context: Context, win_id=None):
             sequences=sequences
         )
         # only do bidirectional sync if secondary window matches the strip at current time in main
-        if not isinstance(strip, SceneSequence) or strip.scene != context.scene:
+        if not isinstance(strip, SceneStrip) or strip.scene != context.scene:
             return
 
         # calculate offset
@@ -505,7 +505,7 @@ def update_sync(context: Context, win_id=None):
                 new_main_frame,
                 main_scene.sequence_editor.sequences,
             )
-            update_main_time = isinstance(new_strip, SceneSequence)
+            update_main_time = isinstance(new_strip, SceneStrip)
         if update_main_time:
             # update main time change in the next event loop + force the sync system update
             # because Blender won't trigger a frame_changed event to avoid infinite recursion
@@ -534,7 +534,7 @@ def update_sync(context: Context, win_id=None):
     seq, frame = get_sequence_at_frame(main_scene.frame_current, sequences)
 
     # return if no sequence at current time or not a scene strip
-    if not isinstance(seq, SceneSequence) or not seq.scene:
+    if not isinstance(seq, SceneStrip) or not seq.scene:
         wm.storypencil_settings.main_strip_name = ""
         return
 

--- a/scripts/addons_core/bfa_default_addons/Default_Extensions/storypencil_storyboard_tools/synchro.py
+++ b/scripts/addons_core/bfa_default_addons/Default_Extensions/storypencil_storyboard_tools/synchro.py
@@ -11,10 +11,10 @@ from bpy.app.handlers import persistent
 
 from bpy.types import (
     Context,
-    MetaSequence,
+    MetaStrip,
     Operator,
     PropertyGroup,
-    SceneSequence,
+    SceneStrip,
     Window,
     WindowManager,
 )
@@ -307,7 +307,7 @@ def get_not_main_window(wm: WindowManager) -> Window:
     return None
 
 
-def get_main_strip(wm: WindowManager) -> SceneSequence:
+def get_main_strip(wm: WindowManager) -> SceneStrip:
     """Get Scene Strip at current time in Main window
 
     :param wm: the WindowManager instance
@@ -391,10 +391,10 @@ def get_sequence_at_frame(
 
     # consider higher strip in stack
     strip = sorted(strips, key=lambda x: x.channel)[-1]
-    # go deeper when current strip is a MetaSequence
-    if isinstance(strip, MetaSequence):
+    # go deeper when current strip is a MetaStrip
+    if isinstance(strip, MetaStrip):
         return get_sequence_at_frame(frame, strip.sequences, skip_muted)
-    if isinstance(strip, SceneSequence):
+    if isinstance(strip, SceneStrip):
         # apply time offset to get in sequence's referential
         frame = frame - strip.frame_start + strip.scene.frame_start
         # enter scene's sequencer if used as input
@@ -420,7 +420,7 @@ def set_scene_frame(scene, frame, force_update_main=False):
                 bpy.context, bpy.context.window_manager.storypencil_settings.main_window_id)
 
 
-def setup_window_from_scene_strip(window: Window, strip: SceneSequence):
+def setup_window_from_scene_strip(window: Window, strip: SceneStrip):
     """Change the Scene and camera of `window` based on `strip`.
 
     :param window: [description]
@@ -487,7 +487,7 @@ def update_sync(context: Context, win_id=None):
             sequences=sequences
         )
         # only do bidirectional sync if secondary window matches the strip at current time in main
-        if not isinstance(strip, SceneSequence) or strip.scene != context.scene:
+        if not isinstance(strip, SceneStrip) or strip.scene != context.scene:
             return
 
         # calculate offset
@@ -505,7 +505,7 @@ def update_sync(context: Context, win_id=None):
                 new_main_frame,
                 main_scene.sequence_editor.sequences,
             )
-            update_main_time = isinstance(new_strip, SceneSequence)
+            update_main_time = isinstance(new_strip, SceneStrip)
         if update_main_time:
             # update main time change in the next event loop + force the sync system update
             # because Blender won't trigger a frame_changed event to avoid infinite recursion
@@ -534,7 +534,7 @@ def update_sync(context: Context, win_id=None):
     seq, frame = get_sequence_at_frame(main_scene.frame_current, sequences)
 
     # return if no sequence at current time or not a scene strip
-    if not isinstance(seq, SceneSequence) or not seq.scene:
+    if not isinstance(seq, SceneStrip) or not seq.scene:
         wm.storypencil_settings.main_strip_name = ""
         return
 


### PR DESCRIPTION
See: https://developer.blender.org/docs/release_notes/4.4/python_api/#breaking_1
This resolved #4985
`ImageSequence` -> `ImageStrip`
`MetaSequence` -> `MetaStrip`
`MovieSequence` -> `MovieStrip`
`SceneSequence` -> `SceneStrip` (some was changed to a generic `Strip` before)
`SoundSequence` -> `SoundStrip`


