### PR TITLE
Fix: 5482-outliner---blender-file-mode-could-be-blend-file

### DIFF
--- a/source/blender/makesrna/intern/rna_space.cc
+++ b/source/blender/makesrna/intern/rna_space.cc
@@ -4356,7 +4356,7 @@ static void rna_def_space_outliner(BlenderRNA *brna)
       {SO_LIBRARIES,
        "LIBRARIES",
        ICON_FILE_BLEND,
-       "Blender File",
+       "Blend File", /* BFA - Renamed to Blend File instead. */
        "Display data of current file and linked libraries"},
       {SO_DATA_API,
        "DATA_API",


### PR DESCRIPTION
-- Renamed to Blend File from Blender File.

