### PR TITLE
Fix: 5335-asset-shelf---thumbnail-sizes-need-consistency-with-defaults

### DIFF
--- a/scripts/startup/bl_ui/asset_shelf.py
+++ b/scripts/startup/bl_ui/asset_shelf.py
@@ -12,10 +12,10 @@ from bpy.props import EnumProperty # BFA
 
 # BFA - Preset sizes for asset shelf thumbnails
 thumbnail_sizes = {
-    "TINY" : 48,
-    "SMALL" : 96,
-    "MEDIUM" : 128,
-    "LARGE" : 256,
+    "TINY" : 32,      # Matches toolshelf
+    "SMALL" : 64,     # Asset shelf default
+    "MEDIUM" : 128,   # Asset browser default
+    "LARGE" : 256,    # Maximum size
 }
 
 # BFA - Preset sizes and their corresponding UI labels
@@ -26,11 +26,11 @@ class ASSETSHELF_OT_change_thumbnail_size(Operator):
     bl_label = "Change Thumbnail Size"
     bl_idname = "asset_shelf.change_thumbnail_size"
     bl_description = "Change the size of thumbnails in discrete steps"
-   
+
     size : EnumProperty(
         name="Thumbnail Size",
         description="Change the size of thumbnails in discrete steps",
-        default="TINY",
+        default="SMALL", # BFA - default to small
         items=thumbnail_size_labels
     )
 

--- a/source/blender/editors/space_file/filesel.cc
+++ b/source/blender/editors/space_file/filesel.cc
@@ -127,8 +127,8 @@ static void fileselect_ensure_updated_asset_params(SpaceFile *sfile)
   base_params->recursion_level = FILE_SELECT_MAX_RECURSIONS;
   /* 'SMALL' size by default. More reasonable since this is typically used as regular editor,
    * space is more of an issue here. */
-  base_params->thumbnail_size = 96;
-  base_params->list_thumbnail_size = 32;
+  base_params->thumbnail_size = 128; /* BFA - Matches MEDIUM in display_size_items */
+  base_params->list_thumbnail_size = 64;  /* Matches SMALL in display_size_items */
   base_params->list_column_size = 220;
 
   fileselect_initialize_params_common(sfile, base_params);

--- a/source/blender/makesrna/intern/rna_space.cc
+++ b/source/blender/makesrna/intern/rna_space.cc
@@ -7580,12 +7580,12 @@ static void rna_def_fileselect_params(BlenderRNA *brna)
 
   /* BFA - Adjusted sizes to be more useful in Thumbnail View and match from menus dropdown */
   static const EnumPropertyItem display_size_items[] = {
-      {48, "TINY", 0, "Tiny", ""},
-      {96, "SMALL", 0, "Small", ""},
-      {128, "NORMAL", 0, "Medium", ""},
-      {256, "LARGE", 0, "Large", ""},
+      {32, "TINY", 0, "Tiny", ""},       // Matches toolshelf
+      {64, "SMALL", 0, "Small", ""},     // Asset shelf default
+      {128, "NORMAL", 0, "Medium", ""},  // Asset browser default
+      {256, "LARGE", 0, "Large", ""},    // Maximum size
       {0, nullptr, 0, nullptr, nullptr},
-  };
+};
 
   srna = RNA_def_struct(brna, "FileSelectParams", nullptr);
   RNA_def_struct_path_func(srna, "rna_FileSelectParams_path");


### PR DESCRIPTION
-- adjusted default sizes mention in issue #5335 

asset shelf default = small (64)
asset browser default = medium (128)

Would this need to updated in manual?

