### PR TITLE
Fix:5723-3d-view---missing-grease-pencil-snap-pie-menu

### DIFF
--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -1790,7 +1790,7 @@ class VIEW3D_MT_view_pie_menus(Menu):
         ).name = "ANIM_MT_keyframe_insert_pie"
         layout.separator()
 
-        layout.operator("wm.call_menu_pie", text="Greasepencil Snap", icon="MENU_PANEL").name = "GPENCIL_MT_snap_pie"
+        layout.operator("wm.call_menu_pie", text="Greasepencil Snap", icon="MENU_PANEL").name = "GREASE_PENCIL_MT_snap_pie"
 
         layout.separator()
 


### PR DESCRIPTION
-- updated operator .name

[Screencast_20251018_152716.webm](https://github.com/user-attachments/assets/e6925a81-e489-45ad-8a06-fea0d41d494a)
