### PR TITLE
Sculpt Mode - Mask By Color tool - Use split layout for Threshold #5784

### DIFF
--- a/scripts/startup/bl_ui/space_toolsystem_toolbar.py
+++ b/scripts/startup/bl_ui/space_toolsystem_toolbar.py
@@ -2006,7 +2006,7 @@ class _defs_sculpt:
     def mask_by_color():
         def draw_settings(_context, layout, tool):
             props = tool.operator_properties("sculpt.mask_by_color")
-            layout.use_property_split = False
+            layout.use_property_split = True # BFA
             layout.prop(props, "threshold")
             layout.use_property_split = False
             layout.prop(props, "contiguous")


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="211" height="175" alt="image" src="https://github.com/user-attachments/assets/c0f07ba1-e24e-43e1-b109-b51ff85d431e" /> | <img width="203" height="165" alt="image" src="https://github.com/user-attachments/assets/cc6023ae-b6b3-4f61-b4bb-adeedf00331a" /> |