### PR TITLE
Properties Editor - Material - Surface - Float dynamic labels left #5449

### DIFF
--- a/source/blender/editors/space_node/node_templates.cc
+++ b/source/blender/editors/space_node/node_templates.cc
@@ -879,7 +879,7 @@ static void ui_node_draw_input(uiLayout &layout,
     }
 
     sub = &sub->row(true);
-    sub->alignment_set(ui::LayoutAlign::Right);
+    sub->alignment_set(ui::LayoutAlign::Left); /* BFA - Align labels left */
     sub->label(node_socket_get_label(&input, panel_label), ICON_NONE);
   }
 


### PR DESCRIPTION
Change the `ui_node_draw_input` function to align the labels left.

| Before | After |
| --- | --- |
| <img width="301" height="467" alt="image" src="https://github.com/user-attachments/assets/f786b96f-c48d-468a-b5b7-c828d805c94e" /> | <img width="301" height="476" alt="image" src="https://github.com/user-attachments/assets/11391f8f-7f42-4991-9b2c-aa02c0be751d" /> |