### PR TITLE
Fix: 5720-3d-view---asset-shelf---dragging-in-materials-only-goes-to-…

### DIFF
--- a/source/blender/editors/object/object_relations.cc
+++ b/source/blender/editors/object/object_relations.cc
@@ -3053,6 +3053,13 @@ void OBJECT_OT_drop_named_material(wmOperatorType *ot)
 
   /* properties */
   WM_operator_properties_id_lookup(ot, true);
+  
+  /* Add the missing property */
+  RNA_def_boolean(ot->srna,
+                 "show_datablock_in_modifier",
+                 false,
+                 "Show in Modifier",
+                 "Show the datablock in the modifier properties");
 }
 
 /** \} */


### PR DESCRIPTION
-- added the missing show_datablock_in_modifier boolean.
-- added import_method code functionality for the asset shelf.

[Screencast_20251018_203843.webm](https://github.com/user-attachments/assets/02bb9770-0945-4fe3-9f39-d1e3acd77998)


