### PR TITLE
Preferences - Editing - Node Editor - Use split layout for Node Color Blend property #5944

### DIFF
--- a/scripts/startup/bl_ui/space_userpref.py
+++ b/scripts/startup/bl_ui/space_userpref.py
@@ -614,6 +614,7 @@ class USERPREF_PT_edit_node_editor(EditingPanel, CenterAlignMixIn, Panel):
 
         col.use_property_split = False
         col.prop(edit, "node_use_autoposition_viewer")  # BFA - Toggle Viewer Auto-positioning
+        col.use_property_split = True # BFA - split non-boolean property
         col.prop(edit, "node_color_blend", text="Node Color Blend")  # BFA - Node Color Blend
 
 


### PR DESCRIPTION
| | |
| --- | --- |
| Before | <img width="710" height="168" alt="Image" src="https://github.com/user-attachments/assets/3b37883d-3de5-4a8a-b1b1-abfe416f0e42" /> |
| After | <img width="732" height="157" alt="image" src="https://github.com/user-attachments/assets/b8b6a78a-227a-4732-9a1a-b4d2b85eb6c9" /> |