### PR TITLE
Edit Mode - Mesh Edit - Mesh Tools Addon - Draw "Set Dimensions" operator as icon depending on panel width #5373

### DIFF
--- a/scripts/addons_core/edit_dimensions.py
+++ b/scripts/addons_core/edit_dimensions.py
@@ -121,9 +121,19 @@ class ED_OT_SetDimensions(Operator):
 
 
 def add_button(self, context):
+    layout = self.layout
+    row = layout.row(align=True)
+    row.scale_x = 2
+    row.scale_y = 2
 
     if context.mode in {'EDIT_MESH'}:
-        self.layout.operator(ED_OT_SetDimensions.bl_idname, icon="PLUGIN")
+        column_count = self.ts_width(layout, context.region, scale_y= 1.75)
+
+        if column_count >= 4:
+            row.operator(ED_OT_SetDimensions.bl_idname, icon="PLUGIN")
+        else:
+            row.operator(ED_OT_SetDimensions.bl_idname, text="", icon="PLUGIN")
+
 
 classes = (
     ED_OT_SetDimensions,


### PR DESCRIPTION
Adjusted the "Mesh Tools" addon's drawing function such that it matches the native operators more.

|  | Before | After |
| --- | --- | --- |
| Text Buttons | <img width="186" height="120" alt="image" src="https://github.com/user-attachments/assets/6d9fea31-f076-45c1-832f-1381d1b9a179" /> | <img width="276" height="139" alt="image" src="https://github.com/user-attachments/assets/7028ee8c-276e-4c4f-83d2-e04db8ef6dcc" /> |
| Icon Buttons | <img width="140" height="84" alt="image" src="https://github.com/user-attachments/assets/cbd85bf0-e9bc-4d5c-acec-7efc714c2ca4" /> | <img width="146" height="110" alt="image" src="https://github.com/user-attachments/assets/d7d396dc-1eef-48e2-9869-16aceabd1723" /> |
