### PR TITLE
WIP: UV Select Similar menu header

### DIFF
--- a/scripts/startup/bl_ui/space_image.py
+++ b/scripts/startup/bl_ui/space_image.py
@@ -249,6 +249,42 @@ class IMAGE_MT_select(Menu):
         layout.operator("uv.select_more", text="More", icon="SELECTMORE")
         layout.operator("uv.select_less", text="Less", icon="SELECTLESS")
 
+### BFA - Start select similiar
+class IMAGE_MT_select_similar(Menu):
+    bl_label = "Select Similar"
+
+    def draw(self, context):
+        layout = self.layout
+        uv_island = context.tool_settings.use_uv_selected_island
+        mode = bpy.context.tool_settings.uv_select_mode
+       
+        layout.operator_context = 'INVOKE_REGION_WIN'
+        layout.operator_context = 'INVOKE_DEFAULT'
+        layout.operator("uv.select_similar", text="Floating Menu", icon="SIMILAR")
+        layout.separator()
+        if uv_island:
+            # Detects if it's in Island mode
+            layout.operator("uv.select_similar_bfa", text="Area", icon="AREA").type = "AREA"
+            layout.operator("uv.select_similar_bfa", text="Area 3D", icon="AREA").type = "AREA_3D"
+            layout.operator("uv.select_similar_bfa", text="Amount of Faces", icon="WINDING").type = "FACE"
+        elif mode == 'EDGE':
+            # Detects if it's in Edge mode
+            layout.operator("uv.select_similar_bfa", text="Length", icon="PARTICLEBRUSH_LENGTH").type = "LENGTH"
+            layout.operator("uv.select_similar_bfa", text="Length 3D", icon="PARTICLEBRUSH_LENGTH").type = "LENGTH_3D"
+            layout.operator("uv.select_similar_bfa", text="Pinned", icon="PINNED").type = "PIN"
+        elif mode == 'FACE':
+            # Detects if it's in Face mode
+            layout.operator("uv.select_similar_bfa", text="Area", icon="AREA").type = "AREA"
+            layout.operator("uv.select_similar_bfa", text="Area 3D", icon="AREA").type = "AREA_3D"
+            layout.operator("uv.select_similar_bfa", text="Material", icon="MATERIAL_DATA").type = "MATERIAL"
+            layout.operator("uv.select_similar_bfa", text="Object", icon="OBJECT_DATA").type = "OBJECT"
+            layout.operator("uv.select_similar_bfa", text="Polygon Sides", icon="SELECT_FACES_BY_SIDE").type = "SIDES"
+            layout.operator("uv.select_similar_bfa", text="Winding", icon="WINDING").type = "WINDING"
+        else:
+            # Detects if it's in Vertex mode, the default
+            layout.operator("uv.select_similar_bfa", text="Pinned", icon="PINNED").type = "PIN"
+
+### BFA - End of changes
 
 class IMAGE_MT_select_legacy(Menu):
     bl_label = "Legacy"
@@ -2252,6 +2288,7 @@ classes = (
     IMAGE_MT_uvs_snap_pie,
     IMAGE_MT_view_annotations, # BFA menu
     IMAGE_MT_view_pie,
+    IMAGE_MT_select_similar,  # BFA menu
     IMAGE_HT_tool_header,
     IMAGE_HT_header,
     IMAGE_MT_editor_menus,

--- a/source/blender/editors/uvedit/uvedit_intern.hh
+++ b/source/blender/editors/uvedit/uvedit_intern.hh
@@ -156,5 +156,6 @@ void UV_OT_select_more(wmOperatorType *ot);
 void UV_OT_select_less(wmOperatorType *ot);
 void UV_OT_select_overlap(wmOperatorType *ot);
 void UV_OT_select_similar(wmOperatorType *ot);
+void UV_OT_select_similar_bfa(wmOperatorType *ot); /* bfa select similiar */
 /* Used only when UV sync select is disabled. */
 void UV_OT_select_mode(wmOperatorType *ot);

--- a/source/blender/editors/uvedit/uvedit_ops.cc
+++ b/source/blender/editors/uvedit/uvedit_ops.cc
@@ -2003,6 +2003,7 @@ void ED_operatortypes_uvedit()
   WM_operatortype_append(UV_OT_select_box);
   WM_operatortype_append(UV_OT_select_lasso);
   WM_operatortype_append(UV_OT_select_similar);
+  WM_operatortype_append(UV_OT_select_similar_bfa); /* bfa select similiar */
   WM_operatortype_append(UV_OT_select_circle);
   WM_operatortype_append(UV_OT_select_more);
   WM_operatortype_append(UV_OT_select_less);

--- a/source/blender/editors/uvedit/uvedit_select.cc
+++ b/source/blender/editors/uvedit/uvedit_select.cc
@@ -5524,6 +5524,31 @@ void UV_OT_select_similar(wmOperatorType *ot)
   RNA_def_float(ot->srna, "threshold", 0.0f, 0.0f, 1.0f, "Threshold", "", 0.0f, 1.0f);
 }
 
+/* bfa start bfa select similiar operator */
+void UV_OT_select_similar_bfa(wmOperatorType *ot)
+{
+  /* identifiers */
+  ot->name = "Select Similar BFA";
+  ot->description = "Select similar UVs by property types";
+  ot->idname = "UV_OT_select_similar_bfa";
+
+  /* API callbacks. */
+  ot->invoke = WM_menu_invoke;
+  ot->exec = uv_select_similar_exec;
+  ot->poll = ED_operator_uvedit_space_image;
+
+  /* flags */
+  ot->flag = OPTYPE_REGISTER | OPTYPE_UNDO | OPTYPE_INTERNAL;
+
+  /* properties */
+  PropertyRNA *prop = ot->prop = RNA_def_enum(
+      ot->srna, "type", uv_select_similar_type_items, SIMVERT_NORMAL, "Type", "");
+  RNA_def_property_translation_context(prop, BLT_I18NCONTEXT_ID_MESH);
+  RNA_def_enum(ot->srna, "compare", prop_similar_compare_types, SIM_CMP_EQ, "Compare", "");
+  RNA_def_float(ot->srna, "threshold", 0.0f, 0.0f, 1.0f, "Threshold", "", 0.0f, 1.0f);
+}
+/* bfa end */
+
 /** \} */
 
 /* -------------------------------------------------------------------- */


### PR DESCRIPTION

UV Select similar in the source is dynamically change based on `uv_select_similar_type_itemf` function in `uvedit_select.cc` which makes hard to exposed options as a menu without populating the enum first. 

The idea of this is add a new Select similar operator with an internal flag which make it can not be search through Operator Search and more importantly without that dynamic change like the original operator and no tampering with the original operator.

https://github.com/user-attachments/assets/44851852-7057-42a3-a542-a3691d153058

Resolved #3204 

*keep this as a WIP for now*
