### PR TITLE
Fix: 5741-blender-icon-on-linux-instead-of-bfas

### DIFF
--- a/intern/ghost/intern/GHOST_SystemWayland.cc
+++ b/intern/ghost/intern/GHOST_SystemWayland.cc
@@ -9368,7 +9368,7 @@ static const char *ghost_wl_app_id = (
 #ifdef WITH_GHOST_WAYLAND_APP_ID
     STRINGIFY(WITH_GHOST_WAYLAND_APP_ID)
 #else
-    "blender"
+    "Bforartists" /* bfa - keep this has Bforartists, this is the app name under wayland! */
 #endif
 );
 


### PR DESCRIPTION
-- set our Bforartists name for the app id under wayland on linux (again??, swear I did this once before???).

