### PR TITLE
Fix: 5744-sequencer-modifier-tab---copy-to-selected-menu-needs-icons

### DIFF
--- a/source/blender/editors/space_sequencer/sequencer_modifier.cc
+++ b/source/blender/editors/space_sequencer/sequencer_modifier.cc
@@ -302,10 +302,10 @@ static wmOperatorStatus strip_modifier_copy_exec(bContext *C, wmOperator *op)
 void SEQUENCER_OT_strip_modifier_copy(wmOperatorType *ot)
 {
   static const EnumPropertyItem type_items[] = {
-      {SEQ_MODIFIER_COPY_REPLACE, "REPLACE", ICON_REPLACE_STRING /*BFA*/, "Replace", "Replace modifiers in destination"},
+      {SEQ_MODIFIER_COPY_REPLACE, "REPLACE", ICON_FILE_REFRESH /*BFA*/, "Replace", "Replace modifiers in destination"},
       {SEQ_MODIFIER_COPY_APPEND,
        "APPEND",
-       ICON_APPEND_BLEND /*BFA*/,
+       ICON_ADD /*BFA*/,
        "Append",
        "Append active modifiers to selected strips"},
       {0, nullptr, 0, nullptr, nullptr},


### PR DESCRIPTION
-- added icons to the Copy to Selected menu.

<img width="201" height="89" alt="image" src="https://github.com/user-attachments/assets/3d7ebbe5-9d14-45db-b6f1-04175e0215f3" />
