### PR TITLE
Sculpt Mode - Cloth Filter - Use split layout for non-boolean properties #5777

### DIFF
--- a/scripts/startup/bl_ui/space_toolsystem_toolbar.py
+++ b/scripts/startup/bl_ui/space_toolsystem_toolbar.py
@@ -1962,7 +1962,7 @@ class _defs_sculpt:
     def cloth_filter():
         def draw_settings(_context, layout, tool):
             props = tool.operator_properties("sculpt.cloth_filter")
-            layout.use_property_split = False
+            layout.use_property_split = True # BFA
             layout.prop(props, "type", expand=False)
             layout.prop(props, "strength")
             row = layout.row(align=True)


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="207" height="257" alt="image" src="https://github.com/user-attachments/assets/76c58a12-2a1d-46ce-8f17-942198776aa5" /> | <img width="201" height="254" alt="image" src="https://github.com/user-attachments/assets/feb6da5e-6afd-4ee4-aba0-f52aad6cd5fe" /> |