### PR TITLE
Image/UV Editor - Sidebar > Image tab - Use split layout for Seam Margin property #5951

### DIFF
--- a/source/blender/editors/space_image/image_buttons.cc
+++ b/source/blender/editors/space_image/image_buttons.cc
@@ -962,8 +962,8 @@ void uiTemplateImage(uiLayout *layout,
       }
       col->use_property_split_set(false); /* bfa - use_property_split = False */
       col->prop(&imaptr, "use_view_as_render", UI_ITEM_NONE, std::nullopt, ICON_NONE);
-      col->prop(&imaptr, "seam_margin", UI_ITEM_NONE, std::nullopt, ICON_NONE);
       col->use_property_split_set(true); /* bfa - use_property_split = True */
+      col->prop(&imaptr, "seam_margin", UI_ITEM_NONE, std::nullopt, ICON_NONE);
     }
   }
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="267" height="300" alt="image" src="https://github.com/user-attachments/assets/72b38c7d-9dcb-44b8-a904-abc9bb03e554" /> | <img width="261" height="310" alt="image" src="https://github.com/user-attachments/assets/12b08092-bf12-4ce9-bca4-ab9cb29f99c7" /> |


