### PR TITLE
Grease Pencil - Draw Mode - Draw Menu > Cleanup > Reproject Strokes - Align prop left in Adjust Last Operator panel #5707

### DIFF
--- a/source/blender/editors/grease_pencil/intern/grease_pencil_edit.cc
+++ b/source/blender/editors/grease_pencil/intern/grease_pencil_edit.cc
@@ -3384,6 +3384,7 @@ static void grease_pencil_reproject_ui(bContext * /*C*/, wmOperator *op)
     row->prop(op->ptr, "offset", UI_ITEM_NONE, std::nullopt, ICON_NONE);
   }
   row = &layout->row(true);
+  row->use_property_split_set(false); /* BFA - float bool property left*/
   row->prop(op->ptr, "keep_original", UI_ITEM_NONE, std::nullopt, ICON_NONE);
 }
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="306" height="101" alt="image" src="https://github.com/user-attachments/assets/8cd7d032-bdc8-4f93-ba14-500a9d959c4f" /> | <img width="300" height="100" alt="image" src="https://github.com/user-attachments/assets/b1aea9f6-81ee-4b98-87af-39ebe5f34d30" /> |