### PR TITLE
Preferences - Make `Corner Handles` and `Numeric Input Arrows` to default to `True`

### DIFF
--- a/source/blender/makesrna/intern/rna_userdef.cc
+++ b/source/blender/makesrna/intern/rna_userdef.cc
@@ -4964,6 +4964,7 @@ static void rna_def_userdef_view(BlenderRNA *brna)
 
   prop = RNA_def_property(srna, "show_number_arrows", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_sdna(prop, nullptr, "uiflag2", USER_ALWAYS_SHOW_NUMBER_ARROWS);
+  RNA_def_property_boolean_default(prop, true);  // BFA - Set default to true
   RNA_def_property_ui_text(
       prop,
       "Show Numeric Input Arrows",

--- a/source/blender/makesrna/intern/rna_userdef.cc
+++ b/source/blender/makesrna/intern/rna_userdef.cc
@@ -4958,6 +4958,7 @@ static void rna_def_userdef_view(BlenderRNA *brna)
 
   prop = RNA_def_property(srna, "show_area_handle", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_sdna(prop, nullptr, "uiflag", USER_AREA_CORNER_HANDLE);
+  RNA_def_property_boolean_default(prop, true);  // BFA - Set default to true
   RNA_def_property_ui_text(prop, "Corner Handles", "Show visible area maintenance corner handles");
   RNA_def_property_update(prop, 0, "rna_userdef_gpu_update");
 


### PR DESCRIPTION
Decided to bundle both in a single PR, just to lessen the stuff to review.
The both require the same code change anyways, so it feels apt to not separate them.