### PR TITLE
Mesh - Particle Edit Mode - Sidebar > Tool Tab > Options panel - Shorten labels of props under "Preserve" sublayout  #5889

### DIFF
--- a/scripts/startup/bl_ui/space_view3d_toolbar.py
+++ b/scripts/startup/bl_ui/space_view3d_toolbar.py
@@ -1694,10 +1694,10 @@ class VIEW3D_PT_tools_particlemode_options(View3DPanel, Panel):
         col.label(text="Preserve")
         row = col.row()
         row.separator()
-        row.prop(pe, "use_preserve_length", text="Preserve Strand Lengths")
-        row = col.row()
-        row.separator()
-        row.prop(pe, "use_preserve_root", text="Preserve Root Positions")
+        # BFA - Use cleaner indentation method
+        subcol = row.column(align=True)
+        subcol.prop(pe, "use_preserve_length", text="Strand Lengths") # BFA - Remove "Preserve" in prop label
+        subcol.prop(pe, "use_preserve_root", text="Root Positions") # BFA - Remove "Preserve" in prop label
 
 
 class VIEW3D_PT_tools_particlemode_options_shapecut(View3DPanel, Panel):


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="292" height="181" alt="image" src="https://github.com/user-attachments/assets/353f6e23-a7b0-492a-be45-7effd522b828" /> | <img width="293" height="183" alt="image" src="https://github.com/user-attachments/assets/962ae973-4b5d-48e8-9c82-9a33ddd2c65d" /> |