### PR TITLE
Compositor - Sequencer Mode - Unsupported Inputs icon needs to be made consistent #5805

### DIFF
--- a/source/blender/nodes/composite/nodes/node_composite_group_input.cc
+++ b/source/blender/nodes/composite/nodes/node_composite_group_input.cc
@@ -189,7 +189,7 @@ void get_compositor_group_input_extra_info(blender::nodes::NodeExtraInfoParams &
       }
       blender::nodes::NodeExtraInfoRow row;
       row.text = IFACE_("Unsupported Inputs");
-      row.icon = ICON_WARNING_LARGE;
+      row.icon = ICON_ERROR;
       row.tooltip = TIP_(
           "Only a main Image and Mask inputs are supported, the rest are unsupported and will "
           "return zero");


### PR DESCRIPTION
Used `ICON_ERROR` since all the other error tooltips used that.

| Before | After |
| --- | --- |
| <img width="489" height="556" alt="image" src="https://github.com/user-attachments/assets/37b45b17-05e6-4b90-9616-ed7a17da917c" /> | <img width="495" height="560" alt="image" src="https://github.com/user-attachments/assets/30b26cb6-e499-40f7-b51b-12fdf43e13a2" /> |