### PR TITLE
Fix: Sculpt Mode - Mesh - Options Panel - attribute not found error #5457

### DIFF
--- a/scripts/startup/bl_ui/space_view3d_toolbar.py
+++ b/scripts/startup/bl_ui/space_view3d_toolbar.py
@@ -1248,7 +1248,7 @@ class VIEW3D_PT_sculpt_options(Panel, View3DPaintPanel):
 
             col2 = col.column()
             props = col2.operator("sculpt.mask_from_cavity", text="Mask From Cavity")
-            props.use_automask_settings = True
+            props.settings_source = 'OPERATOR'
 
             col2 = col.column()
 


### PR DESCRIPTION
A bit of an educated guess, as doing this fixes the attribute issue. Though whether `OPERATOR` is the correct value for `props.settings_source`, it a bit unknown.

The reason is was chosen is because it's what's used by `VIEW3D_MT_mask` from `space_view3d.py`, so it was assumed that `VIEW3D_PT_sculpt_options` from `space_view3d_toolbar.py` would similarly use that too.

| Before | After |
| --- | --- |
| <img width="281" height="148" alt="image" src="https://github.com/user-attachments/assets/3ae5ea00-6db2-4622-a7b1-e1d093a8bc46" /> | <img width="278" height="202" alt="image" src="https://github.com/user-attachments/assets/8bd88537-0148-444f-930b-4e47aea49ce4" /> |

*(notice the missing properties in the Before photo)*