### PR TITLE
Fix: 5836-icons---modal-toolshelf---create-and-compile-weight-paint-i…

### DIFF
--- a/release/datafiles/icons/brush.paint_weight.average.dat
+++ b/release/datafiles/icons/brush.paint_weight.average.dat
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d4b2f6c792b12926cf03cddd9b9b6d2166c7e37fed22d48ce7503ef3a1f75e7e
-size 3284
+oid sha256:e200ee569a1d915dfe396266e926ba7619d17932a9bf474edcde1d8f166bbf59
+size 31202

--- a/release/datafiles/icons/brush.paint_weight.blur.dat
+++ b/release/datafiles/icons/brush.paint_weight.blur.dat
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a06f9541ef8f0f4e4eb1e06999cf26be3721a9edf4a6e9f8c19c70db85cfc127
-size 1304
+oid sha256:b11c57ed8ad18a7000a77ca5195aa99dcb107e5bec1b35866c4718b2121d4be8
+size 20492

--- a/release/datafiles/icons/brush.paint_weight.smear.dat
+++ b/release/datafiles/icons/brush.paint_weight.smear.dat
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:62d81b0f5c74b07654fbd74adcee09e40bdb536ec7889a37c37e954565a67a17
-size 1700
+oid sha256:29f6ebfff170cefcc1b40e039a76bef180ce6d9df5b9412ee4b48e4fe39a9d08
+size 19592

--- a/source/blender/editors/datafiles/CMakeLists.txt
+++ b/source/blender/editors/datafiles/CMakeLists.txt
@@ -39,6 +39,9 @@ set_property(GLOBAL PROPERTY ICON_GEOM_NAMES
   brush.paint_vertex.average
   brush.paint_vertex.blur
   brush.paint_vertex.smear
+  brush.paint_weight.average
+  brush.paint_weight.blur
+  brush.paint_weight.smear
   brush.particle.add
   brush.particle.comb
   brush.particle.cut


### PR DESCRIPTION
-- added the brush weight paint entries to generate their .dat files

<img width="189" height="299" alt="Screenshot_20251101_164642" src="https://github.com/user-attachments/assets/65c9403b-bad0-42f7-a86b-ca44bed9cb99" />

