### PR TITLE
Fix #5362: Update utilize `sequencer_scene` and fixes for 3D sequencer

### DIFF
--- a/scripts/addons_core/bfa_3Dsequencer/scene/core.py
+++ b/scripts/addons_core/bfa_3Dsequencer/scene/core.py
@@ -210,7 +210,7 @@ def remap_relations(manifest: DuplicationManifest):
     def _remap_modifiers(new_object: bpy.types.Object):
         """Remap `new_object`'s modifiers properties."""
         _remap_pointer_properties(new_object.modifiers)
-        if isinstance(new_object.data, bpy.types.GreasePencil):
+        if isinstance(new_object.data, bpy.types.GreasePencilv3):
             _remap_pointer_properties(new_object.grease_pencil_modifiers)
             _remap_pointer_properties(new_object.shader_effects)
 

--- a/scripts/addons_core/bfa_3Dsequencer/sync/core.py
+++ b/scripts/addons_core/bfa_3Dsequencer/sync/core.py
@@ -278,7 +278,7 @@ def scene_change_manager(context: bpy.types.Context):
         gp_material = None
 
         if context.active_object and isinstance(
-            context.active_object.data, bpy.types.GreasePencil
+            context.active_object.data, bpy.types.GreasePencilv3
         ):
             gp_material = context.active_object.active_material
             sync_settings.last_gp_mode = context.active_object.mode
@@ -297,7 +297,7 @@ def scene_change_manager(context: bpy.types.Context):
         # If the new active object is a GP, restore the previously stored material
         # as active if also assigned.
         if (gpencil := context.active_object) and isinstance(
-            gpencil.data, bpy.types.GreasePencil
+            gpencil.data, bpy.types.GreasePencilv3
         ):
             if gp_material:
                 material_idx = gpencil.data.materials.find(gp_material.name)

--- a/source/blender/blenkernel/intern/context.cc
+++ b/source/blender/blenkernel/intern/context.cc
@@ -1174,6 +1174,12 @@ Scene *CTX_data_sequencer_scene(const bContext *C)
   if (ctx_data_pointer_verify(C, "sequencer_scene", (void **)&scene)) {
     return scene;
   }
+  // start BFA - 3D Sequencer
+  SpaceSeq *sseq = CTX_wm_space_seq(C);
+  if (sseq != nullptr && sseq->scene_override != nullptr) {
+    return sseq->scene_override;
+  }
+  // end bfa
   /* TODO: Use sequencer scene. */
   return C->data.scene;
 }

--- a/source/blender/editors/screen/screen_context.cc
+++ b/source/blender/editors/screen/screen_context.cc
@@ -672,24 +672,19 @@ static eContextResult screen_ctx_pose_object(const bContext *C, bContextDataResu
   }
   return CTX_RESULT_OK;
 }
