### PR TITLE
Fix: 5719-splashscreen---clamp-version-number

### DIFF
--- a/scripts/startup/bl_operators/wm.py
+++ b/scripts/startup/bl_operators/wm.py
@@ -3348,7 +3348,7 @@ class WM_MT_splash_quick_setup(Menu):
             col = split.column()
             col.operator(
                 "preferences.copy_prev",
-                text=iface_("Load Bforartists {:d}.{:d} Preferences", "Operator").format(old_version[0], old_version[1] - 1), #BFA - made it subtract a version, since we are ahead one of Blender in the config settings
+                text=iface_("Load Bforartists {}.{} Preferences", "Operator").format(*old_version), # bfa - show the correct previous version to load
                 icon='DUPLICATE', #BFA
                 translate=False,
             )


### PR DESCRIPTION
-- fixed to properly show the previous version.

<img width="523" height="547" alt="Screenshot_20251018_141451" src="https://github.com/user-attachments/assets/671b4e99-249e-4849-a6b5-47046be23308" />
<img width="530" height="543" alt="Screenshot_20251018_135930" src="https://github.com/user-attachments/assets/fa99bd6b-28f3-4a0a-834e-4090a4656219" />
<img width="532" height="562" alt="Screenshot_20251018_135718" src="https://github.com/user-attachments/assets/84dcea31-77b2-456f-a932-27abbf98449b" />


