### PR TITLE
Fix: 5699-warning-property-value-not-found

### DIFF
--- a/scripts/presets/keyconfig/Bforartists-macOS.py
+++ b/scripts/presets/keyconfig/Bforartists-macOS.py
@@ -9603,7 +9603,6 @@ keyconfig_data = \
      {"type": 'FOUR', "value": 'PRESS'},
      {"properties":
       [("data_path", 'tool_settings.use_uv_select_island'),
-       ("value", 'ISLAND'),
        ],
       },
      ),

--- a/scripts/presets/keyconfig/Bforartists.py
+++ b/scripts/presets/keyconfig/Bforartists.py
@@ -8031,7 +8031,6 @@ keyconfig_data = \
      {"type": 'FOUR', "value": 'PRESS'},
      {"properties":
       [("data_path", 'tool_settings.use_uv_select_island'),
-       ("value", 'ISLAND'),
        ],
       },
      ),


### PR DESCRIPTION
-- removed unused ISLAND value for the select island keymap

