### PR TITLE
Texture Node Editor - Add descriptions to nodes

### DIFF
--- a/source/blender/nodes/texture/nodes/node_texture_at.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_at.cc
@@ -44,6 +44,7 @@ void register_node_type_tex_at()
 
   tex_node_type_base(&ntype, "TextureNodeAt", TEX_NODE_AT);
   ntype.ui_name = "At";
+  ntype.ui_description = "Give the color of a texture at the specified coordinates";
   ntype.enum_name_legacy = "AT";
   ntype.nclass = NODE_CLASS_DISTORT;
   blender::bke::node_type_socket_templates(&ntype, inputs, outputs);

--- a/source/blender/nodes/texture/nodes/node_texture_bricks.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_bricks.cc
@@ -109,6 +109,7 @@ void register_node_type_tex_bricks()
 
   tex_node_type_base(&ntype, "TextureNodeBricks", TEX_NODE_BRICKS);
   ntype.ui_name = "Bricks";
+  ntype.ui_description = "Generate a procedural texture producing bricks";
   ntype.enum_name_legacy = "BRICKS";
   ntype.nclass = NODE_CLASS_PATTERN;
   blender::bke::node_type_socket_templates(&ntype, inputs, outputs);

--- a/source/blender/nodes/texture/nodes/node_texture_checker.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_checker.cc
@@ -56,6 +56,7 @@ void register_node_type_tex_checker()
 
   tex_node_type_base(&ntype, "TextureNodeChecker", TEX_NODE_CHECKER);
   ntype.ui_name = "Checker";
+  ntype.ui_description = "Generate a checkerboard texture";
   ntype.enum_name_legacy = "CHECKER";
   ntype.nclass = NODE_CLASS_PATTERN;
   blender::bke::node_type_socket_templates(&ntype, inputs, outputs);

--- a/source/blender/nodes/texture/nodes/node_texture_combine_color.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_combine_color.cc
@@ -70,6 +70,7 @@ void register_node_type_tex_combine_color()
 
   tex_node_type_base(&ntype, "TextureNodeCombineColor", TEX_NODE_COMBINE_COLOR);
   ntype.ui_name = "Combine Color";
+  ntype.ui_description = "Combine four channels into one color, based on a particular color model";
   ntype.enum_name_legacy = "COMBINE_COLOR";
   ntype.nclass = NODE_CLASS_OP_COLOR;
   blender::bke::node_type_socket_templates(&ntype, inputs, outputs);

--- a/source/blender/nodes/texture/nodes/node_texture_coord.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_coord.cc
@@ -36,6 +36,7 @@ void register_node_type_tex_coord()
 
   tex_node_type_base(&ntype, "TextureNodeCoordinates", TEX_NODE_COORD);
   ntype.ui_name = "Coordinates";
+  ntype.ui_description = "Output the local geometry coordinates, relative to the bounding box";
   ntype.enum_name_legacy = "COORD";
   ntype.nclass = NODE_CLASS_INPUT;
   blender::bke::node_type_socket_templates(&ntype, nullptr, outputs);

--- a/source/blender/nodes/texture/nodes/node_texture_curves.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_curves.cc
@@ -56,6 +56,7 @@ void register_node_type_tex_curve_time()
 
   tex_node_type_base(&ntype, "TextureNodeCurveTime", TEX_NODE_CURVE_TIME);
   ntype.ui_name = "Time";
+  ntype.ui_description = "Generate a factor value (from 0.0 to 1.0) between the scene start and end time, using a curve mapping";
   ntype.enum_name_legacy = "CURVE_TIME";
   ntype.nclass = NODE_CLASS_INPUT;
   blender::bke::node_type_socket_templates(&ntype, nullptr, time_outputs);
@@ -109,6 +110,7 @@ void register_node_type_tex_curve_rgb()
 
   tex_node_type_base(&ntype, "TextureNodeCurveRGB", TEX_NODE_CURVE_RGB);
   ntype.ui_name = "RGB Curves";
+  ntype.ui_description = "Apply color corrections for each color channel";
   ntype.enum_name_legacy = "CURVE_RGB";
   ntype.nclass = NODE_CLASS_OP_COLOR;
   blender::bke::node_type_socket_templates(&ntype, rgb_inputs, rgb_outputs);

--- a/source/blender/nodes/texture/nodes/node_texture_distance.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_distance.cc
@@ -46,6 +46,7 @@ void register_node_type_tex_distance()
 
   tex_node_type_base(&ntype, "TextureNodeDistance", TEX_NODE_DISTANCE);
   ntype.ui_name = "Distance";
