### PR TITLE
Cleanup: Object - Use static tooltip description for `"Transforms to Deltas"` operator instead of dynamic property

### DIFF
--- a/scripts/startup/bl_operators/object.py
+++ b/scripts/startup/bl_operators/object.py
@@ -748,8 +748,8 @@ class ClearAllRestrictRender(Operator):
 
 
 class TransformsToDeltas(Operator):
-    """Convert normal object transforms to delta transforms, """ \
-        """any existing delta transforms will be included as well"""
+    """Converts normal object transforms to delta transforms.\n""" \
+        """Any existing delta transform will be included as well""" # BFA
     bl_idname = "object.transforms_to_deltas"
     bl_label = "Transforms to Deltas"
     bl_options = {'REGISTER', 'UNDO'}
@@ -770,16 +770,6 @@ class TransformsToDeltas(Operator):
         description=("Clear transform values after transferring to deltas"),
         default=True,
     )
-
-    # bfa - description for the delta transforms
-    arg: bpy.props.StringProperty()
-
-    @classmethod
-    def description(cls, context, properties):
-        #return "arg is: " + properties.arg
-        return properties.arg
-
-    # bfa - description end
 
     @classmethod
     def poll(cls, context):

--- a/scripts/startup/bl_ui/space_toolbar.py
+++ b/scripts/startup/bl_ui/space_toolbar.py
@@ -1766,22 +1766,15 @@ class TOOLBAR_MT_edit(Menu):
 
                     myvar = row.operator("object.transforms_to_deltas", text="", icon = "APPLYMOVEDELTA")
                     myvar.mode = 'LOC'
-                    myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                     myvar = row.operator("object.transforms_to_deltas", text="", icon = "APPLYROTATEDELTA")
                     myvar.mode = 'ROT'
-                    myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                     myvar = row.operator("object.transforms_to_deltas", text="", icon = "APPLYSCALEDELTA")
                     myvar.mode = 'SCALE'
-                    myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                     myvar = row.operator("object.transforms_to_deltas", text="", icon = "APPLYALLDELTA")
                     myvar.mode = 'ALL'
-                    myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
-
-
-
 
                     row.operator("object.anim_transforms_to_deltas", text = "", icon = "APPLYANIDELTA")
 

--- a/scripts/startup/bl_ui/space_toolsystem_toolbar_tabs.py
+++ b/scripts/startup/bl_ui/space_toolsystem_toolbar_tabs.py
@@ -846,19 +846,15 @@ class VIEW3D_PT_objecttab_apply_delta(toolshelf_calculate, Panel):
 
             myvar = col.operator("object.transforms_to_deltas", text="Location to Deltas", text_ctxt=i18n_contexts.default, icon = "APPLYMOVEDELTA")
             myvar.mode = 'LOC'
-            myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
             myvar = col.operator("object.transforms_to_deltas", text="Rotation to Deltas", text_ctxt=i18n_contexts.default, icon = "APPLYROTATEDELTA")
             myvar.mode = 'ROT'
-            myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
             myvar = col.operator("object.transforms_to_deltas", text="Scale to Deltas", text_ctxt=i18n_contexts.default, icon = "APPLYSCALEDELTA")
             myvar.mode = 'SCALE'
-            myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
             myvar = col.operator("object.transforms_to_deltas", text="All Transforms to Deltas", text_ctxt=i18n_contexts.default, icon = "APPLYALLDELTA")
             myvar.mode = 'ALL'
-            myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
             col.separator(factor = 0.5)
 
@@ -876,20 +872,16 @@ class VIEW3D_PT_objecttab_apply_delta(toolshelf_calculate, Panel):
                 row = col.row(align=True)
                 myvar = row.operator("object.transforms_to_deltas", text="", icon = "APPLYMOVEDELTA")
                 myvar.mode = 'LOC'
-                myvar.arg = 'Convert normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                 myvar = row.operator("object.transforms_to_deltas", text="", icon = "APPLYROTATEDELTA")
                 myvar.mode = 'ROT'
