### PR TITLE
Fix: 5653-keymap---uv-editor---4-for-island-mode-is-broken

### DIFF
--- a/scripts/presets/keyconfig/Bforartists-macOS.py
+++ b/scripts/presets/keyconfig/Bforartists-macOS.py
@@ -9592,10 +9592,10 @@ keyconfig_data = \
        ],
       },
      ),
-    ("wm.context_set_enum",
+    ("wm.context_toggle",
      {"type": 'FOUR', "value": 'PRESS'},
      {"properties":
-      [("data_path", 'tool_settings.uv_select_mode'),
+      [("data_path", 'tool_settings.use_uv_select_island'),
        ("value", 'ISLAND'),
        ],
       },

--- a/scripts/presets/keyconfig/Bforartists.py
+++ b/scripts/presets/keyconfig/Bforartists.py
@@ -8020,10 +8020,10 @@ keyconfig_data = \
        ],
       },
      ),
-    ("wm.context_set_enum",
+    ("wm.context_toggle",
      {"type": 'FOUR', "value": 'PRESS'},
      {"properties":
-      [("data_path", 'tool_settings.uv_select_mode'),
+      [("data_path", 'tool_settings.use_uv_select_island'),
        ("value", 'ISLAND'),
        ],
       },


### PR DESCRIPTION
-- fixed the island select in the uv editor, wrong context was set.