-static Scene *space_sequencer_get_active_scene(const bContext *C)  /*BFA - 3D Sequencer*/
+/**
+ * BFA - 3D Sequencer, uses CTX_data_sequencer_scene instead 
+ * TODO: remove for Scene Selector
+*/
+static Scene *bfa_3d_sequencer_get_active_scene(const bContext *C)
 {
-  wmWindow *win = CTX_wm_window(C);
-  Scene *scene = WM_window_get_active_scene(win);
-  /*############## BFA - 3D Sequencer ##############*/
-  SpaceSeq *sseq = CTX_wm_space_seq(C);
-
-  if (sseq != NULL && sseq->scene_override != NULL) {
-    scene = sseq->scene_override;
-  }
-  return scene;
+  return CTX_data_sequencer_scene(C);
 }
 
 static eContextResult screen_ctx_active_sequence_strip(const bContext *C,
                                                        bContextDataResult *result)
 {
-  Scene *scene = space_sequencer_get_active_scene(C);
-  /*############## BFA - 3D Sequencer End ##############*/
+  Scene *scene = bfa_3d_sequencer_get_active_scene(C);
   Strip *strip = blender::seq::select_active_get(scene);
   if (strip) {
     CTX_data_pointer_set(result, &scene->id, &RNA_Strip, strip);
@@ -713,7 +708,7 @@ static eContextResult screen_ctx_sequences(const bContext *C, bContextDataResult
 }
 static eContextResult screen_ctx_selected_sequences(const bContext *C, bContextDataResult *result)
 {
-  Scene *scene = space_sequencer_get_active_scene(C); /*BFA - 3D Sequencer*/
+  Scene *scene = bfa_3d_sequencer_get_active_scene(C); /*BFA - 3D Sequencer*/
   Editing *ed = blender::seq::editing_get(scene);
   if (ed) {
     LISTBASE_FOREACH (Strip *, strip, ed->seqbasep) {
@@ -729,7 +724,7 @@ static eContextResult screen_ctx_selected_sequences(const bContext *C, bContextD
 static eContextResult screen_ctx_selected_editable_sequences(const bContext *C,
                                                              bContextDataResult *result)
 {
-  Scene *scene = space_sequencer_get_active_scene(C); /*BFA - 3D Sequencer*/
+  Scene *scene = bfa_3d_sequencer_get_active_scene(C); /*BFA - 3D Sequencer*/
   Editing *ed = blender::seq::editing_get(scene);
   if (ed == nullptr) {
     return CTX_RESULT_NO_DATA;

--- a/source/blender/editors/space_sequencer/sequencer_edit.cc
+++ b/source/blender/editors/space_sequencer/sequencer_edit.cc
@@ -3675,20 +3675,20 @@ void SEQUENCER_OT_cursor_set(wmOperatorType *ot)
 static bool sequencer_remove_scene_override_poll(bContext *C)
 {
   SpaceSeq *seq = CTX_wm_space_seq(C);
-  return (seq != NULL && seq->scene_override != NULL);
+  return (seq != nullptr && seq->scene_override != nullptr);
 }
 
 static wmOperatorStatus sequencer_remove_scene_override_exec(bContext *C, wmOperator *op)
 {
   SpaceSeq *seq = CTX_wm_space_seq(C);
 
-  if (seq == NULL) {
+  if (seq == nullptr) {
     BKE_report(op->reports, RPT_ERROR, "Incorrect context for removing scene override");
     return OPERATOR_CANCELLED;
   }
 
   /* Remove scene override. */
-  seq->scene_override = NULL;
+  seq->scene_override = nullptr;
 
   WM_event_add_notifier(C, NC_SCENE | ND_SEQUENCER, CTX_data_scene(C));
 

--- a/source/blender/sequencer/intern/sequencer.cc
+++ b/source/blender/sequencer/intern/sequencer.cc
@@ -1139,13 +1139,13 @@ void eval_strips(Depsgraph *depsgraph, Scene *scene, ListBase *seqbase)
 Scene *get_ref_scene_for_notifiers(const bContext *C)
 {
   SpaceSeq *seq = CTX_wm_space_seq(C);
-  if (seq != NULL && seq->scene_override != NULL) {
-    /* Passing NULL in the reference of `WM_event_add_notifier` will not restrict the update to one
+  if (seq != nullptr && seq->scene_override != nullptr) {
+    /* Passing nullptr in the reference of `WM_event_add_notifier` will not restrict the update to one
      * particular scene/screen. This needs to be done because when the notifiers are evaluated, the
      * current scene is always expected to be the active scene in the window. In the case of an
      * override, passing the overriden scene as a reference to the notifier will no longer cause
      * updates. So we need to update everything for this to work. */
-    return NULL;
+    return nullptr;
   }
   return CTX_data_scene(C);
 }


### PR DESCRIPTION
This updates the 3D sequencer to use the new `CTX_data_sequencer_scene` since it similiar to what `space_sequencer_get_active_scene` does before, also rename it to `bfa_3d_sequencer_get_active_scene` since Blender doesn't really use it anymore.
Additionally Grease Pencil now uses `GreasePencilv3` for its datablock which cause some syncing to not working. `GreasePencil` was replaced [more info](https://projects.blender.org/blender/blender/pulls/142236)
Resolved #5362