### PR TITLE
Node Editor - Change socket shape of Single data structure to square #5404

### DIFF
--- a/source/blender/gpu/shaders/gpu_shader_2D_node_socket_frag.glsl
+++ b/source/blender/gpu/shaders/gpu_shader_2D_node_socket_frag.glsl
@@ -99,7 +99,7 @@ void main()
     /* BFA - Change single socket shape to enlarged square*/
     /* The name _LINE is still kept though for compatibility */
     case SOCK_DISPLAY_SHAPE_LINE: {
-      distance_squared = square_sdf(co, float2(square_radius * 1.2));
+      distance_squared = square_sdf(co, float2(square_radius * 1.1));
       alpha_threshold = corner_rounding;
       break;
     }

--- a/source/blender/gpu/shaders/gpu_shader_2D_node_socket_frag.glsl
+++ b/source/blender/gpu/shaders/gpu_shader_2D_node_socket_frag.glsl
@@ -96,8 +96,10 @@ void main()
       dot_threshold = finalDotRadius;
       break;
     }
+    /* BFA - Change single socket shape to enlarged square*/
+    /* The name _LINE is still kept though for compatibility */
     case SOCK_DISPLAY_SHAPE_LINE: {
-      distance_squared = square_sdf(co, float2(square_radius * 0.75, square_radius * 1.4));
+      distance_squared = square_sdf(co, float2(square_radius * 1.2));
       alpha_threshold = corner_rounding;
       break;
     }

--- a/source/blender/gpu/shaders/gpu_shader_2D_node_socket_frag.glsl
+++ b/source/blender/gpu/shaders/gpu_shader_2D_node_socket_frag.glsl
@@ -97,7 +97,7 @@ void main()
       break;
     }
     /* BFA - Change single socket shape to enlarged square*/
-    /* The name _LINE is still kept though for compatibility */
+    /* The name _LINE is still kept for compatibility */
     case SOCK_DISPLAY_SHAPE_LINE: {
       distance_squared = square_sdf(co, float2(square_radius * 1.1));
       alpha_threshold = corner_rounding;


### PR DESCRIPTION
This patch changes the socket shape for Single Values in Geometry Nodes.

The original one in Blender is a thin rectangle. While for BFA, the choice has been made to draw this as a square.
This gives the sockets more screen space, making it more proportional to other socket shapes.

|  |  | 
| --- | --- |
| Before | <img width="1809" height="984" alt="image" src="https://github.com/user-attachments/assets/40ede38a-9b5f-4bc2-93d4-766f1b37f8cd" /> |
| After | <img width="1809" height="984" alt="image" src="https://github.com/user-attachments/assets/73e478cb-e4c4-42b7-9950-d3439f093ccc" /> |