### PR TITLE
Fix: 5294-blender_theme_as_cpy-adds-path-to-the-theme-to-the-userdef_…

### DIFF
--- a/tools/utils/blender_theme_as_c.py
+++ b/tools/utils/blender_theme_as_c.py
@@ -183,6 +183,7 @@ def is_ignore_dna_name(name):
         return True
     elif name in {
             b'active_theme_area',
+            b'filepath', # BFA - don't add the filepath to the userdef_default_theme.c file
     }:
         return True
     else:


### PR DESCRIPTION
fix to ignore the filepath when updating themes

