### PR TITLE
Image Editor - Sidebar - View tab > Annotations panel - Use split layout for numerical sliders #5940

### DIFF
--- a/scripts/startup/bl_ui/properties_grease_pencil_common.py
+++ b/scripts/startup/bl_ui/properties_grease_pencil_common.py
@@ -393,11 +393,13 @@ class AnnotationDataPanel:
 
         tool_settings = context.tool_settings
         layout.use_property_split = True # BFA - split non-boolean properties
+
+        col = layout.column() # BFA - lessen vertical spacing between properties
         if gpd and gpl:
-            layout.prop(gpl, "annotation_opacity", text="Opacity", slider=True)
-            layout.prop(gpl, "thickness")
+            col.prop(gpl, "annotation_opacity", text="Opacity", slider=True)
+            col.prop(gpl, "thickness")
         else:
-            layout.prop(tool_settings, "annotation_thickness", text="Thickness")
+            col.prop(tool_settings, "annotation_thickness", text="Thickness")
 
         if gpl:
             # Full-Row - Frame Locking (and Delete Frame)


### PR DESCRIPTION
Aside from using a split layout, also did the small tweak of lessening the vertical spacing between sliders.
I personally just felt they were spaced apart just a bit too much.

| Before | After |
| --- | --- |
| <img width="266" height="233" alt="image" src="https://github.com/user-attachments/assets/e3a0fe71-1aeb-47a2-969a-c28a3c1a62b9" /> | <img width="262" height="226" alt="image" src="https://github.com/user-attachments/assets/9d66cf7f-496f-4da4-ab77-e2f5548c0d78" /> |