### PR TITLE
Fix: node_util.py TypeError when connecting Bool socket to Material Output

### DIFF
--- a/scripts/modules/bpy_extras/node_utils.py
+++ b/scripts/modules/bpy_extras/node_utils.py
@@ -24,7 +24,7 @@ def find_base_socket_type(socket):
     if socket.type == 'INT':
         return 'NodeSocketInt'
     if socket.type == 'BOOLEAN':
-        return 'NodeSocketBoolean'
+        return 'NodeSocketBool'
     if socket.type == 'VECTOR':
         return 'NodeSocketVector'
     if socket.type == 'ROTATION':


### PR DESCRIPTION
Issue:
 Connecting a Boolean-type socket to Material Output from within a NodeGroup using Ctrl+Shift+LeftClick caused a TypeError.

Cause:
 In node_utils.py, the socket type was incorrectly written as 'NodeSocketBoolean' instead of 'NodeSocketBool'.

Testing:
Verified the fix on Blender versions 4.2 through 5.0.1a, and Bforartists 4.5.2. Only this instance of 'NodeSocketBoolean' existed in the codebase; all other references already used 'NodeSocketBool'.

Specifics: When connecting a node to Material Output with Ctrl-Shift-LeftClick from inside of a nodegroup, a temporary socket is added to the the Group Output. When that socket was type BOOL, node_utils.py returned that the 'Viewer' socket created should be NodeSocketBoolean, instead of NodeSocketBool.

