### PR TITLE
Bug Fix - "All groups are locked" error when no vertex groups are locked

### DIFF
--- a/source/blender/editors/object/object_vgroup.cc
+++ b/source/blender/editors/object/object_vgroup.cc
@@ -1430,7 +1430,7 @@ static bool vgroup_normalize_all(Object *ob,
     soft_lock_flags[def_nr] = true;
   }
 
-  const bool all_locked = !lock_flags.contains(false);
+  const bool all_locked = !lock_flags.is_empty() && !lock_flags.contains(false); /*BFA - fix for the vertex group lock by making it more intelligent*/
   if (all_locked) {
     BKE_report(reports, RPT_ERROR, "All groups are locked");
   }


### PR DESCRIPTION
#5625

