### PR TITLE
3D View - Aramture - Weight Paint - Overlays - Bone Wireframe Opacity fix#5820

### DIFF
--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -10179,7 +10179,7 @@ class VIEW3D_PT_overlay_bones(Panel):
     bl_space_type = "VIEW_3D"
     bl_region_type = "HEADER"
     bl_label = "Bones"
-    bl_ui_units_x = 14
+    bl_ui_units_x = 18 # BFA - made wider for the label
 
     @staticmethod
     def is_using_wireframe(context):
@@ -10237,6 +10237,7 @@ class VIEW3D_PT_overlay_bones(Panel):
             row.prop(overlay, "show_xray_bone")
             row = col.row()
             #row.active = shading.type == "WIREFRAME" # BFA - WIP - you can tune this always?
+            row.use_property_split = True # BFA
             row.prop(overlay, "bone_wire_alpha")
 
 


### PR DESCRIPTION
<img width="1591" height="594" alt="image" src="https://github.com/user-attachments/assets/fe326ff8-ae5f-4599-be2c-cd243f670686" />

The overlay for bone wireframe opacicy was under the object overlays, but shouldn't be - only on armature. Now exposed correctly. 
I also split the label. 

