### PR TITLE
Grease Pencil Edit mode - Stroke menu - Simplify Stroke - separate tooltips #5314

### DIFF
--- a/source/blender/editors/grease_pencil/intern/grease_pencil_edit.cc
+++ b/source/blender/editors/grease_pencil/intern/grease_pencil_edit.cc
@@ -397,6 +397,23 @@ static void grease_pencil_simplify_ui(bContext *C, wmOperator *op)
   }
 }
 
+/* BFA - Make "Simplify Stroke" description dynamic*/
+/* It uses the mode's description if that was set, otherwise use the operator description is fallback */
+static std::string simplify_strokes_description(bContext * /* C */,
+                                                wmOperatorType *ot,
+                                                PointerRNA *ptr)
+{
+  PropertyRNA *prop = RNA_struct_find_property(ptr, "mode");
+
+  if (RNA_property_is_set(ptr, prop)) {
+    const int mode = RNA_property_enum_get(ptr, prop);
+    return std::string(prop_simplify_modes[mode].description);
+  }
+  else {
+    return std::string(ot->description);
+  }
+}
+
 static void GREASE_PENCIL_OT_stroke_simplify(wmOperatorType *ot)
 {
   PropertyRNA *prop;
@@ -404,6 +421,8 @@ static void GREASE_PENCIL_OT_stroke_simplify(wmOperatorType *ot)
   ot->name = "Simplify Stroke";
   ot->idname = "GREASE_PENCIL_OT_stroke_simplify";
   ot->description = "Simplify selected strokes";
+  ot->get_description =
+      simplify_strokes_description; /* BFA - Generate description from 'mode' property*/
 
   ot->exec = grease_pencil_stroke_simplify_exec;
   ot->poll = editable_grease_pencil_poll;


### PR DESCRIPTION
Use `get_description` to use the `mode's` description, if that property is set.
Otherwise, use the operator's description as fallback.

|  | Before | After |
| --- | --- | --- |
| Unspecified | <img width="366" height="68" alt="image" src="https://github.com/user-attachments/assets/f1260100-ea72-4ebe-936b-3d1e73cebcde" /> | <img width="363" height="66" alt="image" src="https://github.com/user-attachments/assets/c5d689a1-6443-488c-8c8b-78d887185214" /> |
| Fixed | <img width="444" height="62" alt="image" src="https://github.com/user-attachments/assets/1f9f09a0-16f3-475c-bc0c-546e4de9816b" /> | <img width="447" height="66" alt="image" src="https://github.com/user-attachments/assets/71defa79-2626-4592-bd04-6e81e290af00" /> |
| Adaptive | <img width="472" height="74" alt="image" src="https://github.com/user-attachments/assets/7076d427-3715-4437-8a25-2aeea28f3c78" /> | <img width="492" height="69" alt="image" src="https://github.com/user-attachments/assets/101d84b0-30ef-4928-9499-11e43a4ef4c9" /> |
| Sample | <img width="458" height="69" alt="image" src="https://github.com/user-attachments/assets/889bbf10-d5ac-4f0b-be08-27883a4b8faa" /> | <img width="456" height="68" alt="image" src="https://github.com/user-attachments/assets/4cfc0414-f2a4-4510-9060-526e47031d31" /> |
| Merge | <img width="449" height="73" alt="image" src="https://github.com/user-attachments/assets/82df01d6-fe5e-4594-976e-1377672222b1" /> | <img width="449" height="69" alt="image" src="https://github.com/user-attachments/assets/9700806a-efd4-450e-938a-4e40585bba2b" /> |