### PR TITLE
Brush Settings - Fix inconsistency in drawing `use_locked_size` property #5568

### DIFF
--- a/scripts/startup/bl_ui/properties_paint_common.py
+++ b/scripts/startup/bl_ui/properties_paint_common.py
@@ -1339,7 +1339,7 @@ def brush_shared_settings(layout, context, brush, popover=False):
             if brush.use_pressure_size:
                 layout.template_curve_mapping(brush, "curve_size", brush=True)
         if size_mode:
-            layout.row().prop(size_owner, "use_locked_size", expand=False)  # BFA
+            layout.row().prop(size_owner, "use_locked_size", expand=True)
             layout.separator()
 
     if strength:


### PR DESCRIPTION
This fixes inconsistencies between how the `use_locked_size` brush setting in drawn in different contexts.

| Grease Pencil (Draw Mode) | Mesh (Sculpt Mode) - Before | Mesh (Sculpt Mode) - After |
| --- | --- | --- |
| <img width="250" height="80" alt="Image" src="https://github.com/user-attachments/assets/0044b997-1e93-48a6-a9e6-53dcc832f1cd" /> | <img width="259" height="153" alt="Image" src="https://github.com/user-attachments/assets/ecc10ab8-9225-4599-a1fe-ce8bd7dd51ff" /> | <img width="240" height="137" alt="image" src="https://github.com/user-attachments/assets/6460a21e-93e3-46e6-9ff7-ac0fa8c7a48f" /> |

This should also alleviate inconsistencies in addons like Paint System when used in Blender vs BFA.
| Blender | BFA - Before | BFA - After |
| --- | --- | --- |
| <img width="229" height="190" alt="image" src="https://github.com/user-attachments/assets/6b82bbc5-b650-4e5a-9ce0-c879405bfc67" /> | <img width="233" height="192" alt="image" src="https://github.com/user-attachments/assets/aaaedc4c-14eb-4682-95cc-e6953afe7e1b" /> | <img width="236" height="203" alt="image" src="https://github.com/user-attachments/assets/109db7ac-91ba-46d7-ac1c-01f88a265c8f" /> |