### PR TITLE
Fix: 5761-bezier-curve-in-edit-mode-draw-tool-tool-settings-align-pro…

### DIFF
--- a/scripts/startup/bl_ui/space_toolsystem_toolbar.py
+++ b/scripts/startup/bl_ui/space_toolsystem_toolbar.py
@@ -1281,7 +1281,11 @@ def curve_draw_settings(context, layout, tool, *, extra=False):
         row.prop(cps, "depth_mode", expand=True)
     if cps.depth_mode == 'SURFACE':
         col = layout.column()
+        # BFA - align left for sidebar and properties editor tools only
+        if region_type == 'UI' or 'PROPERTIES':
+            col.use_property_split = False
         col.prop(cps, "use_project_only_selected")
+        col.use_property_split = True
         col.prop(cps, "surface_offset")
         col.use_property_split = False
         col.prop(cps, "use_offset_absolute")


### PR DESCRIPTION
-- align use_project_only_selected prop to left.

<img width="310" height="435" alt="image" src="https://github.com/user-attachments/assets/28e4a6c1-7662-4244-af71-4fa8a01c1723" />
