### PR TITLE
Sequencer + Compositor - New "Sequencer" mode with Sequencer Info strip #5806

### DIFF
--- a/source/blender/makesrna/intern/rna_nodetree.cc
+++ b/source/blender/makesrna/intern/rna_nodetree.cc
@@ -10100,7 +10100,7 @@ static void rna_def_nodes(BlenderRNA *brna)
   define(brna, "CompositorNode", "CompositorNodeSetAlpha", nullptr, ICON_IMAGE_ALPHA);
   define(brna, "CompositorNode", "CompositorNodeSplit", nullptr, ICON_NODE_VIWERSPLIT);
   define(brna, "CompositorNode", "CompositorNodeStabilize", def_cmp_stabilize2d, ICON_NODE_STABILIZE2D);
-  define(brna, "CompositorNode", "CompositorNodeSequencerStripInfo", nullptr, ICON_INFO);
+  define(brna, "CompositorNode", "CompositorNodeSequencerStripInfo", nullptr, ICON_SEQUENCE);
   define(brna, "CompositorNode", "CompositorNodeSwitch", nullptr, ICON_SWITCH_DIRECTION);
   define(brna, "CompositorNode", "CompositorNodeSwitchView", nullptr, ICON_VIEW_SWITCHACTIVECAM);
   define(brna, "CompositorNode", "CompositorNodeTime", def_time, ICON_NODE_CURVE_TIME);


### PR DESCRIPTION
Changed icon of "Sequencer Strip Info" from "INFO" to "SEQUENCE"

| Before | After |
| --- | --- |
| <img width="246" height="240" alt="image" src="https://github.com/user-attachments/assets/7a01badf-e7b0-4e75-8246-b4926e88bc0c" /> | <img width="262" height="242" alt="image" src="https://github.com/user-attachments/assets/fba738c9-615f-42b3-94a4-1b548dcad34d" /> |