### PR TITLE
Fix: 5965-compositor-view-menu---double-menu-entry-asset-shelf

### DIFF
--- a/scripts/startup/bl_ui/space_node.py
+++ b/scripts/startup/bl_ui/space_node.py
@@ -529,7 +529,7 @@ class NODE_MT_view(Menu):
         layout.prop(snode, "show_region_toolbar")
         layout.prop(snode, "show_region_ui")
         layout.prop(snode, "show_toolshelf_tabs")
-        layout.prop(snode, "show_region_asset_shelf")
+        layout.prop(snode, "show_region_asset_shelf") # BFA - we dont need is_compositor since we show here!
 
         layout.separator()
 
@@ -547,9 +547,6 @@ class NODE_MT_view(Menu):
             layout.operator("node.connect_to_output", text="Link to Output",
                             icon='GROUPOUTPUT').run_in_geometry_nodes = True
             layout.operator("node.select_link_viewer", text="Link to Viewer", icon='RESTRICT_RENDER_OFF')
-
-        if is_compositor:
-            layout.prop(snode, "show_region_asset_shelf")
 
         layout.separator()
 
@@ -1325,11 +1322,11 @@ class NODE_PT_overlay(Panel):
 
         # BFA - World Center overlay
         col.separator()
-        
+
         split = col.split()
         row = split.row()
         row.prop(overlay, "show_world_center", text="Canvas Center")
-        
+
         if not overlay.show_world_center:
             row.label(icon="DISCLOSURE_TRI_RIGHT")
         else:


### PR DESCRIPTION
-- removed the is_compositor, since we already show the asset shelf in other places compared to blender.

