### PR TITLE
Cleanup: Sculpt Mode - Mesh - Capitalize "Cavity (inverted)"

### DIFF
--- a/scripts/startup/bl_ui/properties_paint_common.py
+++ b/scripts/startup/bl_ui/properties_paint_common.py
@@ -1531,7 +1531,7 @@ def brush_settings_advanced(layout, context, settings, brush, popover=False):
         split.use_property_split = False
         row = split.row()
         row.separator()
-        row.prop(brush, "use_automasking_cavity_inverted", text="Cavity (Inverted)")
+        row.prop(brush, "use_automasking_cavity_inverted", text="Cavity (Inverted)") # BFA - Capitalize label
 
         is_cavity_active = (
             brush.use_automasking_cavity or brush.use_automasking_cavity_inverted

--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -12609,7 +12609,7 @@ class VIEW3D_PT_sculpt_automasking(Panel):
         split.use_property_split = False
         row = split.row()
         row.separator()
-        row.prop(sculpt, "use_automasking_cavity_inverted", text="Cavity (Inverted)")
+        row.prop(sculpt, "use_automasking_cavity_inverted", text="Cavity (Inverted)") # BFA - Capitalize label
 
         is_cavity_active = (
             sculpt.use_automasking_cavity or sculpt.use_automasking_cavity_inverted


### PR DESCRIPTION
That label is inconsistent as it's capitalized in some places and not in others. 
This patch capitalizes that label in all places where it is lowercase.

