### PR TITLE
Animation Editors - Dopesheet/Footer - New Timeline and footer with ouble dentries #5808

### DIFF
--- a/scripts/startup/bl_ui/space_dopesheet.py
+++ b/scripts/startup/bl_ui/space_dopesheet.py
@@ -209,13 +209,25 @@ class DOPESHEET_PT_filters(DopesheetFilterPopoverBase, Panel):
 
 ################################ BFA -Switch between the editors ##########################################
 
+class ANIM_OT_switch_editors_to_timeline(bpy.types.Operator):
+    """Switch to Dope Sheet Editor"""  # blender will use this as a tooltip for menu items and buttons.
+
+    bl_idname = "wm.switch_editor_to_timeline"  # unique identifier for buttons and menu items to reference.
+    # display name in the interface.
+    bl_label = "Switch to the Timeline Editor"
+
+    # execute() is called by blender when running the operator.
+    def execute(self, context):
+        bpy.ops.wm.context_set_enum(data_path="area.ui_type", value="TIMELINE")
+        return {"FINISHED"}
+
 
 class ANIM_OT_switch_editors_to_dopesheet(bpy.types.Operator):
     """Switch to Dope Sheet Editor"""  # blender will use this as a tooltip for menu items and buttons.
 
     bl_idname = "wm.switch_editor_to_dopesheet"  # unique identifier for buttons and menu items to reference.
     # display name in the interface.
-    bl_label = "Switch to Dope Sheet Editor"
+    bl_label = "Switch to the Dope Sheet Editor"
 
     # execute() is called by blender when running the operator.
     def execute(self, context):
@@ -228,7 +240,7 @@ class ANIM_OT_switch_editors_to_graph(bpy.types.Operator):
 
     bl_idname = "wm.switch_editor_to_graph"  # unique identifier for buttons and menu items to reference.
     # display name in the interface.
-    bl_label = "Switch to Graph Editor"
+    bl_label = "Switch to the Graph Editor"
 
     # execute() is called by blender when running the operator.
     def execute(self, context):
@@ -242,7 +254,7 @@ class ANIM_OT_switch_editors_to_driver(bpy.types.Operator):
 
     bl_idname = "wm.switch_editor_to_driver"  # unique identifier for buttons and menu items to reference.
     # display name in the interface.
-    bl_label = "Switch to Driver Editor"
+    bl_label = "Switch to the Driver Editor"
 
     # execute() is called by blender when running the operator.
     def execute(self, context):
@@ -267,7 +279,7 @@ class ANIM_OT_switch_editors_to_nla(bpy.types.Operator):
 
 
 class ANIM_OT_switch_editors_in_dopesheet(bpy.types.Operator):
-    """You are in Dope Sheet Editor"""  # blender will use this as a tooltip for menu items and buttons.
+    """You are in the Dope Sheet Editor"""  # blender will use this as a tooltip for menu items and buttons.
 
     bl_idname = "wm.switch_editor_in_dopesheet"  # unique identifier for buttons and menu items to reference.
     bl_label = "Dope Sheet Editor"  # display name in the interface.
@@ -277,6 +289,17 @@ class ANIM_OT_switch_editors_in_dopesheet(bpy.types.Operator):
     def execute(self, context):
         return {"FINISHED"}
 
+
+class ANIM_OT_switch_editors_in_timeline(bpy.types.Operator):
+    """You are in the Timeline Editor"""  # blender will use this as a tooltip for menu items and buttons.
+
+    bl_idname = "wm.switch_editor_in_timeline"  # unique identifier for buttons and menu items to reference.
+    bl_label = "Timeline Editor"  # display name in the interface.
+    bl_options = {"INTERNAL"}  # use internal so it can not be searchable
+
+    # Blank button, we don't execute anything here.
+    def execute(self, context):
+        return {"FINISHED"}
 
 #######################################
 # DopeSheet Editor - General/Standard UI
@@ -297,14 +320,34 @@ class DOPESHEET_HT_header(Header):
         # bfa - The tabs to switch between the four animation editors. The classes are in space_dopesheet.py
         row = layout.row(align=True)
 
