### PR TITLE
Fix #5554: Disable Material icon rendering causes crash through asset shelf

### DIFF
--- a/source/blender/editors/interface/interface_icons.cc
+++ b/source/blender/editors/interface/interface_icons.cc
@@ -1339,10 +1339,6 @@ static void icon_set_image(const bContext *C,
                            enum eIconSizes size,
                            const bool use_job)
 {
-  /* bfa - disable material icons rendering */
-  if (U.flag & USER_DISABLE_MATERIAL_ICON && GS(id->name) == ID_MA) {
-    return;
-  }
   if (!prv_img) {
     if (G.debug & G_DEBUG) {
       CLOG_WARN(&LOG, "%s: no preview image for this ID: %s", __func__, id->name);


### PR DESCRIPTION
This causes asset shelf material preview display to not render and crash

Resolve: #5554 