### PR TITLE
Fix #5268: Switch editor operators flag cause warning

### DIFF
--- a/scripts/startup/bl_ui/space_dopesheet.py
+++ b/scripts/startup/bl_ui/space_dopesheet.py
@@ -218,7 +218,6 @@ class ANIM_OT_switch_editors_to_dopesheet(bpy.types.Operator):
     bl_idname = "wm.switch_editor_to_dopesheet"        # unique identifier for buttons and menu items to reference.
     # display name in the interface.
     bl_label = "Switch to Dope Sheet Editor"
-    bl_options = {'REGISTER', 'UNDO'}  # enable undo for the operator.
 
     # execute() is called by blender when running the operator.
     def execute(self, context):
@@ -232,7 +231,6 @@ class ANIM_OT_switch_editors_to_graph(bpy.types.Operator):
     bl_idname = "wm.switch_editor_to_graph"        # unique identifier for buttons and menu items to reference.
     # display name in the interface.
     bl_label = "Switch to Graph Editor"
-    bl_options = {'REGISTER', 'UNDO'}  # enable undo for the operator.
 
     # execute() is called by blender when running the operator.
     def execute(self, context):
@@ -246,7 +244,6 @@ class ANIM_OT_switch_editors_to_driver(bpy.types.Operator):
     bl_idname = "wm.switch_editor_to_driver"        # unique identifier for buttons and menu items to reference.
     # display name in the interface.
     bl_label = "Switch to Driver Editor"
-    bl_options = {'REGISTER', 'UNDO'}  # enable undo for the operator.
 
     # execute() is called by blender when running the operator.
     def execute(self, context):
@@ -259,7 +256,6 @@ class ANIM_OT_switch_editors_to_nla(bpy.types.Operator):
     """Switch to NLA editor"""      # blender will use this as a tooltip for menu items and buttons.
     bl_idname = "wm.switch_editor_to_nla"        # unique identifier for buttons and menu items to reference.
     bl_label = "Switch to NLA Editor"         # display name in the interface.
-    bl_options = {'REGISTER', 'UNDO'}  # enable undo for the operator.
 
     # execute() is called by blender when running the operator.
     def execute(self, context):
@@ -273,7 +269,7 @@ class ANIM_OT_switch_editors_in_dopesheet(bpy.types.Operator):
     """You are in Dope Sheet Editor"""      # blender will use this as a tooltip for menu items and buttons.
     bl_idname = "wm.switch_editor_in_dopesheet"        # unique identifier for buttons and menu items to reference.
     bl_label = "Dope Sheet Editor"         # display name in the interface.
-    bl_options = {'REGISTER', 'UNDO'}  # enable undo for the operator.
+    bl_options = {'INTERNAL'}  # use internal so it can not be searchable
 
     # Blank button, we don't execute anything here.
     def execute(self, context):

--- a/scripts/startup/bl_ui/space_graph.py
+++ b/scripts/startup/bl_ui/space_graph.py
@@ -35,7 +35,7 @@ class ANIM_OT_switch_editor_in_graph(Operator):
 
     bl_idname = "wm.switch_editor_in_graph"  # unique identifier for buttons and menu items to reference.
     bl_label = "Graph Editor"  # display name in the interface.
-    bl_options = {"REGISTER", "UNDO"}  # enable undo for the operator.
+    bl_options = {'INTERNAL'}  # use internal so it can not be searchable
 
     def execute(self, context):  # Blank button, we don't execute anything here.
         return {"FINISHED"}
@@ -46,7 +46,7 @@ class ANIM_OT_switch_editor_in_driver(Operator):
 
     bl_idname = "wm.switch_editor_in_driver"  # unique identifier for buttons and menu items to reference.
     bl_label = "Driver Editor"  # display name in the interface.
-    bl_options = {"REGISTER", "UNDO"}  # enable undo for the operator.
+    bl_options = {'INTERNAL'}  # use internal so it can not be searchable
 
     def execute(self, context):  # Blank button, we don't execute anything here.
         return {"FINISHED"}

--- a/scripts/startup/bl_ui/space_image.py
+++ b/scripts/startup/bl_ui/space_image.py
@@ -2172,7 +2172,6 @@ class IMAGE_OT_switch_editors_to_uv(bpy.types.Operator):
     bl_idname = "wm.switch_editor_to_uv"        # unique identifier for buttons and menu items to reference.
     # display name in the interface.
     bl_label = "Switch to UV Editor"
-    bl_options = {'REGISTER', 'UNDO'}  # enable undo for the operator.
 
     # execute() is called by blender when running the operator.
     def execute(self, context):
