### PR TITLE
Fix: 5905-3d-view-sidebar-animation-tab-fix-to-camera-subtab-align-pr…

### DIFF
--- a/scripts/startup/bl_ui/space_view3d_sidebar.py
+++ b/scripts/startup/bl_ui/space_view3d_sidebar.py
@@ -64,11 +64,17 @@ class VIEW3D_PT_copy_global_transform_fix_to_camera(GlobalTransformPanelMixin, P
         scene = context.scene
 
         # Fix to Scene Camera:
-        layout.use_property_split = False # BFA - align left
-        props_box = layout.column(heading="Fix", heading_ctxt=i18n_contexts.id_camera, align=True)
-        props_box.prop(scene.tool_settings, "anim_fix_to_cam_use_loc", text="Location")
-        props_box.prop(scene.tool_settings, "anim_fix_to_cam_use_rot", text="Rotation")
-        props_box.prop(scene.tool_settings, "anim_fix_to_cam_use_scale", text="Scale")
+        col = layout.column(align=True) # bfa - align left
+        col.label(text='Fix', text_ctxt=i18n_contexts.id_camera)
+        row = col.row()
+        row.separator() # bfa - indent
+        row.prop(scene.tool_settings, "anim_fix_to_cam_use_loc", text="Location")
+        row = col.row()
+        row.separator() # bfa - indent
+        row.prop(scene.tool_settings, "anim_fix_to_cam_use_rot", text="Rotation")
+        row = col.row()
+        row.separator() # bfa - indent
+        row.prop(scene.tool_settings, "anim_fix_to_cam_use_scale", text="Scale")
 
         keyingset = AutoKeying.active_keyingset(context)
         if keyingset:


### PR DESCRIPTION
-- align left the Fix to Camera props.

<img width="202" height="355" alt="image" src="https://github.com/user-attachments/assets/ec5e9b47-8faa-4ed7-8da9-09a1b74e38eb" />

