### PR TITLE
Fix: 5476-mac---missing-function-causing-crash-again

### DIFF
--- a/source/blender/gpu/metal/mtl_shader_generator.mm
+++ b/source/blender/gpu/metal/mtl_shader_generator.mm
@@ -972,6 +972,7 @@ bool MTLShader::generate_msl_from_glsl_compute(const shader::ShaderCreateInfo *i
     ss_compute << ATOMIC_DEFINE_STR;
   }
 
+  generate_specialization_constant_declarations(info, ss_compute);
   generate_compilation_constant_declarations(info, ss_compute);
 
   /* Conditional defines. */


### PR DESCRIPTION
- Readding the function again, this will stop mac from crashing again.

