### PR TITLE
Sequencer - Remove double Snapping menu #5513

### DIFF
--- a/scripts/startup/bl_ui/space_sequencer.py
+++ b/scripts/startup/bl_ui/space_sequencer.py
@@ -206,16 +206,11 @@ class SEQUENCER_HT_header(Header):
             row = layout.row(align=True)
             row.prop(sequencer_tool_settings, "overlap_mode", text="")
 
-        # if st.view_type in {'SEQUENCER', 'SEQUENCER_PREVIEW'}:
-        row = layout.row(align=True)
-        row.prop(tool_settings, "use_snap_sequencer", text="")
-        sub = row.row(align=True)
-        sub.popover(panel="SEQUENCER_PT_snapping", text="",)  # BFA - removed title
         if st.view_type in {'SEQUENCER', 'SEQUENCER_PREVIEW'}:
             row = layout.row(align=True)
             row.prop(tool_settings, "use_snap_sequencer", text="")
             sub = row.row(align=True)
-            sub.popover(panel="SEQUENCER_PT_snapping")
+            sub.popover(panel="SEQUENCER_PT_snapping", text="")  # BFA - removed title
 
         # layout.separator_spacer()  #BFA
 


### PR DESCRIPTION
Removed duplicated `Snapping` popover panels in the Sequencer header.

| Before | After |
| --- | --- |
| <img width="187" height="75" alt="image" src="https://github.com/user-attachments/assets/a708ae71-f2ab-4334-920e-5ad9391d83a7" /> | <img width="203" height="71" alt="image" src="https://github.com/user-attachments/assets/5930450f-4fef-446f-9d99-b1b1e0ede3d9" /> |

Added back the if-check for {'SEQUENCER', 'SEQUENCER_PREVIEW'}.
Since it doesn't make sense to have strip snapping in `PREVIEW` mode, since that doesn't have sequence strips.
<img width="1099" height="466" alt="image" src="https://github.com/user-attachments/assets/7e3087da-11f1-4c86-8fb1-9d30bccce073" />


