### PR TITLE
Default Asset Library - New Compositor nodes #5867

### DIFF
--- a/assets_bfa/blender_assets.cats.txt
+++ b/assets_bfa/blender_assets.cats.txt
@@ -39,6 +39,7 @@ f57862b2-0845-4ce7-a860-ce343dee67b9:Brushes/Mesh Texture Paint/Utilities:Brushe
 77635e98-1a5a-482e-9cb1-ba9ec4bc5b74:Brushes/Mesh Weight Paint:Brushes-Mesh Weight Paint
 36584c79-a99e-4b1c-bd5c-8e4865ae3abe:Compositor Nodegroups:Compositor Nodegroups
 679c9c61-2227-41c9-b483-0112dcd65b71:Compositor Nodegroups/Color:Compositor Nodegroups-Color
+f6d4a6a3-884c-42eb-a109-4cea52ba0d34:Compositor Nodegroups/Filters:Compositor Nodegroups-Filters
 d1c404ad-8d6d-4f1f-9e4a-a213a4c95346:Compositor Nodegroups/Lenses:Compositor Nodegroups-Lenses
 6b797445-b178-47a3-8733-33494410e95b:Compositor Nodegroups/Lenses/Grains:Compositor Nodegroups-Lenses-Grains
 9891369b-7907-4d84-9a83-3bf0f0eb7917:Compositor Nodegroups/Lenses/Quality:Compositor Nodegroups-Lenses-Quality

--- a/assets_bfa/nodes/compositing_nodes_essentials.blend
+++ b/assets_bfa/nodes/compositing_nodes_essentials.blend
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:865f2d56b9bbfe9ce81118ce689e24912f60038fbecc6bbcc91c1e5270cdf4df
-size 1365754
+oid sha256:98699a7c6f7b2a34b48e4de2c82511aa998c268f3fc184fc8b19bc35fef7376c
+size 1368495

--- a/scripts/addons_core/bfa_default_library/Compositor Nodes Library/C_Library_01.blend
+++ b/scripts/addons_core/bfa_default_library/Compositor Nodes Library/C_Library_01.blend
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1420e227a6dcc9b52ec8cc8602d5eeb433ade706c71410a99e8be2f2235a9722
-size 29514299
+oid sha256:db22b984b80a2bbca030df08c38a0eaaab3d7e70615d2131bb653a16461c9fae
+size 39550266

--- a/scripts/addons_core/bfa_default_library/Compositor Nodes Library/blender_assets.cats.txt
+++ b/scripts/addons_core/bfa_default_library/Compositor Nodes Library/blender_assets.cats.txt
@@ -10,6 +10,7 @@ VERSION 1
 8b7c1825-4730-4b2c-9470-fc89c1ace80a:Compositor Nodegroups/Color:Compositor Nodegroups-Color
 ffdb4adb-8aea-4ca3-966b-dadaee1afcc4:Compositor Nodegroups/Creative:Compositor Nodegroups-Creative
 54577834-5d3f-491a-ae51-d1c1113da3e7:Compositor Nodegroups/Creative/Design:Compositor Nodegroups-Creative-Design
+0b3f4cf3-f7c0-49d3-acfd-e3813f4e2105:Compositor Nodegroups/Distortion:Compositor Nodegroups-Distortion
 ee3d94c8-07ff-4b66-ba0e-a78e35be5c5a:Compositor Nodegroups/Filters:Compositor Nodegroups-Filters
 92b77f83-10f9-4fcd-9143-7f932bd632a1:Compositor Nodegroups/Filters/Dithering:Compositor Nodegroups-Filters-Dithering
 00dce0bd-3082-443b-99fb-dea3cfbb9182:Compositor Nodegroups/Lenses:Compositor Nodegroups-Lenses


### PR DESCRIPTION
This adds over 91 nodes to the compositor to hit the ground hard this release, with 8 additional compositor nodes prepared for the release. Total new nodes, 99. 

<img width="1920" height="1009" alt="image" src="https://github.com/user-attachments/assets/a0c9dfa0-f9fd-468f-9de3-affd4c39e5bc" />
<img width="1584" height="879" alt="image" src="https://github.com/user-attachments/assets/1e2fb440-4752-4341-a2a0-a0444452f505" />

- Added thumbnails to all compositor assets
- Tuned tooltips on many
- Updated the depth of field system of the nodes
- Rebuilt the camera shake node
- Organized nodes
- Updated categories slightly
- Converted more patterns to Compositor Nodes
- Added feature parity nodes for shader vectors, some. 

I'll document this one, as it is extensive. 