### PR TITLE
Properties Editor - Color Management Use White Balance - Split labels from properties #5540

### DIFF
--- a/source/blender/editors/interface/templates/interface_template_color_management.cc
+++ b/source/blender/editors/interface/templates/interface_template_color_management.cc
@@ -85,6 +85,11 @@ void uiTemplateColormanagedViewSettings(uiLayout *layout,
     row->label("", ICON_DISCLOSURE_TRI_RIGHT);  // bfa - icon
   } else {
     row->label("", ICON_DISCLOSURE_TRI_DOWN);  // bfa - icon
+    
+    row = &col->row(true);
+    row->separator(); // bfa - Indent
+    col = &row->column(false);
+    col->use_property_split_set(true); // bfa - split properties
     col->prop(
         &view_transform_ptr, "white_balance_temperature", UI_ITEM_NONE, std::nullopt, ICON_NONE);
     col->prop(&view_transform_ptr, "white_balance_tint", UI_ITEM_NONE, std::nullopt, ICON_NONE);


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="295" height="100" alt="image" src="https://github.com/user-attachments/assets/786af9fe-a991-44bf-b428-d164dee647f7" /> | <img width="299" height="101" alt="image" src="https://github.com/user-attachments/assets/cf292eb6-1a0b-4116-9f71-1296947dac59" /> |