### PR TITLE
Fix: 5766-grease-pencil-in-edit-mdoe-interpolate-tool-active-tool-pan…

### DIFF
--- a/scripts/startup/bl_ui/space_toolsystem_toolbar.py
+++ b/scripts/startup/bl_ui/space_toolsystem_toolbar.py
@@ -2536,9 +2536,7 @@ class _defs_grease_pencil_edit:
                 row = layout.row()
                 row.use_property_split = False
                 row.prop(props, "exclude_breakdowns")
-            else:
-                layout.prop(props, "exclude_breakdowns")
-            
+                
             layout.prop(props, "flip")
             layout.prop(props, "smooth_factor")
             layout.prop(props, "smooth_steps")


### PR DESCRIPTION
-- align exclude_breakdowns prop to left.
-- added region_type context to set row.use_property_split = False in UI and PROPERTIES only and not the tools setting header.

<img width="2600" height="1442" alt="image" src="https://github.com/user-attachments/assets/b52119ce-bcda-455a-8121-70af5ef08aa5" />


