### PR TITLE
Image Editor - Sidebar > Image Tab > UDIM Tiles > Add Tile to Image dialog - Align Fill property left #5938

### DIFF
--- a/source/blender/editors/space_image/image_ops.cc
+++ b/source/blender/editors/space_image/image_ops.cc
@@ -4440,7 +4440,11 @@ static void tile_add_draw(bContext * /*C*/, wmOperator *op)
   col.prop(op->ptr, "number", UI_ITEM_NONE, std::nullopt, ICON_NONE);
   col.prop(op->ptr, "count", UI_ITEM_NONE, std::nullopt, ICON_NONE);
   col.prop(op->ptr, "label", UI_ITEM_NONE, std::nullopt, ICON_NONE);
+  
+  /* BFA - Align boolean property left */
+  layout.use_property_split_set(false);
   layout.prop(op->ptr, "fill", UI_ITEM_NONE, std::nullopt, ICON_NONE);
+  layout.use_property_split_set(true);
 
   if (RNA_boolean_get(op->ptr, "fill")) {
     draw_fill_tile(op->ptr, layout);


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="329" height="323" alt="image" src="https://github.com/user-attachments/assets/496e7401-30ae-4fde-831d-9a73cb6c4af8" /> | <img width="329" height="323" alt="image" src="https://github.com/user-attachments/assets/a29630ab-732b-46e0-82e3-f1e496a98095" /> |

Resolves: #5938