### PR TITLE
Edit Mode - Curve - Ensure consistency for "Delete" operations

### DIFF
--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -7954,7 +7954,8 @@ def draw_curve(self, context):
 
     layout.separator()
 
-    layout.menu("VIEW3D_MT_edit_curve_delete")
+    # BFA - Put menu items in top-level, the same way as in the context menu
+    layout.menu_contents("VIEW3D_MT_edit_curve_delete")
     if edit_object.type == 'CURVE':
         layout.operator("curve.dissolve_verts", icon="DISSOLVE_VERTS")
 
@@ -8084,14 +8085,8 @@ class VIEW3D_MT_edit_curve_context_menu(Menu):
         layout.operator("curve.split", icon="SPLIT")
         layout.operator("curve.decimate", icon="DECIMATE")
         layout.operator("curve.separate", icon="SEPARATE")
+        layout.menu_contents("VIEW3D_MT_edit_curve_delete") # BFA - Re-use same submenu used in "Curve" header menu
         layout.operator("curve.dissolve_verts", icon="DISSOLVE_VERTS")
-        layout.operator(
-            "curve.delete", text="Delete Segment", icon="DELETE"
-        ).type = 'SEGMENT'
-        layout.operator(
-            "curve.delete", text="Delete Point", icon="DELETE"
-        ).type = "VERT"
-
         layout.separator()
 
         layout.menu("VIEW3D_MT_edit_curve_showhide")  # BFA - added to context menu
@@ -8102,9 +8097,17 @@ class VIEW3D_MT_edit_curve_delete(Menu):
 
     def draw(self, _context):
         layout = self.layout
+        
+        # BFA - Change label if menu is used as a popup
+        if layout.operator_context == 'EXEC_REGION_WIN':
+            vertices_label = "Vertices"
+            segment_label = "Segment"
+        else:
+            vertices_label = "Delete Vertices"
+            segment_label = "Delete Segment"
 
-        layout.operator("curve.delete", text="Vertices", icon="DELETE").type = "VERT"
-        layout.operator("curve.delete", text="Segment", icon="DELETE").type = 'SEGMENT'
+        layout.operator("curve.delete", text=vertices_label, icon="DELETE").type = "VERT"
+        layout.operator("curve.delete", text=segment_label, icon="DELETE").type = 'SEGMENT'
 
 
 class VIEW3D_MT_edit_curve_showhide(Menu):


### PR DESCRIPTION
Related Task: #5398

Currently, there are three places the delete operations for Curves show up:
- Under the "Curve" menu in the Header
- In the right-click context menu
- Invoked via hotkey (typically `Delete` or `X`)

There have been some inconsistencies due between the header and context menus since the context menu references those delete operators manually.

This patch makes it so that the same submenu is used for all three: `VIEW3D_MT_edit_curve_delete`
|  | Header | Context Menu | Hotkey |
| --- | --- | --- | --- |
| Before | <img width="429" height="101" alt="image" src="https://github.com/user-attachments/assets/4314da3c-0a51-441f-8e23-ea9648ab3664" /> | <img width="245" height="96" alt="image" src="https://github.com/user-attachments/assets/e58a7cb8-ce3f-442c-9a7e-d7bb671ab678" /> | <img width="231" height="118" alt="image" src="https://github.com/user-attachments/assets/0bfeaa44-1341-4f02-8015-bfbb6566fcf1" /> |
| After | <img width="233" height="114" alt="image" src="https://github.com/user-attachments/assets/e9330c5a-6bb6-484f-bbe9-7382a146e54b" /> | <img width="242" height="99" alt="image" src="https://github.com/user-attachments/assets/58942c96-0c6b-4ccc-bf43-7383f07f89cd" /> | <img width="236" height="122" alt="image" src="https://github.com/user-attachments/assets/72ad3e25-c52d-47fe-aa3d-ddd0f54cfab3" /> |

For the header & context menus, `layout.menu_contents` is used instead of `layout.menu`, so that these operators are placed directly in the top-level. For invoking using a hotkey, special code is added to remove the word "Delete" from the operator levels, as all operations exposed in that context are delete operations.

