### PR TITLE
Image Editor - Mask Mode - Sidebar > View tab > 2D Cursor panel - Use split layout for numerical sliders #5939

### DIFF
--- a/scripts/startup/bl_ui/space_image.py
+++ b/scripts/startup/bl_ui/space_image.py
@@ -1946,7 +1946,7 @@ class IMAGE_PT_uv_cursor(Panel):
 
         sima = context.space_data
 
-        layout.use_property_split = False
+        layout.use_property_split = True # BFA - use split for non-bool properties
         layout.use_property_decorate = False
 
         col = layout.column()


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="268" height="121" alt="image" src="https://github.com/user-attachments/assets/b0b33ce3-35f1-46e8-9a81-b241f7ce78b1" /> | <img width="262" height="118" alt="image" src="https://github.com/user-attachments/assets/46d42042-6c2f-4a63-8d40-c0d209c0b5df" /> |

