### PR TITLE
Properties Editor - Scene - Simulation - Increase split between simulation range label and toggle #5515

### DIFF
--- a/scripts/startup/bl_ui/properties_scene.py
+++ b/scripts/startup/bl_ui/properties_scene.py
@@ -361,7 +361,7 @@ class SCENE_PT_simulation(SceneButtonsPanel, Panel):
         scene = context.scene
 
         col = layout.column()
-        split = col.split(factor=.4) # BFA
+        split = col.split(factor=.425) # BFA
         split.use_property_split=False
         split.prop(scene, "use_custom_simulation_range", text="Simulation Range")
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="305" height="109" alt="image" src="https://github.com/user-attachments/assets/761a209d-7db3-465b-93b2-62d092238e58" /> | <img width="305" height="113" alt="image" src="https://github.com/user-attachments/assets/b53eeff2-7a2a-4a6c-84d9-d41bfe29fba9" /> |