### PR TITLE
Asset Shelf : Add Pack import method to asset shelf

### DIFF
--- a/source/blender/editors/asset/intern/asset_shelf.cc
+++ b/source/blender/editors/asset/intern/asset_shelf.cc
@@ -874,8 +874,9 @@ static void asset_shelf_header_draw(const bContext *C, Header *header)
             row->prop(&shelf_ptr, "drop_instances_to_origin", UI_ITEM_NONE, "", ICON_CENTER);
           }
           break;
-        case FILE_ASSET_IMPORT_APPEND:
-        case FILE_ASSET_IMPORT_APPEND_REUSE:
+        case SHELF_ASSET_IMPORT_APPEND:
+        case SHELF_ASSET_IMPORT_APPEND_REUSE:
+        case SHELF_ASSET_IMPORT_PACK:
           {
             uiLayout *row = &layout->row(true);
             row->prop(&shelf_ptr, "instance_collections_on_append", UI_ITEM_NONE, "", ICON_OUTLINER_OB_GROUP_INSTANCE);

--- a/source/blender/editors/space_view3d/view3d_dropboxes.cc
+++ b/source/blender/editors/space_view3d/view3d_dropboxes.cc
@@ -404,9 +404,6 @@ static void view3d_ob_drop_copy_external_asset(bContext *C, wmDrag *drag, wmDrop
   if (use_override) {  
     ID *owner_id = id; 
     ID *id_or = id;
-    /* BFA - WIP - removed for warning?*/
-    //PointerRNA owner_ptr;
-    //PropertyRNA *prop;
     if (!ELEM(nullptr, owner_id, id_or)) {
       id = ui_template_id_liboverride_hierarchy_make(
       C, CTX_data_main(C), owner_id, id_or, nullptr);

--- a/source/blender/makesdna/DNA_screen_types.h
+++ b/source/blender/makesdna/DNA_screen_types.h
@@ -900,8 +900,13 @@ typedef enum AssetShelfImportMethod {
    * heavy data dependencies (e.g. the image data-blocks of a material, the mesh of an object) may
    * be reused from an earlier append. */
   SHELF_ASSET_IMPORT_APPEND_REUSE = 2,
-  /** Default: Follow the preference setting for this asset library. */
-  SHELF_ASSET_IMPORT_LINK_OVERRIDE = 3,
+  /**
+   * Link the data-block, but also pack it in the current file to keep it working even if the
+   * source file is not available anymore.
+   */
+  SHELF_ASSET_IMPORT_PACK = 3,
+  /** BFA only data-block linking with make override. */
+  SHELF_ASSET_IMPORT_LINK_OVERRIDE = 4,
 } AssetShelfImportMethod;
 
 // See eFileAssetImportFlags

--- a/source/blender/makesrna/intern/rna_space.cc
+++ b/source/blender/makesrna/intern/rna_space.cc
@@ -395,12 +395,6 @@ static const EnumPropertyItem rna_enum_asset_import_method_items[] = {
      "typically heavy data. For example the textures of a material asset, or the mesh of an "
      "object asset, don't have to be copied every time this asset is imported. The instances of "
      "the asset share the data instead"},
-    // BFA only file asset browser link override
-    {FILE_ASSET_IMPORT_LINK_OVERRIDE,
-      "LINK_OVERRIDE",
-      ICON_LIBRARY_DATA_OVERRIDE,
-      "Link (Override)",
-      "Import the assets as linked library overrided data.\nThis will only override the active hierarchy.\nTo override all selected contents, use the Outliner Editor"},
     {FILE_ASSET_IMPORT_PACK,
      "PACK",
      ICON_PACKAGE,

--- a/source/blender/makesrna/intern/rna_space.cc
+++ b/source/blender/makesrna/intern/rna_space.cc
@@ -401,6 +401,12 @@ static const EnumPropertyItem rna_enum_asset_import_method_items[] = {
      "Pack",
      "Import the asset as linked data-block, and pack it in the current file (ensures that it "
      "remains unchanged in case the library data is modified, is not available anymore, etc.)"},
+    // BFA only file asset browser link override
+    {FILE_ASSET_IMPORT_LINK_OVERRIDE,
+     "LINK_OVERRIDE",
+      ICON_LIBRARY_DATA_OVERRIDE,
+      "Link (Override)",
+      "Import the assets as linked library overrided data.\nThis will only override the active hierarchy.\nTo override all selected contents, use the Outliner Editor"},
     {0, nullptr, 0, nullptr, nullptr},
 };
 

--- a/source/blender/makesrna/intern/rna_ui.cc
+++ b/source/blender/makesrna/intern/rna_ui.cc
@@ -74,7 +74,7 @@ static const EnumPropertyItem asset_shelf_import_method_items[] = {
       "typically heavy data. For example the textures of a material asset, or the mesh of an "
       "object asset, don't have to be copied every time this asset is imported. The instances of "
       "the asset share the data instead"},
-      {FILE_ASSET_IMPORT_PACK,
+    {SHELF_ASSET_IMPORT_PACK,
       "PACK",
       ICON_PACKAGE,
       "Pack",

--- a/source/blender/makesrna/intern/rna_ui.cc
+++ b/source/blender/makesrna/intern/rna_ui.cc
@@ -54,7 +54,7 @@ const EnumPropertyItem rna_enum_uilist_layout_type_items[] = {
     {0, nullptr, 0, nullptr, nullptr},
 };
 
-// bfa start asset shelf
+// bfa asset shelf import method
 static const EnumPropertyItem asset_shelf_import_method_items[] = {
     {SHELF_ASSET_IMPORT_LINK,
       "LINK",
@@ -2550,7 +2550,7 @@ static void rna_def_asset_shelf(BlenderRNA *brna)
   RNA_def_property_ui_text(prop, "Display Filter", "Filter assets by name");
   RNA_def_property_flag(prop, PROP_TEXTEDIT_UPDATE);
   RNA_def_property_update(prop, NC_SPACE | ND_REGIONS_ASSET_SHELF, nullptr);
-
+  // bfa start asset shelf
   prop = RNA_def_property(srna, "import_method", PROP_ENUM, PROP_NONE);
   RNA_def_property_enum_items(prop, asset_shelf_import_method_items);
   RNA_def_property_enum_funcs(
@@ -2559,6 +2559,7 @@ static void rna_def_asset_shelf(BlenderRNA *brna)
   RNA_def_property_ui_text(prop, "Import Method", "Determines how the asset will be imported");
   RNA_def_property_update(prop, NC_SPACE | ND_REGIONS_ASSET_SHELF, nullptr);
   RNA_def_property_enum_default(prop, SHELF_ASSET_IMPORT_APPEND);
+  // bfa end
 
   prop = RNA_def_property(srna, "instance_collections_on_link", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_sdna(

--- a/source/blender/makesrna/intern/rna_ui.cc
+++ b/source/blender/makesrna/intern/rna_ui.cc
@@ -54,6 +54,40 @@ const EnumPropertyItem rna_enum_uilist_layout_type_items[] = {
     {0, nullptr, 0, nullptr, nullptr},
 };
 
+// bfa start asset shelf
+static const EnumPropertyItem asset_shelf_import_method_items[] = {
+    {SHELF_ASSET_IMPORT_LINK,
+      "LINK",
+      ICON_LINK_BLEND,
+      "Link",
+      "Import the assets as linked data"},
+    {SHELF_ASSET_IMPORT_APPEND,
+      "APPEND",
+      ICON_APPEND_BLEND,
+      "Append",
+      "Import the assets as copied data, with no link to the original asset data"},
+    {SHELF_ASSET_IMPORT_APPEND_REUSE,
+      "APPEND_REUSE",
+      ICON_FILE_BLEND,
+      "Append (Reuse Data)",
+      "Import the assets as copied data while avoiding multiple copies of nested, "
+      "typically heavy data. For example the textures of a material asset, or the mesh of an "
+      "object asset, don't have to be copied every time this asset is imported. The instances of "
+      "the asset share the data instead"},
+      {FILE_ASSET_IMPORT_PACK,
+      "PACK",
+      ICON_PACKAGE,
+      "Pack",
+      "Import the asset as linked data-block, and pack it in the current file (ensures that it "
+      "remains unchanged in case the library data is modified, is not available anymore, etc.)"},
+    {SHELF_ASSET_IMPORT_LINK_OVERRIDE,
+      "LINK_OVERRIDE",
+      ICON_LIBRARY_DATA_OVERRIDE,
+      "Link (Override)",
+      "Import the assets as linked library overrided data.\nThis will only override the active hierarchy.\nTo override all selected contents, use the Outliner Editor"},
+    {0, nullptr, 0, nullptr, nullptr},
+};
+
 #ifdef RNA_RUNTIME
 
 #  include "MEM_guardedalloc.h"
@@ -1663,6 +1697,38 @@ static StructRNA *rna_FileHandler_refine(PointerRNA *file_handler_ptr)
              &RNA_FileHandler;
 }
 
+// bfa start asset shelf import method, append pack
+static const EnumPropertyItem *rna_ShelfAssetSelectParams_import_method_itemf(
+    bContext * /*C*/, PointerRNA * /*ptr*/, PropertyRNA * /*prop*/, bool *r_free)
+{
+  EnumPropertyItem *items = nullptr;
+  int items_num = 0;
+  for (const EnumPropertyItem *item = asset_shelf_import_method_items; item->identifier; item++)
+  {
+    switch (eFileAssetImportMethod(item->value)) {
+      case SHELF_ASSET_IMPORT_APPEND_REUSE: {
+        if (U.experimental.no_data_block_packing) {
+          RNA_enum_item_add(&items, &items_num, item);
+        }
+        break;
+      }
+      case SHELF_ASSET_IMPORT_PACK: {
+        if (!U.experimental.no_data_block_packing) {
+          RNA_enum_item_add(&items, &items_num, item);
+        }
+        break;
+      }
+      default: {
+        RNA_enum_item_add(&items, &items_num, item);
+        break;
+      }
+    }
+  }
+  RNA_enum_item_end(&items, &items_num);
+  *r_free = true;
+  return items;
+}
+// bfa end
 #else /* RNA_RUNTIME */
 
 static void rna_def_ui_layout(BlenderRNA *brna)
@@ -2486,35 +2552,9 @@ static void rna_def_asset_shelf(BlenderRNA *brna)
   RNA_def_property_update(prop, NC_SPACE | ND_REGIONS_ASSET_SHELF, nullptr);
 
   prop = RNA_def_property(srna, "import_method", PROP_ENUM, PROP_NONE);
-  // bfa start asset shelf
-  // BFA - WIP - jưst gonna put the enum here
-  static const EnumPropertyItem asset_shelf_import_method_items[] = {
-      {SHELF_ASSET_IMPORT_LINK,
-       "LINK",
-       ICON_LINK_BLEND,
-       "Link",
-       "Import the assets as linked data"},
-      {SHELF_ASSET_IMPORT_APPEND,
-       "APPEND",
-       ICON_APPEND_BLEND,
-       "Append",
-       "Import the assets as copied data, with no link to the original asset data"},
-      {SHELF_ASSET_IMPORT_APPEND_REUSE,
-       "APPEND_REUSE",
-       ICON_FILE_BLEND,
-       "Append (Reuse Data)",
-       "Import the assets as copied data while avoiding multiple copies of nested, "
-       "typically heavy data. For example the textures of a material asset, or the mesh of an "
-       "object asset, don't have to be copied every time this asset is imported. The instances of "
-       "the asset share the data instead"},
-      {SHELF_ASSET_IMPORT_LINK_OVERRIDE,
-       "LINK_OVERRIDE",
-       ICON_LIBRARY_DATA_OVERRIDE,
-       "Link (Override)",
-       "Import the assets as linked library overrided data.\nThis will only override the active hierarchy.\nTo override all selected contents, use the Outliner Editor"},
-      {0, nullptr, 0, nullptr, nullptr},
-  };
   RNA_def_property_enum_items(prop, asset_shelf_import_method_items);
+  RNA_def_property_enum_funcs(
+    prop, nullptr, nullptr, "rna_ShelfAssetSelectParams_import_method_itemf");
   RNA_def_property_enum_sdna(prop, nullptr, "settings.import_method");
   RNA_def_property_ui_text(prop, "Import Method", "Determines how the asset will be imported");
   RNA_def_property_update(prop, NC_SPACE | ND_REGIONS_ASSET_SHELF, nullptr);


### PR DESCRIPTION
This PR cleanups asset shelf import method and adds pack import method to the UI. 
Same for asset browser, previous append reuse option can be return by using checkbox in Preferences > Developer Tools >No Data-block Packing
Resolve #5623 