### PR TITLE
Cleanup: Node Editor - Toolshelf - Remove erroneous docstrings

### DIFF
--- a/scripts/startup/bl_ui/space_node_toolshelf.py
+++ b/scripts/startup/bl_ui/space_node_toolshelf.py
@@ -193,7 +193,6 @@ class NODES_PT_toolshelf_display_settings_relations(bpy.types.Panel):
 
 
 class NODES_PT_relations_group_operations(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Group"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -235,7 +234,6 @@ class NODES_PT_relations_nodegroups(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_relations_layout(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Layout"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -256,7 +254,6 @@ class NODES_PT_relations_layout(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_shader_add_input(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Input"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -315,7 +312,6 @@ class NODES_PT_toolshelf_shader_add_input(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_shader_add_output(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Output"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -358,7 +354,6 @@ class NODES_PT_toolshelf_shader_add_output(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_shader_add_shader(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Shader"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -430,7 +425,6 @@ class NODES_PT_toolshelf_shader_add_shader(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_shader_add_displacement(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Displacement"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -470,7 +464,6 @@ class NODES_PT_toolshelf_shader_add_displacement(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_shader_add_color(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Color"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -531,7 +524,6 @@ class NODES_PT_toolshelf_shader_add_color(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_shader_add_texture(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Texture"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -583,7 +575,6 @@ class NODES_PT_toolshelf_shader_add_texture(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_shader_add_utilities(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Utilities"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -631,7 +622,6 @@ class NODES_PT_toolshelf_shader_add_utilities(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_shader_add_vector(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Vector"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -684,7 +674,6 @@ class NODES_PT_toolshelf_shader_add_vector(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_shader_add_math(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Math"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -726,7 +715,6 @@ class NODES_PT_toolshelf_shader_add_math(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_shader_add_script(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Script"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -751,7 +739,6 @@ class NODES_PT_toolshelf_shader_add_script(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_compositor_add_input(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Input"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -780,7 +767,6 @@ class NODES_PT_toolshelf_compositor_add_input(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_compositor_add_input_constant(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Constant"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -804,7 +790,6 @@ class NODES_PT_toolshelf_compositor_add_input_constant(bpy.types.Panel, NodePane
 
 
 class NODES_PT_toolshelf_compositor_add_input_scene(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Scene"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -828,7 +813,6 @@ class NODES_PT_toolshelf_compositor_add_input_scene(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_compositor_add_output(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Output"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -856,7 +840,6 @@ class NODES_PT_toolshelf_compositor_add_output(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_compositor_add_color(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Color"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -889,7 +872,6 @@ class NODES_PT_toolshelf_compositor_add_color(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_compositor_add_color_adjust(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Adjust"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -920,7 +902,6 @@ class NODES_PT_toolshelf_compositor_add_color_adjust(bpy.types.Panel, NodePanel)
 
 
 class NODES_PT_toolshelf_compositor_add_color_mix(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Mix"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -948,7 +929,6 @@ class NODES_PT_toolshelf_compositor_add_color_mix(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_compositor_add_filter(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Filter"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -985,7 +965,6 @@ class NODES_PT_toolshelf_compositor_add_filter(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_compositor_add_filter_blur(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Blur"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1012,7 +991,6 @@ class NODES_PT_toolshelf_compositor_add_filter_blur(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_compositor_add_keying(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Keying"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1045,7 +1023,6 @@ class NODES_PT_toolshelf_compositor_add_keying(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_compositor_add_mask(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Mask"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1077,7 +1054,6 @@ class NODES_PT_toolshelf_compositor_add_mask(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_compositor_add_tracking(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Tracking"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1136,7 +1112,6 @@ class NODES_PT_toolshelf_compositor_add_texture(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_compositor_add_transform(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Transform"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1236,7 +1211,6 @@ class NODES_PT_toolshelf_compositor_add_utilities_math(bpy.types.Panel, NodePane
 
 
 class NODES_PT_toolshelf_compositor_add_utilities_vector(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Vector"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1270,7 +1244,6 @@ class NODES_PT_toolshelf_compositor_add_utilities_vector(bpy.types.Panel, NodePa
 
 
 class NODES_PT_toolshelf_texture_add_input(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Input"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1297,7 +1270,6 @@ class NODES_PT_toolshelf_texture_add_input(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_texture_add_output(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Output"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1323,7 +1295,6 @@ class NODES_PT_toolshelf_texture_add_output(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_texture_add_color(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Color"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1354,7 +1325,6 @@ class NODES_PT_toolshelf_texture_add_color(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_texture_add_converter(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Converter"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1384,7 +1354,6 @@ class NODES_PT_toolshelf_texture_add_converter(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_texture_add_distort(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Distort"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1412,7 +1381,6 @@ class NODES_PT_toolshelf_texture_add_distort(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_texture_add_pattern(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Pattern"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1438,7 +1406,6 @@ class NODES_PT_toolshelf_texture_add_pattern(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_texture_add_texture(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Textures"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1473,7 +1440,6 @@ class NODES_PT_toolshelf_texture_add_texture(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_attribute(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Attribute"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1504,7 +1470,6 @@ class NODES_PT_toolshelf_gn_add_attribute(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_input(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Input"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1519,7 +1484,6 @@ class NODES_PT_toolshelf_gn_add_input(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_input_constant(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Constant"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1550,7 +1514,6 @@ class NODES_PT_toolshelf_gn_add_input_constant(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_input_gizmo(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Gizmo"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1574,7 +1537,6 @@ class NODES_PT_toolshelf_gn_add_input_gizmo(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_input_file(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Import"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1601,7 +1563,6 @@ class NODES_PT_toolshelf_gn_add_input_file(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_input_scene(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Scene"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1635,7 +1596,6 @@ class NODES_PT_toolshelf_gn_add_input_scene(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_output(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Output"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1662,7 +1622,6 @@ class NODES_PT_toolshelf_gn_add_output(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_geometry(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Geometry"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1688,7 +1647,6 @@ class NODES_PT_toolshelf_gn_add_geometry(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_geometry_read(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Read"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1722,7 +1680,6 @@ class NODES_PT_toolshelf_gn_add_geometry_read(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_geometry_sample(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Sample"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1752,7 +1709,6 @@ class NODES_PT_toolshelf_gn_add_geometry_sample(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_geometry_write(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Write"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1781,7 +1737,6 @@ class NODES_PT_toolshelf_gn_add_geometry_write(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_geometry_operations(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Operations"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1818,7 +1773,6 @@ class NODES_PT_toolshelf_gn_add_geometry_operations(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_curve(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Curve"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1834,7 +1788,6 @@ class NODES_PT_toolshelf_gn_add_curve(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_curve_read(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Read"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1869,7 +1822,6 @@ class NODES_PT_toolshelf_gn_add_curve_read(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_curve_sample(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Sample"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1895,7 +1847,6 @@ class NODES_PT_toolshelf_gn_add_curve_sample(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_curve_write(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Write"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1928,7 +1879,6 @@ class NODES_PT_toolshelf_gn_add_curve_write(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_curve_operations(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Operations"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1965,7 +1915,6 @@ class NODES_PT_toolshelf_gn_add_curve_operations(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_curve_primitives(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Primitives"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -1998,7 +1947,6 @@ class NODES_PT_toolshelf_gn_add_curve_primitives(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_curve_topology(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Topology"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2026,7 +1974,6 @@ class NODES_PT_toolshelf_gn_add_curve_topology(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_grease_pencil(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Grease Pencil"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2042,7 +1989,6 @@ class NODES_PT_toolshelf_gn_add_grease_pencil(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_grease_pencil_read(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Read"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2068,7 +2014,6 @@ class NODES_PT_toolshelf_gn_add_grease_pencil_read(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_grease_pencil_write(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Write"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2096,7 +2041,6 @@ class NODES_PT_toolshelf_gn_add_grease_pencil_write(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_grease_pencil_operations(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Operations"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2123,7 +2067,6 @@ class NODES_PT_toolshelf_gn_add_grease_pencil_operations(bpy.types.Panel, NodePa
 
 
 class NODES_PT_toolshelf_gn_add_instances(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Instances"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2159,7 +2102,6 @@ class NODES_PT_toolshelf_gn_add_instances(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_mesh(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Mesh"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2175,7 +2117,6 @@ class NODES_PT_toolshelf_gn_add_mesh(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_mesh_read(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Read"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2216,7 +2157,6 @@ class NODES_PT_toolshelf_gn_add_mesh_read(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_mesh_sample(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Sample"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2243,7 +2183,6 @@ class NODES_PT_toolshelf_gn_add_mesh_sample(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_mesh_write(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Write"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2271,7 +2210,6 @@ class NODES_PT_toolshelf_gn_add_mesh_write(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_mesh_operations(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Operations"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2312,7 +2250,6 @@ class NODES_PT_toolshelf_gn_add_mesh_operations(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_mesh_primitives(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Primitives"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2346,7 +2283,6 @@ class NODES_PT_toolshelf_gn_add_mesh_primitives(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_mesh_topology(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Topology"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2380,7 +2316,6 @@ class NODES_PT_toolshelf_gn_add_mesh_topology(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_mesh_uv(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "UV"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2407,7 +2342,6 @@ class NODES_PT_toolshelf_gn_add_mesh_uv(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_point(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Point"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2439,7 +2373,6 @@ class NODES_PT_toolshelf_gn_add_point(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_volume(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Volume"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2465,7 +2398,6 @@ class NODES_PT_toolshelf_gn_add_volume(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_simulation(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Simulation"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2490,7 +2422,6 @@ class NODES_PT_toolshelf_gn_add_simulation(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_material(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Material"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2519,7 +2450,6 @@ class NODES_PT_toolshelf_gn_add_material(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_texture(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Texture"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2553,7 +2483,6 @@ class NODES_PT_toolshelf_gn_add_texture(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_utilities(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Utilities"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2583,7 +2512,6 @@ class NODES_PT_toolshelf_gn_add_utilities(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_utilities_color(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Color"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2614,7 +2542,6 @@ class NODES_PT_toolshelf_gn_add_utilities_color(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_utilities_text(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Text"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2650,7 +2577,6 @@ class NODES_PT_toolshelf_gn_add_utilities_text(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_utilities_vector(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Vector"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2684,7 +2610,6 @@ class NODES_PT_toolshelf_gn_add_utilities_vector(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_utilities_bundle(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Bundle"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2713,7 +2638,6 @@ class NODES_PT_toolshelf_gn_add_utilities_bundle(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_utilities_closure(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Closure"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2743,7 +2667,6 @@ class NODES_PT_toolshelf_gn_add_utilities_closure(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_utilities_field(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Field"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2774,7 +2697,6 @@ class NODES_PT_toolshelf_gn_add_utilities_field(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_utilities_math(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Math"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2811,7 +2733,6 @@ class NODES_PT_toolshelf_gn_add_utilities_math(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_utilities_matrix(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Matrix"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2847,7 +2768,6 @@ class NODES_PT_toolshelf_gn_add_utilities_matrix(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_utilities_rotation(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Rotation"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'
@@ -2883,7 +2803,6 @@ class NODES_PT_toolshelf_gn_add_utilities_rotation(bpy.types.Panel, NodePanel):
 
 
 class NODES_PT_toolshelf_gn_add_utilities_deprecated(bpy.types.Panel, NodePanel):
-    """Creates a Panel in the Object properties window"""
     bl_label = "Deprecated"
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'UI'


### PR DESCRIPTION
I think this was a description from the Panel example in the code templates.
Basically just got copied over to all the toolshelf panels, even though the description isn't correct here.