### PR TITLE
Node Editor - Add shelf has a group bug #5448

### DIFF
--- a/scripts/startup/bl_ui/node_add_menu.py
+++ b/scripts/startup/bl_ui/node_add_menu.py
@@ -83,6 +83,10 @@ def draw_node_groups(context, layout):
     space_node = context.space_data
     node_tree = space_node.edit_tree
 
+    # BFA - Check if there's an active node tree
+    if node_tree is None:
+        return
+
     from nodeitems_builtins import node_tree_group_type
 
     prefs = context.preferences


### PR DESCRIPTION
Turns out when the node tree is inactive in cases where "use nodes" is off, this will error.

