### PR TITLE
Image Editor - Paint Mode - Sidebar > Tool tab > Texture Map - Align Rake and Random props left #5933

### DIFF
--- a/scripts/startup/bl_ui/properties_paint_common.py
+++ b/scripts/startup/bl_ui/properties_paint_common.py
@@ -622,10 +622,12 @@ class TextureMaskPanel(BrushPanel):
             col = layout.column()
             col.prop(mask_tex_slot, "angle", text="Angle")
             if mask_tex_slot.has_texture_angle_source:
+                col.use_property_split = False # BFA - Align bool property left
                 col.prop(mask_tex_slot, "use_rake", text="Rake")
 
                 if brush.brush_capabilities.has_random_texture_angle and mask_tex_slot.has_random_texture_angle:
                     col.prop(mask_tex_slot, "use_random", text="Random")
+                    col.use_property_split = True # BFA - Align bool property left (end)
                     if mask_tex_slot.use_random:
                         col.prop(mask_tex_slot, "random_angle", text="Random Angle")
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="257" height="158" alt="image" src="https://github.com/user-attachments/assets/b6512f6d-0bfd-405b-a0e1-582b580b25b7" /> | <img width="272" height="183" alt="image" src="https://github.com/user-attachments/assets/60e52aec-ad50-4a4b-b40c-cc71cc6ea5bd" /> |