-        row.operator("wm.switch_editor_in_dopesheet", text="", icon="DOPESHEET_ACTIVE")
-        row.operator("wm.switch_editor_to_graph", text="", icon="GRAPH")
-        row.operator("wm.switch_editor_to_driver", text="", icon="DRIVER")
-        row.operator("wm.switch_editor_to_nla", text="", icon="NLA")
+
+        if context.space_data.mode == "TIMELINE":
+            # bfa - The tabs to switch between the four animation editors. The classes are in space_dopesheet.py
+            row = layout.row(align=True)
+            row.operator("wm.switch_editor_to_dopesheet", text="", icon="DOPESHEET_ACTIVE")
+            row.operator("wm.switch_editor_to_graph", text="", icon="GRAPH")
+            row.operator("wm.switch_editor_to_driver", text="", icon="DRIVER")
+            row.operator("wm.switch_editor_to_nla", text="", icon="NLA")
+
+            row = layout.row(align=True)
+
+            row.operator("wm.switch_editor_to_dopesheet", text="", icon="TIME", depress=True)  # BFA - legacy, but toggles the dopesheet to timeline on a short-hand
+
+        elif context.space_data.mode == "DOPESHEET_EDITOR":
+            # bfa - The tabs to switch between the four animation editors. The classes are in space_dopesheet.py
+            row = layout.row(align=True)
+            row.operator("wm.switch_editor_in_dopesheet", text="", icon="DOPESHEET_ACTIVE")
+            row.operator("wm.switch_editor_to_graph", text="", icon="GRAPH")
+            row.operator("wm.switch_editor_to_driver", text="", icon="DRIVER")
+            row.operator("wm.switch_editor_to_nla", text="", icon="NLA")
+
+            row = layout.row(align=True)
+
+            row.operator("wm.switch_editor_to_timeline", text="", icon="TIME") # BFA - legacy, but toggles the dopesheet to timeline on a short-hand
 
         ###########################
 
-        layout.template_header()
+        #layout.template_header()
 
         if st.mode != 'TIMELINE':
             # Timeline mode is special, as it's presented as a sub-type of the
@@ -322,11 +365,10 @@ class DOPESHEET_HT_editor_buttons:
     def draw_header(cls, context, layout):
         st = context.space_data
         tool_settings = context.tool_settings
-        ds_mode = context.space_data.mode  # BFAu
+        ds_mode = context.space_data.mode  # BFA
 
         if st.mode == 'TIMELINE':
             playback_controls(layout, context)
-            layout.separator()
             cls._draw_overlay_selector(context, layout)
             return
 
@@ -1400,11 +1442,13 @@ class DOPESHEET_PT_dopesheet_overlay(Panel):
 
 
 classes = (
+    ANIM_OT_switch_editors_to_timeline, # BFA menu
     ANIM_OT_switch_editors_to_dopesheet,  # BFA menu
     ANIM_OT_switch_editors_to_graph,  # BFA menu
     ANIM_OT_switch_editors_to_driver,  # BFA menu
     ANIM_OT_switch_editors_to_nla,  # BFA menu
     ANIM_OT_switch_editors_in_dopesheet,  # BFA menu
+    ANIM_OT_switch_editors_in_timeline, # BFA menu
     DOPESHEET_HT_header,
     DOPESHEET_HT_playback_controls,
     DOPESHEET_PT_proportional_edit,

--- a/scripts/startup/bl_ui/space_graph.py
+++ b/scripts/startup/bl_ui/space_graph.py
@@ -24,7 +24,7 @@ from bl_ui.space_time import playback_controls
 
 
 class ANIM_OT_switch_editor_in_graph(Operator):
-    """You are in Graph Editor"""  # blender will use this as a tooltip for menu items and buttons.
+    """You are in the Graph Editor"""  # blender will use this as a tooltip for menu items and buttons.
 
     bl_idname = "wm.switch_editor_in_graph"  # unique identifier for buttons and menu items to reference.
     bl_label = "Graph Editor"  # display name in the interface.
@@ -35,7 +35,7 @@ class ANIM_OT_switch_editor_in_graph(Operator):
 
 
 class ANIM_OT_switch_editor_in_driver(Operator):
-    """You are in Driver Editor"""  # blender will use this as a tooltip for menu items and buttons.
+    """You are in the Driver Editor"""  # blender will use this as a tooltip for menu items and buttons.
 
     bl_idname = "wm.switch_editor_in_driver"  # unique identifier for buttons and menu items to reference.
     bl_label = "Driver Editor"  # display name in the interface.

--- a/scripts/startup/bl_ui/space_nla.py
+++ b/scripts/startup/bl_ui/space_nla.py
@@ -18,7 +18,7 @@ from bl_ui.space_time import playback_controls
 
 
 class ANIM_OT_switch_editors_in_nla(bpy.types.Operator):
-    """You are in Nonlinear Animation Editor"""  # blender will use this as a tooltip for menu items and buttons.
+    """You are in the Nonlinear Animation Editor"""  # blender will use this as a tooltip for menu items and buttons.
 
     bl_idname = "wm.switch_editor_in_nla"  # unique identifier for buttons and menu items to reference.
     bl_label = "Nonlinear Animation Editor"  # display name in the interface.

--- a/scripts/startup/bl_ui/space_time.py
+++ b/scripts/startup/bl_ui/space_time.py
@@ -54,17 +54,18 @@ def playback_controls(layout, context):
     # BFA - exposed to top sequencer header, where contextually relevant, make sure 3D Sequencer is enabled
     if is_sequencer and not addon_utils.check("bfa_3Dsequencer")[0]:
         layout.prop(context.workspace, "use_scene_time_sync", text="Sync Scene Time")
-    if tool_settings and not is_timeline:
-        # The Keyframe settings are not exposed in the Timeline view.
-        icon_keytype = 'KEYTYPE_{:s}_VEC'.format(tool_settings.keyframe_type)
-        layout.popover(
-            panel="TIME_PT_keyframing_settings",
-            text_ctxt=i18n_contexts.id_windowmanager,
-            icon=icon_keytype,
-        )
 
     layout.separator_spacer()
     # BFA - moved dropdowns to consistently float right
+
+    # Time jump
+    row = layout.row(align=True)
+    row.operator("screen.time_jump", text="", icon='FRAME_PREV').backward = True
+    row.prop(scene, "time_jump_delta", text="")
+    row.operator("screen.time_jump", text="", icon='FRAME_NEXT').backward = False
+    row.popover(panel="TIME_PT_jump", text="")
+
+    row = layout.row(align=True)
 
     row.operator("screen.frame_jump", text="", icon="REW").end = False
     row.operator("screen.keyframe_jump", text="", icon="PREV_KEYFRAME").next = False
@@ -88,13 +89,6 @@ def playback_controls(layout, context):
     row.operator("screen.keyframe_jump", text="", icon="NEXT_KEYFRAME").next = True
     row.operator("screen.frame_jump", text="", icon="FF").end = True
     row.operator("screen.animation_cancel", text="", icon="LOOP_BACK").restore_frame = True
-
-    # Time jump
-    row = layout.row(align=True)
-    row.operator("screen.time_jump", text="", icon='FRAME_PREV').backward = True
-    row.prop(scene, "time_jump_delta", text="")
-    row.operator("screen.time_jump", text="", icon='FRAME_NEXT').backward = False
-    row.popover(panel="TIME_PT_jump", text="")
 
     # BFA - removed separator_spacer to center controls better
 
@@ -156,6 +150,7 @@ def playback_controls(layout, context):
             )
 
         if tool_settings:
