### PR TITLE
Mesh object in edit mode, Face sub mode, context menu - double separator #5394

### DIFF
--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -7151,8 +7151,6 @@ class VIEW3D_MT_edit_mesh_context_menu(Menu):
             # BFA-Draise - Legacy Operator Added to own group with consistent order
             col.operator("mesh.inset", icon="INSET_FACES")
 
-            col.separator()
-
             col.separator()  # BFA-Draise - Seperated extrude operators to be in own group for consistency
 
             if selected_faces_len >= 2:
@@ -7179,7 +7177,7 @@ class VIEW3D_MT_edit_mesh_context_menu(Menu):
             col.operator("mesh.faces_shade_smooth", icon="SHADING_SMOOTH")
             col.operator("mesh.faces_shade_flat", icon="SHADING_FLAT")
 
-            layout.separator()
+            col.separator()
 
             # Removal Operators
             col.operator("mesh.unsubdivide", icon="UNSUBDIVIDE")


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="254" height="211" alt="image" src="https://github.com/user-attachments/assets/a57c2612-494b-4928-8728-8c5dd8428ec4" /> | <img width="237" height="210" alt="image" src="https://github.com/user-attachments/assets/698b01d4-a962-49e7-b6ec-ccb6fda738c6" /> |

A separator meant to be added to `col` was added to `layout` instead, meaning it got added at the end of that specific section of the context menu. So this doubles the separators as there is already a separator already intended there.

