### PR TITLE
Fix: 5636-keymap---node-editors---add-double-click-to-enter-node-groups

### DIFF
--- a/scripts/presets/keyconfig/Bforartists-macOS.py
+++ b/scripts/presets/keyconfig/Bforartists-macOS.py
@@ -6222,6 +6222,7 @@ keyconfig_data = \
     ("node.links_mute", {"type": 'RIGHTMOUSE', "value": 'PRESS', "alt": True, "oskey": True}, None),
     ("node.links_cut", {"type": 'RIGHTMOUSE', "value": 'CLICK_DRAG', "oskey": True}, None),
     ("node.group_make", {"type": 'G', "value": 'PRESS', "oskey": True, "repeat": True}, None),
+    ("node.group_enter_exit", {"type": 'LEFTMOUSE', "value": 'DOUBLE_CLICK'}, None),
     ("node.connect_to_output",
      {"type": 'LEFTMOUSE', "value": 'PRESS', "shift": True, "alt": True},
      {"properties":

--- a/scripts/presets/keyconfig/Bforartists.py
+++ b/scripts/presets/keyconfig/Bforartists.py
@@ -5165,6 +5165,7 @@ keyconfig_data = \
     ("node.links_mute", {"type": 'RIGHTMOUSE', "value": 'PRESS', "ctrl": True, "alt": True}, None),
     ("node.links_cut", {"type": 'RIGHTMOUSE', "value": 'CLICK_DRAG', "ctrl": True}, None),
     ("node.group_make", {"type": 'G', "value": 'PRESS', "ctrl": True, "repeat": True}, None),
+    ("node.group_enter_exit", {"type": 'LEFTMOUSE', "value": 'DOUBLE_CLICK'}, None),
     ("node.connect_to_output",
      {"type": 'LEFTMOUSE', "value": 'PRESS', "shift": True, "alt": True},
      {"properties":

--- a/source/blender/editors/space_node/node_intern.hh
+++ b/source/blender/editors/space_node/node_intern.hh
@@ -201,6 +201,7 @@ void node_keymap(wmKeyConfig *keyconf);
 
 rctf node_frame_rect_inside(const SpaceNode &snode, const bNode &node);
 bool node_or_socket_isect_event(const bContext &C, const wmEvent &event);
+bNode *node_under_mouse_get(const SpaceNode &snode, const float2 mouse);
 
 bool node_deselect_all(bNodeTree &node_tree);
 void node_socket_select(bNode *node, bNodeSocket &sock);
@@ -321,6 +322,7 @@ void NODE_OT_group_insert(wmOperatorType *ot);
 void NODE_OT_group_ungroup(wmOperatorType *ot);
 void NODE_OT_group_separate(wmOperatorType *ot);
 void NODE_OT_group_edit(wmOperatorType *ot);
+void NODE_OT_group_enter_exit(wmOperatorType *ot);
 
 void NODE_OT_default_group_width_set(wmOperatorType *ot);
 

--- a/source/blender/editors/space_node/node_ops.cc
+++ b/source/blender/editors/space_node/node_ops.cc
@@ -65,6 +65,7 @@ void node_operatortypes()
   WM_operatortype_append(NODE_OT_group_ungroup);
   WM_operatortype_append(NODE_OT_group_separate);
   WM_operatortype_append(NODE_OT_group_edit);
+  WM_operatortype_append(NODE_OT_group_enter_exit);
 
   WM_operatortype_append(NODE_OT_default_group_width_set);
 

--- a/source/blender/editors/space_node/node_select.cc
+++ b/source/blender/editors/space_node/node_select.cc
@@ -126,7 +126,7 @@ static bool node_frame_select_isect_mouse(const SpaceNode &snode,
   return false;
 }
 
-static bNode *node_under_mouse_select(const SpaceNode &snode, const float2 mouse)
+bNode *node_under_mouse_get(const SpaceNode &snode, const float2 mouse)
 {
   for (bNode *node : tree_draw_order_calc_nodes_reversed(*snode.edittree)) {
     switch (node->type_legacy) {
@@ -149,7 +149,7 @@ static bNode *node_under_mouse_select(const SpaceNode &snode, const float2 mouse
 
 static bool is_position_over_node_or_socket(SpaceNode &snode, ARegion &region, const float2 &mouse)
 {
-  if (node_under_mouse_select(snode, mouse)) {
+  if (node_under_mouse_get(snode, mouse)) {
     return true;
   }
   if (node_find_indicated_socket(snode, region, mouse, SOCK_IN | SOCK_OUT)) {
@@ -597,7 +597,7 @@ static bool node_mouse_select(bContext *C,
   if (!sock) {
 
     /* Find the closest visible node. */
-    node = node_under_mouse_select(snode, cursor);
+    node = node_under_mouse_get(snode, cursor);
     found = (node != nullptr);
     node_was_selected = node && (node->flag & SELECT);
 


### PR DESCRIPTION
-- added the double click to enter a node group keymap to the Bforartists.py and Bforartists-macOS.py key configs -- added needed .cc .hh files too (but week40 merge should have this too)

