### PR TITLE
Fix: 5969-build---make-lite---missing-function-causes-make-lite-to-fail

### DIFF
--- a/source/blender/imbuf/IMB_openexr.hh
+++ b/source/blender/imbuf/IMB_openexr.hh
@@ -90,7 +90,7 @@ bool IMB_exr_get_ppm(ExrHandle *handle, double ppm[2]);
 
 /* Retrieves the EXR display window information. The information is in the same structure specified
  * in ImBuf, see its documentation for more information. */
-void IMB_get_exr_display_window(ExrHandle *handle,
+void IMB_exr_get_display_window(ExrHandle *handle,
                                 int display_size[2],
                                 int display_offset[2],
                                 int data_offset[2]);

--- a/source/blender/imbuf/intern/openexr/openexr_api.cpp
+++ b/source/blender/imbuf/intern/openexr/openexr_api.cpp
@@ -2076,7 +2076,7 @@ static void get_exr_display_window(const MultiPartInputFile &file,
   data_offset[1] = data_window.min[1] - display_window.min[1];
 }
 
-void IMB_get_exr_display_window(ExrHandle *handle,
+void IMB_exr_get_display_window(ExrHandle *handle,
                                 int display_size[2],
                                 int display_offset[2],
                                 int data_offset[2])

--- a/source/blender/imbuf/intern/openexr/openexr_stub.cpp
+++ b/source/blender/imbuf/intern/openexr/openexr_stub.cpp
@@ -83,3 +83,10 @@ bool IMB_exr_get_ppm(ExrHandle * /*handle*/, double /*ppm*/[2])
 {
   return false;
 }
+
+void IMB_exr_get_display_window(ExrHandle * /*handle*/,
+                                int /*display_size*/[2],
+                                int /*display_offset*/[2],
+                                int /*data_offset*/[2])
+{
+}

--- a/source/blender/render/intern/render_result.cc
+++ b/source/blender/render/intern/render_result.cc
@@ -706,7 +706,7 @@ RenderResult *render_result_new_from_exr(
   int display_size[2];
   int display_offset[2];
   int data_offset[2];
-  IMB_get_exr_display_window(exrhandle, display_size, display_offset, data_offset);
+  IMB_exr_get_display_window(exrhandle, display_size, display_offset, data_offset);
 
   IMB_exr_multilayer_convert(exrhandle, rr, ml_addview_cb, ml_addlayer_cb, ml_addpass_cb);
 


### PR DESCRIPTION
-- added the mission function
-- renamed existing to new name (matches blender)

