### PR TITLE
Node Editor - Add icons to the "Drag Off" search menu #5978

### DIFF
--- a/source/blender/editors/space_node/link_drag_search.cc
+++ b/source/blender/editors/space_node/link_drag_search.cc
@@ -226,7 +226,8 @@ static void search_link_ops_for_asset_metadata(const bNodeTree &node_tree,
                  params.node_tree, params.node, params.socket, node, *new_node_socket);
            }
          },
-         weight});
+         weight,
+         ICON_NODETREE, /* BFA - add icon */});
 
     weight--;
   }
@@ -280,12 +281,12 @@ static void gather_socket_link_operations(const bContext &C,
     }
   }
 
-  search_link_ops.append({IFACE_("Reroute"), add_reroute_node_fn});
+  search_link_ops.append({IFACE_("Reroute"), add_reroute_node_fn, 0, ICON_NODE_REROUTE}); /* BFA - add icon */
 
   const bool is_node_group = !(node_tree.id.flag & ID_FLAG_EMBEDDED_DATA);
 
   if (is_node_group && socket.in_out == SOCK_IN) {
-    search_link_ops.append({IFACE_("Group Input"), add_group_input_node_fn});
+    search_link_ops.append({IFACE_("Group Input"), add_group_input_node_fn, 0, ICON_GROUPINPUT}); /* BFA - add icon */
 
     int weight = -1;
     node_tree.tree_interface.foreach_item([&](const bNodeTreeInterfaceItem &item) {
@@ -311,7 +312,8 @@ static void gather_socket_link_operations(const bContext &C,
                               [interface_socket](nodes::LinkSearchOpParams &params) {
                                 add_existing_group_input_fn(params, interface_socket);
                               },
-                              weight});
+                              weight,
+                              ICON_GROUPINPUT, /* BFA - add icon */});
       weight--;
       return true;
     });
@@ -344,7 +346,8 @@ static void link_drag_search_update_fn(
   const Vector<SocketLinkOperation *> filtered_items = search.query(string);
 
   for (SocketLinkOperation *item : filtered_items) {
-    if (!UI_search_item_add(items, item->name, item, ICON_NONE, 0, 0)) {
+    /* BFA - add icon */
+    if (!UI_search_item_add(items, item->name, item, item->icon, 0, 0)) {
       break;
     }
   }

--- a/source/blender/nodes/NOD_socket_search_link.hh
+++ b/source/blender/nodes/NOD_socket_search_link.hh
@@ -70,6 +70,7 @@ struct SocketLinkOperation {
   std::string name;
   LinkSocketFn fn;
   int weight = 0;
+  int icon = 0; /* BFA - add icon parameter */
 };
 
 class GatherLinkSearchOpParams {

--- a/source/blender/nodes/intern/socket_search_link.cc
+++ b/source/blender/nodes/intern/socket_search_link.cc
@@ -17,6 +17,8 @@
 #include "NOD_node_declaration.hh"
 #include "NOD_socket.hh"
 #include "NOD_socket_search_link.hh"
+#include "RNA_access.hh"
+#include "RNA_types.hh"
 
 namespace blender::nodes {
 
@@ -35,7 +37,25 @@ void GatherLinkSearchOpParams::add_item_full_name(std::string name,
                                                   SocketLinkOperation::LinkSocketFn fn,
                                                   int weight)
 {
-  items_.append({std::move(name), std::move(fn), weight});
+    SocketLinkOperation op;
+
+    /* BFA - Get Node RNA Icon*/
+    int icon = 0;
+    if (!node_type_.idname.empty()) {
+        StructRNA *srna = RNA_struct_find(node_type_.idname.c_str());
+        if (srna) {
+            icon = RNA_struct_ui_icon(srna);
+        }
+    }
+    
+    /* BFA - construct link operation object */
+    op.name = std::move(name);
+    op.fn = std::move(fn);
+    op.weight = weight;
+    op.icon = icon;
+
+    /* BFA - append to search entries */
+    items_.append(std::move(op));
 }
 
 const bNodeSocket &GatherLinkSearchOpParams::other_socket() const


### PR DESCRIPTION
This change makes the link-drag search retrieve the icon defined in a node's RNA.
In cases where this isn't defined yet _*(such as new nodes, or those in experimental)*_ , the code falls back to not using one.

<img width="621" height="449" alt="image" src="https://github.com/user-attachments/assets/0289358d-181c-4cae-a80e-9470eca4a2c9" />
