### PR TITLE
Edit Mode - Grease Pencil - Tool Panels - Rename "Gpencil" category to "Grease Pencil" #5375

### DIFF
--- a/scripts/startup/bl_ui/space_toolsystem_toolbar_tabs.py
+++ b/scripts/startup/bl_ui/space_toolsystem_toolbar_tabs.py
@@ -4727,7 +4727,7 @@ class VIEW3D_PT_gp_gpenciltab_dissolve(toolshelf_calculate, Panel):
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'TOOLS'
     bl_context = "grease_pencil_edit"
-    bl_category = "Gpencil"
+    bl_category = "Grease Pencil"
     bl_options = {'HIDE_BG'}
 
     # just show when the toolshelf tabs toggle in the view menu is on.
@@ -4786,7 +4786,7 @@ class VIEW3D_PT_gp_gpenciltab_cleanup(toolshelf_calculate, Panel):
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'TOOLS'
     bl_context = "grease_pencil_edit"
-    bl_category = "Gpencil"
+    bl_category = "Grease Pencil"
     bl_options = {'HIDE_BG', 'DEFAULT_CLOSED'}
 
     # just show when the toolshelf tabs toggle in the view menu is on.
@@ -4856,7 +4856,7 @@ class VIEW3D_PT_gp_gpenciltab_separate(toolshelf_calculate, Panel):
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'TOOLS'
     bl_context = "grease_pencil_edit"
-    bl_category = "Gpencil"
+    bl_category = "Grease Pencil"
     bl_options = {'HIDE_BG', 'DEFAULT_CLOSED'}
 
     # just show when the toolshelf tabs toggle in the view menu is on.


### PR DESCRIPTION
Make it consistent with the header menu which is named "Grease Pencil".

Also just a good rule of thumb to make the names explicit if screen space is not a limiting factor.
There really isn't much utility to shortening the name to "Gpencil", so it's not worth making the user have to remember the fact the name is shortened in the tool tabs.