### PR TITLE
Sculpt Mode - Various Tool Groups - Split non-boolean properties #5756

### DIFF
--- a/scripts/startup/bl_ui/space_toolsystem_toolbar.py
+++ b/scripts/startup/bl_ui/space_toolsystem_toolbar.py
@@ -116,7 +116,6 @@ class _defs_view3d_generic:
             layout.prop(props, "use_depth")
             layout.use_property_split = True # BFA
             layout.prop(props, "orientation")
-            layout.use_property_split = False # BFA
         return dict(
             idname="builtin.cursor",
             label="Cursor",
@@ -806,6 +805,7 @@ class _defs_edit_mesh:
             props_macro = props.MESH_OT_polybuild_face_at_cursor
             layout.use_property_split = False # BFA - align left
             layout.prop(props_macro, "create_quads")
+            layout.use_property_split = True # BFA
 
         def description(_context, _item, km):
             if km is not None:
@@ -842,6 +842,7 @@ class _defs_edit_mesh:
             props = tool.operator_properties("transform.edge_slide")
             layout.use_property_split = False
             layout.prop(props, "correct_uv")
+            layout.use_property_split = True # BFA
 
         return dict(
             idname="builtin.edge_slide",
@@ -858,6 +859,7 @@ class _defs_edit_mesh:
             props = tool.operator_properties("transform.vert_slide")
             layout.use_property_split = False
             layout.prop(props, "correct_uv")
+            layout.use_property_split = True # BFA
 
         return dict(
             idname="builtin.vertex_slide",
@@ -897,6 +899,7 @@ class _defs_edit_mesh:
             layout.prop(props, "use_individual")
             layout.prop(props, "use_even_offset")
             layout.prop(props, "use_relative_offset")
+            layout.use_property_split = True # BFA
 
         return dict(
             idname="builtin.inset_faces",
@@ -1034,6 +1037,7 @@ class _defs_edit_mesh:
             props_macro = props.TRANSFORM_OT_shrink_fatten
             layout.use_property_split = False
             layout.prop(props_macro, "use_even_offset")
+            layout.use_property_split = True # BFA
         return dict(
             idname="builtin.extrude_along_normals",
             label="Extrude Along Normals",
@@ -1060,6 +1064,7 @@ class _defs_edit_mesh:
             props = tool.operator_properties("mesh.dupli_extrude_cursor")
             layout.use_property_split = False
             layout.prop(props, "rotate_source")
+            layout.use_property_split = True # BFA
 
         return dict(
             idname="builtin.extrude_to_cursor",
@@ -1081,6 +1086,7 @@ class _defs_edit_mesh:
             props_macro = props.TRANSFORM_OT_edge_slide
             layout.use_property_split = False
             layout.prop(props_macro, "correct_uv")
+            layout.use_property_split = True # BFA
 
         return dict(
             idname="builtin.loop_cut",
@@ -1147,6 +1153,7 @@ class _defs_edit_mesh:
             props = tool.operator_properties("transform.shrink_fatten")
             layout.use_property_split = False
             layout.prop(props, "use_even_offset")
+            layout.use_property_split = True # BFA
 
         return dict(
             idname="builtin.shrink_fatten",
@@ -1177,6 +1184,7 @@ class _defs_edit_mesh:
                 layout.prop(props, "use_occlude_geometry")
                 layout.prop(props, "only_selected")
                 layout.prop(props, "xray")
+                layout.use_property_split = True # BFA
                 region_is_header = bpy.context.region.type == 'TOOL_HEADER'
                 if region_is_header:
                     show_extra = True
@@ -1813,6 +1821,7 @@ class _defs_sculpt:
             layout.use_property_split = False
             props = tool.operator_properties("sculpt.face_set_polyline_gesture")
             layout.prop(props, "use_front_faces_only", expand=False)
+            layout.use_property_split = True # BFA
 
         return dict(
             idname="builtin.polyline_face_set",
@@ -1827,7 +1836,7 @@ class _defs_sculpt:
     @ToolDef.from_fn
     def trim_box():
         def draw_settings(_context, layout, tool):
-            layout.use_property_split = False
+            layout.use_property_split = True # BFA
             props = tool.operator_properties("sculpt.trim_box_gesture")
             layout.prop(props, "trim_solver", expand=False)
             layout.prop(props, "trim_mode", expand=False)
@@ -1835,6 +1844,7 @@ class _defs_sculpt:
             layout.prop(props, "trim_extrude_mode", expand=False)
             layout.use_property_split = False
             layout.prop(props, "use_cursor_depth", expand=False)
+            layout.use_property_split = True # BFA
         return dict(
             idname="builtin.box_trim",
             label="Box Trim",
@@ -1851,7 +1861,7 @@ class _defs_sculpt:
             props = tool.operator_properties("sculpt.trim_lasso_gesture")
 
             if not extra:
-                layout.use_property_split = False
+                layout.use_property_split = True # BFA
                 layout.prop(props, "trim_solver", expand=False)
                 layout.prop(props, "trim_mode", expand=False)
                 layout.prop(props, "trim_orientation", expand=False)
@@ -1879,10 +1889,11 @@ class _defs_sculpt:
     def trim_line():
         def draw_settings(_context, layout, tool):
             props = tool.operator_properties("sculpt.trim_line_gesture")
-            layout.use_property_split = False
+            layout.use_property_split = True # BFA
             layout.prop(props, "trim_solver", expand=False)
             layout.prop(props, "trim_orientation", expand=False)
             layout.prop(props, "trim_extrude_mode", expand=False)
+            layout.use_property_split = False
             layout.prop(props, "use_cursor_depth", expand=False)
             layout.prop(props, "use_limit_to_segment", expand=False)
         return dict(
@@ -1898,11 +1909,12 @@ class _defs_sculpt:
     def trim_polyline():
         def draw_settings(_context, layout, tool):
             props = tool.operator_properties("sculpt.trim_polyline_gesture")
-            layout.use_property_split = False
+            layout.use_property_split = True # BFA
             layout.prop(props, "trim_solver", expand=False)
             layout.prop(props, "trim_mode", expand=False)
             layout.prop(props, "trim_orientation", expand=False)
             layout.prop(props, "trim_extrude_mode", expand=False)
+            layout.use_property_split = False
             layout.prop(props, "use_cursor_depth", expand=False)
 
         return dict(
@@ -1934,7 +1946,7 @@ class _defs_sculpt:
     @ToolDef.from_fn
     def mesh_filter():
         def draw_settings(_context, layout, tool):
-            layout.use_property_split = False
+            layout.use_property_split = True # BFA
             props = tool.operator_properties("sculpt.mesh_filter")
             layout.prop(props, "type", expand=False)
             layout.prop(props, "strength")
@@ -1962,7 +1974,7 @@ class _defs_sculpt:
     def cloth_filter():
         def draw_settings(_context, layout, tool):
             props = tool.operator_properties("sculpt.cloth_filter")
-            layout.use_property_split = False
+            layout.use_property_split = True # BFA
             layout.prop(props, "type", expand=False)
             layout.prop(props, "strength")
             row = layout.row(align=True)
@@ -1973,6 +1985,7 @@ class _defs_sculpt:
             layout.use_property_split = False
             layout.prop(props, "use_face_sets")
             layout.prop(props, "use_collisions")
+            layout.use_property_split = True # BFA
 
         return dict(
             idname="builtin.cloth_filter",
@@ -1987,7 +2000,7 @@ class _defs_sculpt:
     def color_filter():
         def draw_settings(_context, layout, tool):
             props = tool.operator_properties("sculpt.color_filter")
-            layout.use_property_split = False
+            layout.use_property_split = True # BFA
             layout.prop(props, "type", expand=False)
             if props.type == 'FILL':
                 layout.prop(props, "fill_color", expand=False)
@@ -2006,12 +2019,13 @@ class _defs_sculpt:
     def mask_by_color():
         def draw_settings(_context, layout, tool):
             props = tool.operator_properties("sculpt.mask_by_color")
-            layout.use_property_split = False
+            layout.use_property_split = True # BFA
             layout.prop(props, "threshold")
             layout.use_property_split = False
             layout.prop(props, "contiguous")
             layout.prop(props, "invert")
             layout.prop(props, "preserve_previous_mask")
+            layout.use_property_split = True # BFA
 
         return dict(
             idname="builtin.mask_by_color",
@@ -2027,10 +2041,11 @@ class _defs_sculpt:
     def face_set_edit():
         def draw_settings(_context, layout, tool):
             props = tool.operator_properties("sculpt.face_set_edit")
-            layout.use_property_split = False
+            layout.use_property_split = True # BFA
             layout.prop(props, "mode", expand=False)
             layout.use_property_split = False
             layout.prop(props, "modify_hidden")
+            layout.use_property_split = True # BFA
 
         return dict(
             idname="builtin.face_set_edit",


### PR DESCRIPTION
In the interest of not ballooning this description with screenshots, I'll just show two examples:

| Before | After |
| --- | --- |
| <img width="210" height="207" alt="image" src="https://github.com/user-attachments/assets/c82005b6-601d-4766-91e3-4488c40f4eaa" /> | <img width="212" height="198" alt="image" src="https://github.com/user-attachments/assets/62ab783c-b450-46bb-85a7-18c11f46af77" /> |
| <img width="196" height="249" alt="image" src="https://github.com/user-attachments/assets/9b8b8578-6a9d-4d2b-a438-2e0658c2fe56" /> | <img width="218" height="265" alt="image" src="https://github.com/user-attachments/assets/bda11965-c5bd-4cce-a715-0e495a5dd3cb" /> |

But all other tool panels should follow the pattern of setting `use_property_split = True` for non-boolean properties.
This makes enum properties have more room for their labels. Other properties like float sliders are affected, but this actually makes them more consistent with how we handle sliders in other places.