### PR TITLE
Sculpt Mode - Mesh Filter - Use split layout for non-boolean properties #5776

### DIFF
--- a/scripts/startup/bl_ui/space_toolsystem_toolbar.py
+++ b/scripts/startup/bl_ui/space_toolsystem_toolbar.py
@@ -1934,7 +1934,7 @@ class _defs_sculpt:
     @ToolDef.from_fn
     def mesh_filter():
         def draw_settings(_context, layout, tool):
-            layout.use_property_split = False
+            layout.use_property_split = True # BFA
             props = tool.operator_properties("sculpt.mesh_filter")
             layout.prop(props, "type", expand=False)
             layout.prop(props, "strength")


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="206" height="171" alt="image" src="https://github.com/user-attachments/assets/31c8f0e1-1875-45f4-90e6-5584f50e7854" /> | <img width="210" height="173" alt="image" src="https://github.com/user-attachments/assets/0a7ae62a-f769-4d24-ae22-4c3cb1a77a9e" /> |