### PR TITLE
Fix: 5747-edit-mode-with-a-mesh-object-polygon-tool-tool-settings-in-…

### DIFF
--- a/scripts/startup/bl_ui/space_toolsystem_toolbar.py
+++ b/scripts/startup/bl_ui/space_toolsystem_toolbar.py
@@ -804,6 +804,7 @@ class _defs_edit_mesh:
         def draw_settings(_context, layout, tool):
             props = tool.operator_properties("mesh.polybuild_face_at_cursor_move")
             props_macro = props.MESH_OT_polybuild_face_at_cursor
+            layout.use_property_split = False # BFA - align left
             layout.prop(props_macro, "create_quads")
 
         def description(_context, _item, km):


### PR DESCRIPTION
-- aligned create_quads to left.

<img width="255" height="197" alt="image" src="https://github.com/user-attachments/assets/e10505c8-f4a0-42ec-bd4a-904673adcc20" />
