### PR TITLE
Sequencer - Strip Panel - Fix Indentation for "Annotation" and "Transparent" properties #5528

### DIFF
--- a/scripts/startup/bl_ui/space_sequencer.py
+++ b/scripts/startup/bl_ui/space_sequencer.py
@@ -3031,16 +3031,18 @@ class SEQUENCER_PT_scene(SequencerButtonsPanel, Panel):
         if strip.scene_input == 'CAMERA':
             layout = layout.column(align=True)
             layout.label(text="Show")
-            layout.use_property_split = False
+            
+            # BFA - Align bool properties left and indent
             row = layout.row()
             row.separator()
-            layout.prop(strip, "use_annotations", text="Annotations")
+            col = row.column(align=True)
+            col.use_property_split = False
+            
+            col.prop(strip, "use_annotations", text="Annotations")
             if scene:
                 # Warning, this is not a good convention to follow.
                 # Expose here because setting the alpha from the "Render" menu is very inconvenient.
-                row = layout.row()
-                row.separator()
-                row.prop(scene.render, "film_transparent")
+                col.prop(scene.render, "film_transparent")
 
 
 class SEQUENCER_PT_scene_sound(SequencerButtonsPanel, Panel):


### PR DESCRIPTION

| Before | After |
| --- | --- |
| <img width="307" height="193" alt="image" src="https://github.com/user-attachments/assets/2abbc2e8-80fb-479a-8a2a-b5065ca67230" /> | <img width="299" height="182" alt="image" src="https://github.com/user-attachments/assets/f4321ae3-29d1-41bf-9051-1bd1a123d13c" /> |
