### PR TITLE
Fix: 5734-particle-mode-with-mesh-object---missing-background-in-side…

### DIFF
--- a/scripts/startup/bl_ui/space_view3d_toolbar.py
+++ b/scripts/startup/bl_ui/space_view3d_toolbar.py
@@ -357,7 +357,6 @@ class View3DPaintBrushPanel(View3DPaintPanel):
 class VIEW3D_PT_tools_particlemode(Panel, View3DPaintPanel):
     bl_context = ".paint_common"  # dot on purpose (access from topbar)
     bl_label = "Particle Tool"
-    bl_options = {"HIDE_HEADER"}
 
     @classmethod
     def poll(cls, context):


### PR DESCRIPTION
-- removed the HIDE_HEADER

<img width="270" height="231" alt="image" src="https://github.com/user-attachments/assets/0635297e-635c-4047-9071-0cc6b02f3800" />