@@ -2186,7 +2185,6 @@ class IMAGE_OT_switch_editors_to_image(bpy.types.Operator):
     bl_idname = "wm.switch_editor_to_image"        # unique identifier for buttons and menu items to reference.
     # display name in the interface.
     bl_label = "Switch to Image Editor"
-    bl_options = {'REGISTER', 'UNDO'}  # enable undo for the operator.
 
     # execute() is called by blender when running the operator.
     def execute(self, context):

--- a/scripts/startup/bl_ui/space_nla.py
+++ b/scripts/startup/bl_ui/space_nla.py
@@ -32,7 +32,7 @@ class ANIM_OT_switch_editors_in_nla(bpy.types.Operator):
 
     bl_idname = "wm.switch_editor_in_nla"  # unique identifier for buttons and menu items to reference.
     bl_label = "Nonlinear Animation Editor"  # display name in the interface.
-    bl_options = {"REGISTER", "UNDO"}  # enable undo for the operator.
+    bl_options = {'INTERNAL'}  # use internal so it can not be searchable
 
     def execute(self, context):  # Blank button, we don't execute anything here.
         return {"FINISHED"}

--- a/scripts/startup/bl_ui/space_node.py
+++ b/scripts/startup/bl_ui/space_node.py
@@ -42,7 +42,6 @@ class NODE_OT_switch_editors_to_compositor(bpy.types.Operator):
     bl_idname = "wm.switch_editor_to_compositor"        # unique identifier for buttons and menu items to reference.
     # display name in the interface.
     bl_label = "Switch to Compositor Editor"
-    bl_options = {'REGISTER', 'UNDO'}  # enable undo for the operator.
 
     # execute() is called by blender when running the operator.
     def execute(self, context):
@@ -56,7 +55,6 @@ class NODE_OT_switch_editors_to_geometry(bpy.types.Operator):
     bl_idname = "wm.switch_editor_to_geometry"        # unique identifier for buttons and menu items to reference.
     # display name in the interface.
     bl_label = "Switch to Geometry Node Editor"
-    bl_options = {'REGISTER', 'UNDO'}  # enable undo for the operator.
 
     # execute() is called by blender when running the operator.
     def execute(self, context):
@@ -70,7 +68,6 @@ class NODE_OT_switch_editors_to_shadereditor(bpy.types.Operator):
     bl_idname = "wm.switch_editor_to_shadereditor"        # unique identifier for buttons and menu items to reference.
     # display name in the interface.
     bl_label = "Switch to Shader Editor"
-    bl_options = {'REGISTER', 'UNDO'}  # enable undo for the operator.
 
     # execute() is called by blender when running the operator.
     def execute(self, context):
@@ -87,7 +84,7 @@ class NODE_OT_switch_editors_in_compositor(bpy.types.Operator):
     bl_idname = "wm.switch_editor_in_compositor"        # unique identifier for buttons and menu items to reference.
     # display name in the interface.
     bl_label = "You are in Compositor Editor"
-    bl_options = {'REGISTER', 'UNDO'}  # enable undo for the operator.
+    bl_options = {'INTERNAL'}  # use internal so it can not be searchable
 
     # execute() is called by blender when running the operator.
     def execute(self, context):
@@ -99,7 +96,7 @@ class NODE_OT_switch_editors_in_geometry(bpy.types.Operator):
     bl_idname = "wm.switch_editor_in_geometry"        # unique identifier for buttons and menu items to reference.
     # display name in the interface.
     bl_label = "You are in Geometry Node Editor"
-    bl_options = {'REGISTER', 'UNDO'}  # enable undo for the operator.
+    bl_options = {'INTERNAL'}  # use internal so it can not be searchable
 
     # execute() is called by blender when running the operator.
     def execute(self, context):
@@ -111,7 +108,7 @@ class NODE_OT_switch_editors_in_shadereditor(bpy.types.Operator):
     bl_idname = "wm.switch_editor_in_shadereditor"        # unique identifier for buttons and menu items to reference.
     # display name in the interface.
     bl_label = "You are in Shader Editor"
-    bl_options = {'REGISTER', 'UNDO'}  # enable undo for the operator.
+    bl_options = {'INTERNAL'}  # use internal so it can not be searchable
 
     # execute() is called by blender when running the operator.
     def execute(self, context):


### PR DESCRIPTION
This fixes #5268 by removing undo flag on the operator
and https://github.com/Bforartists/Bforartists/issues/5268#issuecomment-3083245068 removing register flag due to it being redoable in history while it something should not when execute on context change the current region (the header) causes issue.

Additionally change out "You are in X editor" with internal flag so it can't be search through Operator search.