### PR TITLE
Edit Mode - Grease Pencil object - Properties - Data tab, align Auto Normalize left. #5308

### DIFF
--- a/scripts/startup/bl_ui/properties_data_mesh.py
+++ b/scripts/startup/bl_ui/properties_data_mesh.py
@@ -236,6 +236,7 @@ class DATA_PT_vertex_groups(MeshButtonsPanel, Panel):
             col.use_property_split = True
             col.use_property_decorate = False
             col.prop(context.tool_settings, "vertex_group_weight", text="Weight")
+            col.use_property_split = False # BFA - Align property left
             col.prop(context.tool_settings, "use_auto_normalize", text="Auto Normalize")
 
         draw_attribute_warnings(context, layout, None)


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="309" height="101" alt="image" src="https://github.com/user-attachments/assets/5e1e5c86-163c-403c-83ac-d125f4ff90a0" /> | <img width="310" height="107" alt="image" src="https://github.com/user-attachments/assets/ec2080ee-51f4-4de2-8a92-c9d7c84c4816" /> |