### PR TITLE
Sequencer - Hard crash when switching to the sequencer (timeline gridcan't draw due to bad scene context) #5565

### DIFF
--- a/source/blender/editors/space_sequencer/sequencer_timeline_draw.cc
+++ b/source/blender/editors/space_sequencer/sequencer_timeline_draw.cc
@@ -1826,11 +1826,13 @@ static void draw_timeline_grid(TimelineDrawContext *ctx)
   {
     return;
   }
-
-  U.v2d_min_gridsize *= 3;
-  UI_view2d_draw_lines_x__discrete_frames_or_seconds(
-      ctx->v2d, ctx->scene, (ctx->sseq->flag & SEQ_DRAWFRAMES) == 0, false);
-  U.v2d_min_gridsize /= 3;
+  /* BFA - added scene context to make the timeline grid draw more robust when switching to the Sequencer editor*/
+  if (ctx->scene) {
+    U.v2d_min_gridsize *= 3;
+    UI_view2d_draw_lines_x__discrete_frames_or_seconds(
+        ctx->v2d, ctx->scene, (ctx->sseq->flag & SEQ_DRAWFRAMES) == 0, false);
+    U.v2d_min_gridsize /= 3;
+  }
 }
 
 static void draw_timeline_markers(TimelineDrawContext *ctx)

--- a/source/blender/editors/space_sequencer/sequencer_timeline_draw.cc
+++ b/source/blender/editors/space_sequencer/sequencer_timeline_draw.cc
@@ -1826,13 +1826,18 @@ static void draw_timeline_grid(TimelineDrawContext *ctx)
   {
     return;
   }
-  /* BFA - added scene context to make the timeline grid draw more robust when switching to the Sequencer editor*/
-  if (ctx->scene) {
-    U.v2d_min_gridsize *= 3;
-    UI_view2d_draw_lines_x__discrete_frames_or_seconds(
-        ctx->v2d, ctx->scene, (ctx->sseq->flag & SEQ_DRAWFRAMES) == 0, false);
-    U.v2d_min_gridsize /= 3;
+
+  U.v2d_min_gridsize *= 3;
+
+  const Scene *scene = ctx->scene;
+  if (scene == nullptr) {
+    /* If we don't have a scene available, pick what we defined as default for framerate to show
+     * *something*. */
+    scene = DNA_struct_default_get(Scene);
   }
+  UI_view2d_draw_lines_x__discrete_frames_or_seconds(
+      ctx->v2d, scene, (ctx->sseq->flag & SEQ_DRAWFRAMES) == 0, false);
+  U.v2d_min_gridsize /= 3;
 }
 
 static void draw_timeline_markers(TimelineDrawContext *ctx)

--- a/source/blender/editors/space_sequencer/sequencer_timeline_draw.cc
+++ b/source/blender/editors/space_sequencer/sequencer_timeline_draw.cc
@@ -1826,18 +1826,14 @@ static void draw_timeline_grid(TimelineDrawContext *ctx)
   {
     return;
   }
-
-  U.v2d_min_gridsize *= 3;
-
-  const Scene *scene = ctx->scene;
-  if (scene == nullptr) {
-    /* If we don't have a scene available, pick what we defined as default for framerate to show
-     * *something*. */
-    scene = DNA_struct_default_get(Scene);
+  /* BFA - WIP - TODO: added scene context to make the timeline grid draw more robust when switching to the Sequencer editor*/
+  /* BFA - Blender has a solution for this but needs more depednencies, so this fix is temporary*/
+  if (ctx->scene) {
+    U.v2d_min_gridsize *= 3;
+    UI_view2d_draw_lines_x__discrete_frames_or_seconds(
+        ctx->v2d, ctx->scene, (ctx->sseq->flag & SEQ_DRAWFRAMES) == 0, false);
+    U.v2d_min_gridsize /= 3;
   }
-  UI_view2d_draw_lines_x__discrete_frames_or_seconds(
-      ctx->v2d, scene, (ctx->sseq->flag & SEQ_DRAWFRAMES) == 0, false);
-  U.v2d_min_gridsize /= 3;
 }
 
 static void draw_timeline_markers(TimelineDrawContext *ctx)


### PR DESCRIPTION
Added a scene context to make the sequencer timeline grid more stable and not draw when empty. Since we start our default on empty.

This is a temporary fix for the developer build. Next merge should have a better solution. 