### PR TITLE
Edit Mode - Shrink/Fatten tool - Use split layout for "Drag" popover #5781

### DIFF
--- a/scripts/startup/bl_ui/space_toolsystem_toolbar.py
+++ b/scripts/startup/bl_ui/space_toolsystem_toolbar.py
@@ -1147,6 +1147,7 @@ class _defs_edit_mesh:
             props = tool.operator_properties("transform.shrink_fatten")
             layout.use_property_split = False
             layout.prop(props, "use_even_offset")
+            layout.use_property_split = True # BFA
 
         return dict(
             idname="builtin.shrink_fatten",


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="209" height="124" alt="image" src="https://github.com/user-attachments/assets/a6bb1efe-f40e-46ad-bd08-dd14f04232fd" /> | <img width="205" height="131" alt="image" src="https://github.com/user-attachments/assets/43538f5a-e56e-4098-83b8-697e337aa7cb" /> |