+            # BFA - The Keyframe settings are exposed in the Timeline view.
             icon_keytype = 'KEYTYPE_{:s}_VEC'.format(tool_settings.keyframe_type)
             layout.popover(
                 panel="TIME_PT_keyframing_settings",
@@ -164,11 +159,10 @@ def playback_controls(layout, context):
             )
 
         # BFA - Make this only show in the timeline editor to not show this in the footer.
-        if (getattr(context.space_data, "mode", "") == "TIMELINE"):
-            layout.popover(panel="TIME_PT_view_view_options", text="")
+        if is_timeline:
+            layout.popover(panel="TIME_PT_view_view_options", text="Options")
 
 # BFA - Legacy
-
 
 class TIME_MT_editor_menus(bpy.types.Menu):
     bl_idname = "TIME_MT_editor_menus"
@@ -193,8 +187,6 @@ class TIME_MT_editor_menus(bpy.types.Menu):
             sub.menu("DOPESHEET_MT_select")  # BFA
 
 # BFA - Legacy
-
-
 class TIME_MT_marker(bpy.types.Menu):
     bl_label = "Marker"
 
@@ -203,9 +195,8 @@ class TIME_MT_marker(bpy.types.Menu):
 
         marker_menu_generic(layout, context)
 
+
 # BFA - Legacy
-
-
 class TIME_MT_view(bpy.types.Menu):
     bl_label = "View"
 
@@ -239,41 +230,7 @@ class TIME_MT_view(bpy.types.Menu):
 
         layout.separator()
 
-        layout.menu("DOPESHEET_MT_cache")  # BFA - WIP - move to options
-
-        layout.separator()
-
         layout.menu("INFO_MT_area")
-
-
-class TIME_MT_view(Menu):
-    bl_label = "View"
-
-    def draw(self, context):
-        layout = self.layout
-        scene = context.scene
-        st = context.space_data
-        layout.prop(st, "show_region_hud")
-        layout.prop(st, "show_region_channels")
-        layout.separator()
-        layout.operator("action.view_all")
-        if context.scene.use_preview_range:
-            layout.operator("anim.scene_range_frame", text="Frame Preview Range")
-        else:
-            layout.operator("anim.scene_range_frame", text="Frame Scene Range")
-        layout.operator("action.view_frame")
-        layout.separator()
-        layout.prop(st, "show_markers")
-        layout.prop(st, "show_seconds")
-        layout.prop(st, "show_locked_time")
-        layout.separator()
-        layout.prop(scene, "show_keys_from_selected_only")
-        layout.prop(st.dopesheet, "show_only_errors")
-        layout.separator()
-        layout.menu("DOPESHEET_MT_cache")
-        layout.separator()
-        layout.menu("INFO_MT_area")
-
 
 def marker_menu_generic(layout, context):
     # layout.operator_context = 'EXEC_REGION_WIN'


### PR DESCRIPTION
- Cleaned up the tooltips
- Added a timeline toggle into the dopesheet for short-hand
- Moved the frame jump left, to the playback is more center (as it used to be)
- Made the timeline "options" consistent with the other animation editors
- Cleaned up the View menu to use our one insted of the Blender one that got merged in.
- Removed doubles

