### PR TITLE
Fix: 5945-user-interface---treeview---fix-wrong-icon-for-search-dropdown

### DIFF
--- a/source/blender/editors/datafiles/CMakeLists.txt
+++ b/source/blender/editors/datafiles/CMakeLists.txt
@@ -557,8 +557,8 @@ if(WITH_BLENDER)
       dirty_vertex
       disable
       disc
-      disclosure_tri_right # BFA - exception to the order for the icon +1 toggle
       disclosure_tri_down
+      disclosure_tri_right
       discontinue_euler
       disk_drive
       dissolve_between

--- a/source/blender/editors/include/UI_icons.hh
+++ b/source/blender/editors/include/UI_icons.hh
@@ -419,12 +419,8 @@ DEF_ICON_COLOR(DIAL_GIZMO)
 DEF_ICON_COLOR(DIRTY_VERTEX)
 DEF_ICON_COLOR(DISABLE)
 DEF_ICON_COLOR(DISC)
-
-DEF_ICON_COLOR(DISCLOSURE_TRI_RIGHT) /*BFA - don't change the order, exception to the order for the
-                                        icon +1 toggle*/
-DEF_ICON_COLOR(DISCLOSURE_TRI_DOWN)  /*BFA - don't change the order, exception to the order for the
-                                        icon +1 toggle*/
-
+DEF_ICON_COLOR(DISCLOSURE_TRI_DOWN)
+DEF_ICON_COLOR(DISCLOSURE_TRI_RIGHT)
 DEF_ICON_COLOR(DISCONTINUE_EULER)
 DEF_ICON_COLOR(DISK_DRIVE)
 DEF_ICON_COLOR(DISSOLVE_BETWEEN)


### PR DESCRIPTION
-- adjusted the icon order to fix the DISCONTINUE_EULER taking over the DISCLOSURE_TRI_RIGHT icon place. 
-- removed the old dont change order comment, no longer needed.

[Screencast_20251122_101208.webm](https://github.com/user-attachments/assets/3d27b5af-ee91-424a-98f8-70c829fe1b4c)

