### PR TITLE
Fix: 5336-asset-browser---column-mode---add-quick-size-buttons

### DIFF
--- a/scripts/startup/bl_ui/space_filebrowser.py
+++ b/scripts/startup/bl_ui/space_filebrowser.py
@@ -715,10 +715,12 @@ class ASSETBROWSER_PT_display(asset_utils.AssetBrowserPanel, Panel):
             layout.prop(
                 params, "display_size_discrete", text="Text", expand=True
             )  # BFA - added quick thumbnail sizes.
-            layout.prop(params, "display_size", text="Size")
-        else:
+            layout.prop(params, "display_size", text="Preview Size") # BFA - changed to preview size, be consistent with horizontal list.
+        elif params.display_type == "LIST_HORIZONTAL":
+            layout.prop(
+                params, "list_display_size_discrete", text="Text", expand=True
+            )  # BFA - added quick horizontal list thumbnail sizes.
             layout.column().prop(params, "list_display_size", text="Preview Size")
-        if params.display_type == "LIST_HORIZONTAL":
             layout.column().prop(params, "list_column_size", text="Column Size")
 
         layout.label(text="Sort By")  # BFA - added label

--- a/source/blender/makesrna/intern/rna_space.cc
+++ b/source/blender/makesrna/intern/rna_space.cc
@@ -496,7 +496,7 @@ const EnumPropertyItem rna_enum_clip_editor_mode_items[] = {
 /* Actually populated dynamically through a function,
  * but helps for context-less access (e.g. doc, i18n...). */
 const EnumPropertyItem buttons_context_items[] = {
-    {BCONTEXT_TOOL, "TOOL", ICON_TOOL_SETTINGS, "Tool", "Active Tool and Workspace settings"}, 
+    {BCONTEXT_TOOL, "TOOL", ICON_TOOL_SETTINGS, "Tool", "Active Tool and Workspace settings"},
     {BCONTEXT_SCENE, "SCENE", ICON_SCENE_DATA, "Scene", "Scene Properties"},
     {BCONTEXT_RENDER, "RENDER", ICON_SCENE, "Render", "Render Properties"},
     {BCONTEXT_OUTPUT, "OUTPUT", ICON_OUTPUT, "Output", "Output Properties"},
@@ -7768,7 +7768,6 @@ static void rna_def_fileselect_params(BlenderRNA *brna)
   RNA_def_property_int_sdna(prop, nullptr, "thumbnail_size");
   RNA_def_property_ui_text(prop, "Display Size", "Change the size of thumbnails");
   RNA_def_property_update(prop, NC_SPACE | ND_SPACE_FILE_LIST, nullptr);
-  RNA_def_property_int_default(prop, 96);
   RNA_def_property_range(prop, 16, 256);
   RNA_def_property_ui_range(prop, 16, 256, 1, 0);
 
@@ -7777,6 +7776,13 @@ static void rna_def_fileselect_params(BlenderRNA *brna)
   RNA_def_property_enum_items(prop, display_size_items);
   RNA_def_property_ui_text(
       prop, "Display Size", "Change the size of thumbnails in discrete steps");
+  RNA_def_property_update(prop, NC_SPACE | ND_SPACE_FILE_LIST, nullptr);
+
+  prop = RNA_def_property(srna, "list_display_size_discrete", PROP_ENUM, PROP_NONE);
+  RNA_def_property_enum_sdna(prop, nullptr, "list_thumbnail_size");
+  RNA_def_property_enum_items(prop, display_size_items);
+  RNA_def_property_ui_text(
+      prop, "List Display Size", "Change the size of list thumbnails in discrete steps");
   RNA_def_property_update(prop, NC_SPACE | ND_SPACE_FILE_LIST, nullptr);
 
   prop = RNA_def_property(srna, "list_display_size", PROP_INT, PROP_NONE);


### PR DESCRIPTION
-- Added Preview Size presets to the List Horizontal display view in the asset browser

<img width="321" height="227" alt="image" src="https://github.com/user-attachments/assets/7fdc1901-e49a-4aef-a657-50b9ce9bbf40" />


