### PR TITLE
Geometry Nodes - Sidebar Toolshelf - Fix inconsistent name for vector Map Range #5828

### DIFF
--- a/scripts/startup/bl_ui/space_node_toolshelf.py
+++ b/scripts/startup/bl_ui/space_node_toolshelf.py
@@ -2643,7 +2643,7 @@ class NODES_PT_toolshelf_gn_add_utilities_vector(bpy.types.Panel, NodePanel):
         # When adding a new node, test different padding amounts until the button text is left-aligned with the rest of the panel items.
         entries = (
             OperatorEntry("ShaderNodeCombineXYZ", pad=4),
-            OperatorEntry("ShaderNodeMapRange", text="Map Range Vector", pad=9, settings={"data_type": "'FLOAT_VECTOR'"}),
+            OperatorEntry("ShaderNodeMapRange", pad=9, settings={"data_type": "'FLOAT_VECTOR'"}),
             OperatorEntry("ShaderNodeMix", text="Mix Vector", pad=9, settings={"data_type": "'VECTOR'"}),
             OperatorEntry("ShaderNodeSeparateXYZ", pad=4),
             Separator,


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="283" height="170" alt="Image" src="https://github.com/user-attachments/assets/00c6b7a0-e68b-4f7c-aaa3-d3d79396e91d" /> | <img width="295" height="166" alt="image" src="https://github.com/user-attachments/assets/9f1bedc2-9f56-4738-8cb3-5027721066fa" /> |