### PR TITLE
Fix: 5343-theme---blender-light-theme-is-completely-broken

### DIFF
--- a/scripts/presets/interface_theme/Blender_Light.xml
+++ b/scripts/presets/interface_theme/Blender_Light.xml
@@ -1073,7 +1073,6 @@
         path_keyframe_before="#ffc4c4"
         path_keyframe_after="#c4c4ff"
         frame_current="#5680c2"
-        preview_range="#a14d0066"
         time_scrub_background="#292929e6"
         time_marker_line="#00000060"
         time_marker_line_selected="#ffffff60"


### PR DESCRIPTION
duplicate preview_range entry at line 1058

<img width="2559" height="1403" alt="image" src="https://github.com/user-attachments/assets/60be1504-45e0-456c-b010-8fd509d62e68" />

