### PR TITLE
3D View - Sidebar > Global Transform tab - Make tooltips unique for different paste operators #5906

### DIFF
--- a/scripts/startup/bl_operators/copy_global_transform.py
+++ b/scripts/startup/bl_operators/copy_global_transform.py
@@ -201,21 +201,26 @@ class OBJECT_OT_paste_transform(Operator):
     )
     bl_options = {'REGISTER', 'UNDO'}
 
+    # BFA - Add tooltip description for when operator is mirrored
+    _mirror_description = "(Transform is mirrored relative to the specified object or bone)"
     _method_items = [
         (
             'CURRENT',
             "Current Transform",
-            "Paste onto the current values only, only manipulating the animation data if auto-keying is enabled",
+            # BFA - Reword description for clarity
+            "Paste transform onto the current values, only manipulating the animation data if auto-keying is enabled",
         ),
         (
             'EXISTING_KEYS',
             "Selected Keys",
-            "Paste onto frames that have a selected key, potentially creating new keys on those frames",
+            # BFA - Reword description for clarity
+            "Paste transform onto frames that have a selected key, potentially creating new keys on those frames",
         ),
         (
             'BAKE',
             "Bake on Key Range",
-            "Paste onto all frames between the first and last selected key, creating new keyframes if necessary",
+            # BFA - Reword description for clarity
+            "Paste transform onto all frames between the first and last selected key, creating new keyframes if necessary",
         ),
     ]
     method: bpy.props.EnumProperty(  # type: ignore
@@ -261,6 +266,20 @@ class OBJECT_OT_paste_transform(Operator):
         default=False,
         options={'SKIP_SAVE'},
     )
+
+    # BFA - Make tooltip descriptions based on operator properties
+    @classmethod
+    def description(cls, context, properties):
+        for item in cls._method_items:
+            value, description = item[0], item[2]
+            if value == properties.method:
+
+                if properties.use_mirror:
+                    return description + ".\n" + cls._mirror_description
+                else:
+                    return description
+        
+        return cls.bl_description
 
     @classmethod
     def poll(cls, context: Context) -> bool:


### PR DESCRIPTION
The descriptions are derived from the operator's properties.
Slightly tweaked those property descriptions are they weren't phrased that clearly, prolly because they weren't assumed to be user-facing.

"Mirrored" is a special case, as it actually can apply to any of the three operator methods, so using the same description for each might not be accurate. Instead, the tooltip still uses the same description as its currently used method, and an extra line is added to indicate that the transform is mirrored.

| Before | After |
| --- | --- |
| <img width="617" height="75" alt="image" src="https://github.com/user-attachments/assets/afed825d-5415-4267-97ce-7f565ec0360c" /> | <img width="593" height="57" alt="image" src="https://github.com/user-attachments/assets/90129f56-7e33-41e3-b75e-315754eed5ad" /> |
| <img width="614" height="72" alt="image" src="https://github.com/user-attachments/assets/94c73e09-9a78-4601-b5af-e7868b33bffb" /> | <img width="595" height="70" alt="image" src="https://github.com/user-attachments/assets/5f67bfcc-a1f2-4509-9b39-7fb1de66c79a" /> |
| <img width="608" height="71" alt="image" src="https://github.com/user-attachments/assets/c931b490-91c6-4af3-996e-078d0e5926d3" /> | <img width="570" height="58" alt="image" src="https://github.com/user-attachments/assets/68e2ce50-8c81-46ea-82fa-6cfbd7b14165" /> |
| <img width="608" height="72" alt="image" src="https://github.com/user-attachments/assets/f16f5c56-7716-42ab-b3b7-7535572a4dd9" /> | <img width="606" height="55" alt="image" src="https://github.com/user-attachments/assets/02518d1d-a6f1-42d2-91e8-2583ef9f39ac" /> |