### PR TITLE
Fix: 5626-edit-mode-mesh-menu-weights-greyed-out-legacy-items

### DIFF
--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -5049,7 +5049,7 @@ class VIEW3D_MT_paint_weight(Menu):
 
     @staticmethod
     def draw_generic(layout, is_editmode=False):
-        layout.menu("VIEW3D_MT_paint_weight_legacy", text="Legacy")  # bfa menu
+        # bfa - removed VIEW3D_MT_paint_weight_legacy
 
         if not is_editmode:
             layout.operator(


### PR DESCRIPTION
-- removed unused legacy menu (doesnt work in edit mode)

