### PR TITLE
Cleanup: Fix "alight left" typo in BFA comments

### DIFF
--- a/scripts/startup/bl_ui/properties_data_bone.py
+++ b/scripts/startup/bl_ui/properties_data_bone.py
@@ -357,7 +357,7 @@ class BONE_PT_display(BoneButtonsPanel, Panel):
         ob = context.object
         pose_bone = ob and ob.pose.bones[bone.name]
 
-        row = layout.row() # BFA - changed to collapse disabled and alight left
+        row = layout.row() # BFA - changed to collapse disabled and align left
         row.use_property_split = False
         row.prop(bone, "hide", text = "Hide", toggle=False)
         if bone.hide:
@@ -400,7 +400,7 @@ class BONE_PT_display(BoneButtonsPanel, Panel):
         if bone is None:
             return
 
-        row = layout.row() # BFA - changed to collapse disabled and alight left
+        row = layout.row() # BFA - changed to collapse disabled and align left
         row.use_property_split = False
         row.prop(bone, "hide", text="Hide", toggle=False)
         if bone.hide:


### PR DESCRIPTION
Some comments say _"alight left"_ instead of _"align left"_.

This would make them not show up when searching _"align"_.
That is not ideal in the case where we'd wanna track all cases where we change code to align properties differently. 