### PR TITLE
Theme Editor - Add icon to "Common" subpanel #5403

### DIFF
--- a/source/blender/makesrna/intern/rna_userdef.cc
+++ b/source/blender/makesrna/intern/rna_userdef.cc
@@ -4388,7 +4388,7 @@ static void rna_def_userdef_themes(BlenderRNA *brna)
   static const EnumPropertyItem active_theme_area[] = {
       {0, "USER_INTERFACE", ICON_WORKSPACE, "User Interface", ""},
       {19, "STYLE", ICON_FONTPREVIEW, "Text Style", ""},
-      {25, "COMMON", ICON_NONE, "Common", ""},
+      {25, "COMMON", ICON_COLLAPSEMENU, "Common", ""},
       {24, "ASSET_SHELF", ICON_ASSET_MANAGER, "Asset Shelf", ""},
       {1, "VIEW_3D", ICON_VIEW3D, "3D Viewport", ""},
       {4, "DOPESHEET_EDITOR", ICON_ACTION, "Dope Sheet/Timeline", ""},


### PR DESCRIPTION
<img width="328" height="101" alt="image" src="https://github.com/user-attachments/assets/7e2b3c57-ab6b-4f91-9210-a06ee72514dd" />

Ended up going with `ICON_COLLAPSEMENU`. 
Other options were discussed in #5403.