### PR TITLE
Mesh Edit Mode - Mesh > Transform - "Set Dimensions" addon operator throws error #5591

### DIFF
--- a/scripts/addons_core/edit_dimensions.py
+++ b/scripts/addons_core/edit_dimensions.py
@@ -120,7 +120,14 @@ class ED_OT_SetDimensions(Operator):
         box.prop(self, "new_z")
 
 
-def add_button(self, context):
+# BFA - Use different draw functions for menu & panel
+def add_button_to_menu(self, context):
+    if context.mode in {'EDIT_MESH'}:
+        self.layout.operator(ED_OT_SetDimensions.bl_idname, icon="PLUGIN")
+
+
+# BFA - Use different draw functions for menu & panel
+def add_button_to_panel(self, context):
     layout = self.layout
     row = layout.row(align=True)
     row.scale_x = 2
@@ -143,16 +150,16 @@ def register():
     from bpy.utils import register_class
     for cls in classes:
        register_class(cls)
-    bpy.types.VIEW3D_MT_transform.append(add_button)
-    bpy.types.VIEW3D_PT_objecttab_transform.append(add_button)
+    bpy.types.VIEW3D_MT_transform.append(add_button_to_menu)
+    bpy.types.VIEW3D_PT_objecttab_transform.append(add_button_to_panel)
 
 
 def unregister():
     from bpy.utils import unregister_class
     for cls in classes:
        unregister_class(cls)
-    bpy.types.VIEW3D_MT_transform.remove(add_button)
-    bpy.types.VIEW3D_PT_objecttab_transform.remove(add_button)
+    bpy.types.VIEW3D_MT_transform.remove(add_button_to_menu)
+    bpy.types.VIEW3D_PT_objecttab_transform.remove(add_button_to_panel)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The error is caused by the draw function using a panel method in a menu, a problem caused by the `draw` function being shared by both. This patch separates them, allowing both to be drawn correctly.

<img width="260" height="330" alt="image" src="https://github.com/user-attachments/assets/e4728744-061a-430b-804c-288da9d8517c" />
<img width="357" height="307" alt="image" src="https://github.com/user-attachments/assets/2634ef36-a6c0-41de-b02a-0436a3661917" />
