### PR TITLE
Sculpt Mode - Trim Tool group - Make enum labels have more room #5756

### DIFF
--- a/scripts/startup/bl_ui/space_toolsystem_toolbar.py
+++ b/scripts/startup/bl_ui/space_toolsystem_toolbar.py
@@ -1827,7 +1827,7 @@ class _defs_sculpt:
     @ToolDef.from_fn
     def trim_box():
         def draw_settings(_context, layout, tool):
-            layout.use_property_split = False
+            layout.use_property_split = True # BFA
             props = tool.operator_properties("sculpt.trim_box_gesture")
             layout.prop(props, "trim_solver", expand=False)
             layout.prop(props, "trim_mode", expand=False)
@@ -1851,7 +1851,7 @@ class _defs_sculpt:
             props = tool.operator_properties("sculpt.trim_lasso_gesture")
 
             if not extra:
-                layout.use_property_split = False
+                layout.use_property_split = True # BFA
                 layout.prop(props, "trim_solver", expand=False)
                 layout.prop(props, "trim_mode", expand=False)
                 layout.prop(props, "trim_orientation", expand=False)
@@ -1879,10 +1879,11 @@ class _defs_sculpt:
     def trim_line():
         def draw_settings(_context, layout, tool):
             props = tool.operator_properties("sculpt.trim_line_gesture")
-            layout.use_property_split = False
+            layout.use_property_split = True # BFA
             layout.prop(props, "trim_solver", expand=False)
             layout.prop(props, "trim_orientation", expand=False)
             layout.prop(props, "trim_extrude_mode", expand=False)
+            layout.use_property_split = False # BFA - Float bool property left
             layout.prop(props, "use_cursor_depth", expand=False)
             layout.prop(props, "use_limit_to_segment", expand=False)
         return dict(
@@ -1898,11 +1899,12 @@ class _defs_sculpt:
     def trim_polyline():
         def draw_settings(_context, layout, tool):
             props = tool.operator_properties("sculpt.trim_polyline_gesture")
-            layout.use_property_split = False
+            layout.use_property_split = True # BFA
             layout.prop(props, "trim_solver", expand=False)
             layout.prop(props, "trim_mode", expand=False)
             layout.prop(props, "trim_orientation", expand=False)
             layout.prop(props, "trim_extrude_mode", expand=False)
+            layout.use_property_split = False # BFA - Float bool property left
             layout.prop(props, "use_cursor_depth", expand=False)
 
         return dict(


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="210" height="193" alt="image" src="https://github.com/user-attachments/assets/4f96e0ab-42a0-4400-a7e4-34754a4631f9" /> | <img width="214" height="198" alt="image" src="https://github.com/user-attachments/assets/0c85c018-42b1-4fb7-98eb-2b5d2f106568" /> |
| <img width="207" height="215" alt="image" src="https://github.com/user-attachments/assets/b4f236c4-9ee1-419f-a46c-d063b1d2324d" /> | <img width="205" height="225" alt="image" src="https://github.com/user-attachments/assets/190813e1-2ce9-41a7-b82d-e69fc839132e" /> |
| <img width="206" height="193" alt="image" src="https://github.com/user-attachments/assets/a7048aef-810f-483f-92eb-ab04bf3c4152" /> | <img width="206" height="197" alt="image" src="https://github.com/user-attachments/assets/984c8bf6-a970-441e-a32d-4a2cb64d40a2" /> |
| <img width="203" height="194" alt="image" src="https://github.com/user-attachments/assets/5af80019-9611-484f-b1ba-285122d1d42c" /> | <img width="204" height="199" alt="image" src="https://github.com/user-attachments/assets/07f2095d-8bb4-48c0-bd8e-0517bf6aebd1" /> |