-                myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                 myvar = row.operator("object.transforms_to_deltas", text="", icon = "APPLYALLDELTA")
                 myvar.mode = 'SCALE'
-                myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                 row = col.row(align=True)
                 myvar = row.operator("object.transforms_to_deltas", text="", icon = "APPLYALLDELTA")
                 myvar.mode = 'ALL'
-                myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                 row.operator("object.anim_transforms_to_deltas", text="", icon = "APPLYANIDELTA")
 
@@ -899,20 +891,16 @@ class VIEW3D_PT_objecttab_apply_delta(toolshelf_calculate, Panel):
                 row = col.row(align=True)
                 myvar = row.operator("object.transforms_to_deltas", text="", icon = "APPLYMOVEDELTA")
                 myvar.mode = 'LOC'
-                myvar.arg = 'Convert normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                 myvar = row.operator("object.transforms_to_deltas", text="", icon = "APPLYROTATEDELTA")
                 myvar.mode = 'ROT'
-                myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                 row = col.row(align=True)
                 myvar = row.operator("object.transforms_to_deltas", text="", icon = "APPLYSCALEDELTA")
                 myvar.mode = 'SCALE'
-                myvar.arg = 'nConverts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                 myvar = row.operator("object.transforms_to_deltas", text="", icon = "APPLYALLDELTA")
                 myvar.mode = 'ALL'
-                myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                 row = col.row(align=True)
                 row.operator("object.anim_transforms_to_deltas", text="", icon = "APPLYANIDELTA")
@@ -921,19 +909,15 @@ class VIEW3D_PT_objecttab_apply_delta(toolshelf_calculate, Panel):
 
                 myvar = col.operator("object.transforms_to_deltas", text="", icon = "APPLYMOVEDELTA")
                 myvar.mode = 'LOC'
-                myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                 myvar = col.operator("object.transforms_to_deltas", text="", icon = "APPLYROTATEDELTA")
                 myvar.mode = 'ROT'
-                myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                 myvar = col.operator("object.transforms_to_deltas", text="", icon = "APPLYSCALEDELTA")
                 myvar.mode = 'SCALE'
-                myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                 myvar = col.operator("object.transforms_to_deltas", text="", icon = "APPLYALLDELTA")
                 myvar.mode = 'ALL'
-                myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                 col.separator(factor = 0.5)
 

--- a/scripts/startup/bl_ui/space_topbar_toolbar.py
+++ b/scripts/startup/bl_ui/space_topbar_toolbar.py
@@ -1758,19 +1758,15 @@ class TOPBAR_MT_edit(Menu):
 
                         myvar = row.operator("object.transforms_to_deltas", text="", icon = "APPLYMOVEDELTA")
                         myvar.mode = 'LOC'
-                        myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                         myvar = row.operator("object.transforms_to_deltas", text="", icon = "APPLYROTATEDELTA")
                         myvar.mode = 'ROT'
-                        myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                         myvar = row.operator("object.transforms_to_deltas", text="", icon = "APPLYSCALEDELTA")
                         myvar.mode = 'SCALE'
-                        myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                         myvar = row.operator("object.transforms_to_deltas", text="", icon = "APPLYALLDELTA")
                         myvar.mode = 'ALL'
-                        myvar.arg = 'Converts normal object transforms to delta transforms\nAny existing delta transform will be included as well'
 
                         row.operator("object.anim_transforms_to_deltas", text = "", icon = "APPLYANIDELTA")
 


### PR DESCRIPTION
The `"Transforms to Deltas"` has an `arg` property that allows for dynamically overriding the tooltip description. However, in all places where this operator is used, the same description is used.

This can be better served using a static description for the operator, which would remove the need to copy the same description for every place the operator is used.

In fact, the description used in all instances of the operator is identical to the existing docstring, save for a missing newline character. So this patch adds that newline to the docstring and removes the dynamic description from use.