### PR TITLE
Sculpt Mode - Color Filter - Use split layout for non-boolean properties #5778

### DIFF
--- a/scripts/startup/bl_ui/space_toolsystem_toolbar.py
+++ b/scripts/startup/bl_ui/space_toolsystem_toolbar.py
@@ -1987,7 +1987,7 @@ class _defs_sculpt:
     def color_filter():
         def draw_settings(_context, layout, tool):
             props = tool.operator_properties("sculpt.color_filter")
-            layout.use_property_split = False
+            layout.use_property_split = True # BFA
             layout.prop(props, "type", expand=False)
             if props.type == 'FILL':
                 layout.prop(props, "fill_color", expand=False)


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="209" height="171" alt="image" src="https://github.com/user-attachments/assets/4ffb9ba4-5a03-459d-a7e8-bdc64716bf4e" /> | <img width="204" height="145" alt="image" src="https://github.com/user-attachments/assets/c967b909-a97e-40a1-8848-a2b349dfa3f1" /> |