### PR TITLE
Fix: 5934-image-editor-paint-mode-sidebar-tool-tab-stroke-mask-subpan…

### DIFF
--- a/scripts/startup/bl_ui/properties_paint_common.py
+++ b/scripts/startup/bl_ui/properties_paint_common.py
@@ -759,10 +759,7 @@ class SmoothStrokePanel(BrushPanel):
             return
 
         self.layout.use_property_split = False
-        # self.layout.prop(brush, "use_smooth_stroke",
-        #                 text=self.bl_label if self.is_popover else "")
-
-        self.layout.prop(brush, "use_smooth_stroke", text="Stabilize Stroke")  # bfa - we need the label
+        self.layout.prop(brush, "use_smooth_stroke", text=self.bl_label if self.is_popover else "")
 
     def draw(self, context):
         layout = self.layout

--- a/scripts/startup/bl_ui/space_view3d_toolbar.py
+++ b/scripts/startup/bl_ui/space_view3d_toolbar.py
@@ -932,7 +932,7 @@ class VIEW3D_PT_tools_brush_stroke(Panel, View3DPaintPanel, StrokePanel):
 
 class VIEW3D_PT_tools_brush_stroke_smooth_stroke(Panel, View3DPaintPanel, SmoothStrokePanel):
     bl_context = ".paint_common"  # dot on purpose (access from topbar)
-    bl_label = ""  # BFA - align props left
+    bl_label = "Stabilize Stroke" # bfa - this is the checkbox label in the 3d view sidebar!
     bl_parent_id = "VIEW3D_PT_tools_brush_stroke"
     bl_options = {"DEFAULT_CLOSED"}
 


### PR DESCRIPTION
-- removed second label
-- readded label for VIEW3D_PT_tools_brush_stroke_smooth_stroke, which is needed for the 3d view sidebar prop label

<img width="1283" height="283" alt="image" src="https://github.com/user-attachments/assets/fa5cc9be-4290-4de9-a93b-14fc524618f4" />


