### PR TITLE
Node Editor - Node menu - Move new Swap submenu to header #5856

### DIFF
--- a/scripts/startup/bl_ui/space_node.py
+++ b/scripts/startup/bl_ui/space_node.py
@@ -429,6 +429,7 @@ class NODE_MT_editor_menus(Menu):
         layout.menu("NODE_MT_view")
         layout.menu("NODE_MT_select")
         layout.menu("NODE_MT_add")
+        layout.menu("NODE_MT_swap") # BFA - Move "Swap" menu to header
         layout.menu("NODE_MT_node")
 
 
@@ -710,7 +711,7 @@ class NODE_MT_node(Menu):
         layout.menu("NODE_MT_node_links")
 
         layout.separator()
-        layout.menu("NODE_MT_swap")
+        # layout.menu("NODE_MT_swap") # BFA - Move to header
 		## BFA - set to sub-menu
         layout.menu("NODE_MT_node_group_separate")
 


### PR DESCRIPTION
Moved the header, removed from the "Node" menu.

| Before | After |
| --- | --- |
| <img width="454" height="82" alt="image" src="https://github.com/user-attachments/assets/456a13a5-fbb0-4194-9b0c-70f255d80955" /> | <img width="510" height="101" alt="image" src="https://github.com/user-attachments/assets/a6117060-d28f-4126-a309-7f4347aaf8f4" /> |
| <img width="274" height="546" alt="image" src="https://github.com/user-attachments/assets/1441b30f-edb2-4782-8209-8fb11332a70f" /> | <img width="267" height="517" alt="image" src="https://github.com/user-attachments/assets/22a742e6-ca48-4bc1-872d-e65dab7599d4" /> |
