### PR TITLE
Sequencer - Sidebar - Reverse Frames should float left #5389

### DIFF
--- a/scripts/startup/bl_ui/space_sequencer.py
+++ b/scripts/startup/bl_ui/space_sequencer.py
@@ -3483,6 +3483,9 @@ class SEQUENCER_PT_adjust_video(SequencerButtonsPanel, Panel):
         layout.active = not strip.mute
 
         col.prop(strip, "strobe")
+        
+        # BFA - Align bool property left
+        col.use_property_split = False
         col.prop(strip, "use_reverse_frames")
 
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="309" height="106" alt="image" src="https://github.com/user-attachments/assets/dae4abee-8bfd-470a-b68d-a561fe125e30" /> | <img width="309" height="98" alt="image" src="https://github.com/user-attachments/assets/73766995-4ddc-4261-90a1-5b47ccf9f0c5" /> |