### PR TITLE
Properties Editor - Output - Color Management Panel - Use Curves float left #5514

### DIFF
--- a/source/blender/editors/interface/templates/interface_template_color_management.cc
+++ b/source/blender/editors/interface/templates/interface_template_color_management.cc
@@ -71,8 +71,8 @@ void uiTemplateColormanagedViewSettings(uiLayout *layout,
   row->prop(&view_transform_ptr, "use_curve_mapping", UI_ITEM_NONE, std::nullopt, ICON_NONE); // bfa - row prop
   if (!(view_settings->flag & COLORMANAGE_VIEW_USE_CURVES)) { // bfa - if unchecked, show icon
     row->label("", ICON_DISCLOSURE_TRI_RIGHT);  // bfa - icon
-  }
-  if (view_settings->flag & COLORMANAGE_VIEW_USE_CURVES) {
+  } else {
+    row->label("", ICON_DISCLOSURE_TRI_DOWN);  // bfa - icon
     uiTemplateCurveMapping(
         col, &view_transform_ptr, "curve_mapping", 'c', true, false, false, false);
   }
@@ -83,8 +83,8 @@ void uiTemplateColormanagedViewSettings(uiLayout *layout,
   row->prop(&view_transform_ptr, "use_white_balance", UI_ITEM_NONE, std::nullopt, ICON_NONE); // bfa - row prop
   if (!(view_settings->flag & COLORMANAGE_VIEW_USE_WHITE_BALANCE)) { // bfa - if unchecked, show icon
     row->label("", ICON_DISCLOSURE_TRI_RIGHT);  // bfa - icon
-  }
-  if (view_settings->flag & COLORMANAGE_VIEW_USE_WHITE_BALANCE) {
+  } else {
+    row->label("", ICON_DISCLOSURE_TRI_DOWN);  // bfa - icon
     col->prop(
         &view_transform_ptr, "white_balance_temperature", UI_ITEM_NONE, std::nullopt, ICON_NONE);
     col->prop(&view_transform_ptr, "white_balance_tint", UI_ITEM_NONE, std::nullopt, ICON_NONE);

--- a/source/blender/editors/interface/templates/interface_template_color_management.cc
+++ b/source/blender/editors/interface/templates/interface_template_color_management.cc
@@ -61,9 +61,11 @@ void uiTemplateColormanagedViewSettings(uiLayout *layout,
   col->prop(&view_transform_ptr, "exposure", UI_ITEM_NONE, std::nullopt, ICON_NONE);
   col->prop(&view_transform_ptr, "gamma", UI_ITEM_NONE, std::nullopt, ICON_NONE);
 
+  // BFA - Align bool properties left
+  col->use_property_split_set(false); 
+
   uiLayout *row = &col->row(false);
   row = &col->row(true); // bfa - our layout
-  row->use_property_decorate_set(false); // bfa - use_property_split = False
   row->separator(); // bfa - Indent
   row->alignment_set(blender::ui::LayoutAlign::Left); // bfa - left align
   row->prop(&view_transform_ptr, "use_curve_mapping", UI_ITEM_NONE, std::nullopt, ICON_NONE); // bfa - row prop
@@ -76,7 +78,6 @@ void uiTemplateColormanagedViewSettings(uiLayout *layout,
   }
 
   row = &col->row(true); // bfa - our layout
-  row->use_property_decorate_set(false); // bfa - use_property_split = False
   row->separator(); // bfa - Indent
   row->alignment_set(blender::ui::LayoutAlign::Left); // bfa - left align
   row->prop(&view_transform_ptr, "use_white_balance", UI_ITEM_NONE, std::nullopt, ICON_NONE); // bfa - row prop


### PR DESCRIPTION
Fixed the alignment of the `Use Curves` and `Use White Balance` properties.
Also added the `ICON_DISCLOSURE_TRI_DOWN` icon when those properties are expanded.

|  | Before | After |
| --- | --- | --- |
| Compact | <img width="300" height="205" alt="image" src="https://github.com/user-attachments/assets/9106cc2e-d198-4b04-aa1a-fe1ec2e0857e" /> | <img width="309" height="236" alt="image" src="https://github.com/user-attachments/assets/9d256e66-4d18-423c-86ac-3247da7a2550" /> |
| Expanded | <img width="308" height="548" alt="image" src="https://github.com/user-attachments/assets/81750497-079a-4e3c-909e-07cf30b55df3" /> | <img width="300" height="545" alt="image" src="https://github.com/user-attachments/assets/8f3d8000-c28c-4f07-a6c6-c2af962db466" /> |