### PR TITLE
Image Editor - Paint Mode - Sidebar > Mask Brush > Brush Settings > Advanced - Use split layout for non-boolean properties #5928

### DIFF
--- a/scripts/startup/bl_ui/properties_paint_common.py
+++ b/scripts/startup/bl_ui/properties_paint_common.py
@@ -1783,6 +1783,8 @@ def brush_settings_advanced(layout, context, settings, brush, popover=False):
         else:
             layout.prop(brush, "use_alpha")
 
+        layout.use_property_split = True  # BFA
+
         # Tool specific settings
         if brush.image_brush_type == "SOFTEN":
             layout.separator()


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="261" height="160" alt="image" src="https://github.com/user-attachments/assets/65d4da76-c9d2-498c-a759-6362d7e55797" /> | <img width="262" height="153" alt="image" src="https://github.com/user-attachments/assets/2fa7008a-422f-4549-bbfb-cf7ca74ab591" /> |
| <img width="259" height="183" alt="image" src="https://github.com/user-attachments/assets/df7b9194-dc22-4f31-a420-797e1390cd18" /> | <img width="256" height="187" alt="image" src="https://github.com/user-attachments/assets/3e074acd-a290-4506-9051-a5a9f82c17d2" /> |
| <img width="258" height="153" alt="image" src="https://github.com/user-attachments/assets/01ed1c36-38d6-4ca6-85c8-c7f5ca35e826" /> | <img width="259" height="144" alt="image" src="https://github.com/user-attachments/assets/617833b0-36db-4120-9600-68a93cd9a839" /> |
