### PR TITLE
Fix: 5445-properties-editor---render---volumes-panel---float-unbiased…

### DIFF
--- a/intern/cycles/blender/addon/ui.py
+++ b/intern/cycles/blender/addon/ui.py
@@ -595,7 +595,7 @@ class CYCLES_RENDER_PT_volumes(CyclesButtonsPanel, Panel):
 
     def draw(self, context):
         layout = self.layout
-        layout.use_property_split = True
+        layout.use_property_split = False # BFA
         layout.use_property_decorate = False
 
         scene = context.scene


### PR DESCRIPTION
- Float Unbiased to the left

<img width="413" height="125" alt="image" src="https://github.com/user-attachments/assets/25b8ae47-ff2b-4761-8da8-841677fc8ab6" />
