### PR TITLE
Fix: 5901-3d-view-in-quadview-sidebar-view-tab-indent-props-in-quadvi…

### DIFF
--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -10757,9 +10757,11 @@ class VIEW3D_PT_quad_view(Panel):
         col.prop(region, "lock_rotation")
         row = col.row()
         row.enabled = region.lock_rotation
+        row.separator() # bfa - indent
         row.prop(region, "show_sync_view")
         row = col.row()
         row.enabled = region.lock_rotation and region.show_sync_view
+        row.separator(factor=3.4) # bfa - indent from show_sync_view
         row.prop(region, "use_box_clip")
 
 


### PR DESCRIPTION
-- indent the quad view options like they were in the manual.

<img width="282" height="119" alt="image" src="https://github.com/user-attachments/assets/befc8de8-05dd-4ab9-a47a-8abfd80140a5" />

