### PR TITLE
Fix: 5886-switching-the-bone-while-weight-paint

### DIFF
--- a/scripts/presets/keyconfig/Bforartists.py
+++ b/scripts/presets/keyconfig/Bforartists.py
@@ -8494,14 +8494,14 @@ keyconfig_data = \
     ("paint.weight_sample", {"type": 'RIGHTMOUSE', "value": 'PRESS', "ctrl": True}, None),
     ("paint.weight_sample_group", {"type": 'RIGHTMOUSE', "value": 'PRESS', "shift": True}, None),
     ("paint.weight_gradient",
-     {"type": 'LEFTMOUSE', "value": 'PRESS', "alt": True},
+     {"type": 'A', "value": 'PRESS', "shift": True},
      {"properties":
       [("type", 'LINEAR'),
        ],
       },
      ),
     ("paint.weight_gradient",
-     {"type": 'LEFTMOUSE', "value": 'PRESS', "ctrl": True, "alt": True},
+     {"type": 'A', "value": 'PRESS', "shift": True, "alt": True},
      {"properties":
       [("type", 'RADIAL'),
        ],


### PR DESCRIPTION
-- Changed the paint.weight_gradient keymap to match blender's, this was overriding the alt + left mouse to select bones while in weight paint mode, this matches our blender does it.

our Bforartists-Macos.py keymaps was already doing this!

