### PR TITLE
Image Editor - Paint Mode - Sidebar > Tool tab > Texture - Use split layout for Random Value Property #5948

### DIFF
--- a/scripts/startup/bl_ui/properties_paint_common.py
+++ b/scripts/startup/bl_ui/properties_paint_common.py
@@ -1955,6 +1955,7 @@ def brush_texture_settings(layout, brush, sculpt):
                             col.prop(tex_slot, "random_angle", text="Random Angle")
                 else:
                     col.prop(tex_slot, "use_random", text="Random")
+                    col.use_property_split = True  # BFA
                     if tex_slot.use_random:
                         col.prop(tex_slot, "random_angle", text="Random Angle")
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="260" height="154" alt="image" src="https://github.com/user-attachments/assets/c9888d11-a187-443b-a8d9-19bfa551adaf" /> | <img width="261" height="160" alt="image" src="https://github.com/user-attachments/assets/b58de12a-39b9-443e-9fdf-47cac0f398eb" /> |