+  ntype.ui_description = "Compute the distance between two 3D coordinates";
   ntype.enum_name_legacy = "DISTANCE";
   ntype.nclass = NODE_CLASS_CONVERTER;
   blender::bke::node_type_socket_templates(&ntype, inputs, outputs);

--- a/source/blender/nodes/texture/nodes/node_texture_hueSatVal.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_hueSatVal.cc
@@ -95,6 +95,7 @@ void register_node_type_tex_hue_sat()
 
   tex_node_type_base(&ntype, "TextureNodeHueSaturation", TEX_NODE_HUE_SAT);
   ntype.ui_name = "Hue/Saturation/Value";
+  ntype.ui_description = "Apply a color transformation in the HSV color model";
   ntype.enum_name_legacy = "HUE_SAT";
   ntype.nclass = NODE_CLASS_OP_COLOR;
   blender::bke::node_type_socket_templates(&ntype, inputs, outputs);

--- a/source/blender/nodes/texture/nodes/node_texture_image.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_image.cc
@@ -101,6 +101,7 @@ void register_node_type_tex_image()
 
   tex_node_type_base(&ntype, "TextureNodeImage", TEX_NODE_IMAGE);
   ntype.ui_name = "Image";
+  ntype.ui_description = "Load an external image";
   ntype.enum_name_legacy = "IMAGE";
   ntype.nclass = NODE_CLASS_INPUT;
   blender::bke::node_type_socket_templates(&ntype, nullptr, outputs);

--- a/source/blender/nodes/texture/nodes/node_texture_invert.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_invert.cc
@@ -50,6 +50,7 @@ void register_node_type_tex_invert()
 
   tex_node_type_base(&ntype, "TextureNodeInvert", TEX_NODE_INVERT);
   ntype.ui_name = "Invert Color";
+  ntype.ui_description = "Invert colors, producing a negative";
   ntype.enum_name_legacy = "INVERT";
   ntype.nclass = NODE_CLASS_OP_COLOR;
   blender::bke::node_type_socket_templates(&ntype, inputs, outputs);

--- a/source/blender/nodes/texture/nodes/node_texture_math.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_math.cc
@@ -333,6 +333,7 @@ void register_node_type_tex_math()
 
   tex_node_type_base(&ntype, "TextureNodeMath", TEX_NODE_MATH);
   ntype.ui_name = "Math";
+  ntype.ui_description = "Perform math operations";
   ntype.enum_name_legacy = "MATH";
   ntype.nclass = NODE_CLASS_CONVERTER;
   blender::bke::node_type_socket_templates(&ntype, inputs, outputs);

--- a/source/blender/nodes/texture/nodes/node_texture_mixRgb.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_mixRgb.cc
@@ -60,6 +60,7 @@ void register_node_type_tex_mix_rgb()
 
   tex_node_type_base(&ntype, "TextureNodeMixRGB", TEX_NODE_MIX_RGB);
   ntype.ui_name = "Mix";
+  ntype.ui_description = "Mix two colors by a factor";
   ntype.enum_name_legacy = "MIX_RGB";
   ntype.nclass = NODE_CLASS_OP_COLOR;
   blender::bke::node_type_socket_templates(&ntype, inputs, outputs);

--- a/source/blender/nodes/texture/nodes/node_texture_output.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_output.cc
@@ -140,6 +140,7 @@ void register_node_type_tex_output()
 
   tex_node_type_base(&ntype, "TextureNodeOutput", TEX_NODE_OUTPUT);
   ntype.ui_name = "Output";
+  ntype.ui_description = "Specify the target texture output";
   ntype.enum_name_legacy = "OUTPUT";
   ntype.nclass = NODE_CLASS_OUTPUT;
   blender::bke::node_type_socket_templates(&ntype, inputs, nullptr);

--- a/source/blender/nodes/texture/nodes/node_texture_proc.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_proc.cc
@@ -251,13 +251,14 @@ static void init(bNodeTree * /*ntree*/, bNode *node)
 }
 
 /* Node type definitions */
