### PR TITLE
Preferences - Interface - Align Subpixel Anti-aliasing property left #5264

### DIFF
--- a/scripts/startup/bl_ui/space_userpref.py
+++ b/scripts/startup/bl_ui/space_userpref.py
@@ -258,7 +258,12 @@ class USERPREF_PT_interface_text(InterfacePanel, CenterAlignMixIn, Panel):
         flow.use_property_split = True
         sub = flow.column()
         sub.active = view.use_text_antialiasing
+        
+        # BFA - Align property left
+        sub.use_property_split = False 
         sub.prop(view, "use_text_render_subpixelaa", text="Subpixel Anti-Aliasing")
+        sub.use_property_split = True
+
         sub.prop(view, "text_hinting", text="Hinting")
 
         flow.prop(view, "font_path_ui")


### PR DESCRIPTION
<img width="515" height="174" alt="image" src="https://github.com/user-attachments/assets/9fdf17f6-46b6-4ef2-81a4-5d4e799fca19" />
