### PR TITLE
Text Editor - Remove redundant redo/undo operators #5683

### DIFF
--- a/scripts/startup/bl_ui/space_text.py
+++ b/scripts/startup/bl_ui/space_text.py
@@ -420,8 +420,8 @@ class TEXT_MT_edit(Menu):
         layout.operator("text.paste", icon="PASTEDOWN")
         layout.operator("text.duplicate_line", icon="DUPLICATE")
 
-        layout.operator("ed.undo", icon='LOOP_BACK')
-        layout.operator("ed.redo", icon='LOOP_FORWARDS')
+        # layout.operator("ed.undo", icon='LOOP_BACK') # BFA - remove double entry with main header
+        # layout.operator("ed.redo", icon='LOOP_FORWARDS') # BFA - remove double entry with main header
         layout.separator()
 
         layout.operator("text.move_lines", text="Move Line(s) Up", icon="MOVE_UP").direction = 'UP'


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="332" height="196" alt="image" src="https://github.com/user-attachments/assets/9b22846b-f0c2-4746-bb6c-19c13b08feec" /> | <img width="315" height="134" alt="image" src="https://github.com/user-attachments/assets/44795a39-8d89-44a1-b859-69f5a33140e2" /> |