-#define TexDef(TEXTYPE, idname, outputs, name, Name, EnumNameLegacy) \
+#define TexDef(TEXTYPE, idname, outputs, name, Name, EnumNameLegacy, Description) \
   void register_node_type_tex_proc_##name(void) \
   { \
     static blender::bke::bNodeType ntype; \
 \
     tex_node_type_base(&ntype, idname, TEX_NODE_PROC + TEXTYPE); \
     ntype.ui_name = Name; \
+    ntype.ui_description = Description; \
     ntype.enum_name_legacy = EnumNameLegacy; \
     ntype.nclass = NODE_CLASS_TEXTURE; \
     blender::bke::node_type_socket_templates(&ntype, name##_inputs, outputs); \
@@ -274,14 +275,13 @@ static void init(bNodeTree * /*ntree*/, bNode *node)
 #define C outputs_color_only
 #define CV outputs_both
 
-TexDef(TEX_VORONOI, "TextureNodeTexVoronoi", CV, voronoi, "Voronoi", "TEX_VORONOI");
-TexDef(TEX_BLEND, "TextureNodeTexBlend", C, blend, "Blend", "TEX_BLEND");
-TexDef(TEX_MAGIC, "TextureNodeTexMagic", C, magic, "Magic", "TEX_MAGIC");
-TexDef(TEX_MARBLE, "TextureNodeTexMarble", CV, marble, "Marble", "TEX_MARBLE");
-TexDef(TEX_CLOUDS, "TextureNodeTexClouds", CV, clouds, "Clouds", "TEX_CLOUDS");
-TexDef(TEX_WOOD, "TextureNodeTexWood", CV, wood, "Wood", "TEX_WOOD");
-TexDef(TEX_MUSGRAVE, "TextureNodeTexMusgrave", CV, musgrave, "Musgrave", "TEX_MUSGRAVE");
-TexDef(TEX_NOISE, "TextureNodeTexNoise", C, noise, "Noise", "TEX_NOISE");
-TexDef(TEX_STUCCI, "TextureNodeTexStucci", CV, stucci, "Stucci", "TEX_STUCCI");
-TexDef(
-    TEX_DISTNOISE, "TextureNodeTexDistNoise", CV, distnoise, "Distorted Noise", "TEX_DISTNOISE");
+TexDef(TEX_VORONOI, "TextureNodeTexVoronoi", CV, voronoi, "Voronoi", "TEX_VORONOI", "Generate Worley noise based on the distance to random points");
+TexDef(TEX_BLEND, "TextureNodeTexBlend", C, blend, "Blend", "TEX_BLEND", "Generate a smoothly interpolated progression");
+TexDef(TEX_MAGIC, "TextureNodeTexMagic", C, magic, "Magic", "TEX_MAGIC", "Generate a psychedelic color texture");
+TexDef(TEX_MARBLE, "TextureNodeTexMarble", CV, marble, "Marble", "TEX_MARBLE", "Generate marble-like bands based on the sine, saw, or triangular formula and noise turbulence");
+TexDef(TEX_CLOUDS, "TextureNodeTexClouds", CV, clouds, "Clouds", "TEX_CLOUDS", "Generate fractal Perlin noise");
+TexDef(TEX_WOOD, "TextureNodeTexWood", CV, wood, "Wood", "TEX_WOOD", "Generate wood and ring-shaped patterns");
+TexDef(TEX_MUSGRAVE, "TextureNodeTexMusgrave", CV, musgrave, "Musgrave", "TEX_MUSGRAVE", "Generate a flexible fractal noise based on the specified mode");
+TexDef(TEX_NOISE, "TextureNodeTexNoise", C, noise, "Noise", "TEX_NOISE", "Generate a random color based on an input seed");
+TexDef(TEX_STUCCI, "TextureNodeTexStucci", CV, stucci, "Stucci", "TEX_STUCCI", "Generate noise characterized by multiple tiny bumps, resembling stucco");
+TexDef(TEX_DISTNOISE, "TextureNodeTexDistNoise", CV, distnoise, "Distorted Noise", "TEX_DISTNOISE", "Generate a hybrid pattern where one noise texture is distorted by another");

--- a/source/blender/nodes/texture/nodes/node_texture_rotate.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_rotate.cc
@@ -77,6 +77,7 @@ void register_node_type_tex_rotate()
 
   tex_node_type_base(&ntype, "TextureNodeRotate", TEX_NODE_ROTATE);
   ntype.ui_name = "Rotate";
+  ntype.ui_description = "Rotate the texture coordinates of an image or texture";
   ntype.enum_name_legacy = "ROTATE";
   ntype.nclass = NODE_CLASS_DISTORT;
   blender::bke::node_type_socket_templates(&ntype, inputs, outputs);

--- a/source/blender/nodes/texture/nodes/node_texture_scale.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_scale.cc
@@ -52,6 +52,7 @@ void register_node_type_tex_scale()
 
   tex_node_type_base(&ntype, "TextureNodeScale", TEX_NODE_SCALE);
   ntype.ui_name = "Scale";
+  ntype.ui_description = "Scale the texture coordinates of an image or texture";
   ntype.enum_name_legacy = "SCALE";
   ntype.nclass = NODE_CLASS_DISTORT;
   blender::bke::node_type_socket_templates(&ntype, inputs, outputs);

--- a/source/blender/nodes/texture/nodes/node_texture_separate_color.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_separate_color.cc
@@ -96,6 +96,7 @@ void register_node_type_tex_separate_color()
 
   tex_node_type_base(&ntype, "TextureNodeSeparateColor", TEX_NODE_SEPARATE_COLOR);
   ntype.ui_name = "Separate Color";
+  ntype.ui_description = "Split a color into separate channels, based on a particular color model";
   ntype.enum_name_legacy = "SEPARATE_COLOR";
   ntype.nclass = NODE_CLASS_OP_COLOR;
   blender::bke::node_type_socket_templates(&ntype, inputs, outputs);

--- a/source/blender/nodes/texture/nodes/node_texture_texture.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_texture.cc
@@ -77,6 +77,7 @@ void register_node_type_tex_texture()
 
   tex_node_type_base(&ntype, "TextureNodeTexture", TEX_NODE_TEXTURE);
   ntype.ui_name = "Texture";
+  ntype.ui_description = "Load another node-based or non-node-based texture";
   ntype.enum_name_legacy = "TEXTURE";
   ntype.nclass = NODE_CLASS_INPUT;
   blender::bke::node_type_socket_templates(&ntype, inputs, outputs);

--- a/source/blender/nodes/texture/nodes/node_texture_translate.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_translate.cc
@@ -49,6 +49,7 @@ void register_node_type_tex_translate()
 
   tex_node_type_base(&ntype, "TextureNodeTranslate", TEX_NODE_TRANSLATE);
   ntype.ui_name = "Translate";
+  ntype.ui_description = "Translate the texture coordinates of an image or texture";
   ntype.enum_name_legacy = "TRANSLATE";
   ntype.nclass = NODE_CLASS_DISTORT;
   blender::bke::node_type_socket_templates(&ntype, inputs, outputs);

--- a/source/blender/nodes/texture/nodes/node_texture_valToNor.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_valToNor.cc
@@ -66,6 +66,7 @@ void register_node_type_tex_valtonor()
 
   tex_node_type_base(&ntype, "TextureNodeValToNor", TEX_NODE_VALTONOR);
   ntype.ui_name = "Value to Normal";
+  ntype.ui_description = "Compute a normal map from the given black-and-white values";
   ntype.enum_name_legacy = "VALTONOR";
   ntype.nclass = NODE_CLASS_CONVERTER;
   blender::bke::node_type_socket_templates(&ntype, inputs, outputs);

--- a/source/blender/nodes/texture/nodes/node_texture_valToRgb.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_valToRgb.cc
@@ -51,6 +51,7 @@ void register_node_type_tex_valtorgb()
 
   tex_node_type_base(&ntype, "TextureNodeValToRGB", TEX_NODE_VALTORGB);
   ntype.ui_name = "Color Ramp";
+  ntype.ui_description = "Map values to colors with the use of a gradient";
   ntype.enum_name_legacy = "VALTORGB";
   ntype.nclass = NODE_CLASS_CONVERTER;
   blender::bke::node_type_socket_templates(&ntype, valtorgb_in, valtorgb_out);
@@ -97,6 +98,7 @@ void register_node_type_tex_rgbtobw()
 
   tex_node_type_base(&ntype, "TextureNodeRGBToBW", TEX_NODE_RGBTOBW);
   ntype.ui_name = "RGB to BW";
+  ntype.ui_description = "Convert RGB input into grayscale using luminance";
   ntype.enum_name_legacy = "RGBTOBW";
   ntype.nclass = NODE_CLASS_CONVERTER;
   blender::bke::node_type_socket_templates(&ntype, rgbtobw_in, rgbtobw_out);

--- a/source/blender/nodes/texture/nodes/node_texture_viewer.cc
+++ b/source/blender/nodes/texture/nodes/node_texture_viewer.cc
@@ -37,6 +37,7 @@ void register_node_type_tex_viewer()
 
   tex_node_type_base(&ntype, "TextureNodeViewer", TEX_NODE_VIEWER);
   ntype.ui_name = "Viewer";
+  ntype.ui_description = "Preview the results of the connected output";
   ntype.enum_name_legacy = "VIEWER";
   ntype.nclass = NODE_CLASS_OUTPUT;
   blender::bke::node_type_socket_templates(&ntype, inputs, nullptr);


### PR DESCRIPTION
Adds descriptions to Texture Nodes, which are missing from https://projects.blender.org/blender/blender/pulls/145772.

Related Task: https://github.com/Bforartists/Bforartists/issues/5288 
Note: This patch only partially addresses it, don't close the issue until the change from Blender main is also merged.