### PR TITLE
Edit Mode - Poly Build tool - Use split layout for "Drag" popover #5780

### DIFF
--- a/scripts/startup/bl_ui/space_toolsystem_toolbar.py
+++ b/scripts/startup/bl_ui/space_toolsystem_toolbar.py
@@ -806,6 +806,7 @@ class _defs_edit_mesh:
             props_macro = props.MESH_OT_polybuild_face_at_cursor
             layout.use_property_split = False # BFA - align left
             layout.prop(props_macro, "create_quads")
+            layout.use_property_split = True # BFA
 
         def description(_context, _item, km):
             if km is not None:


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="202" height="125" alt="image" src="https://github.com/user-attachments/assets/f1536076-f212-4b6a-bffd-659a9de6bc58" /> | <img width="199" height="122" alt="image" src="https://github.com/user-attachments/assets/10fda535-58b8-47b2-b7a0-3b49929fb721" /> |