### PR TITLE
UV Editor - Header > UV > Move on Axis - Separate tooltips for Move on Axis operator #5960

### DIFF
--- a/source/blender/editors/uvedit/uvedit_ops.cc
+++ b/source/blender/editors/uvedit/uvedit_ops.cc
@@ -339,6 +339,33 @@ enum class UVMoveDirection {
   Y = 1,
 };
 
+/* BFA - Make shift_items accessible in outside scope, for `move_on_axis_description`*/
+static const EnumPropertyItem shift_items[] = {
+    {int(UVMoveType::Dynamic), "DYNAMIC", 0, "Dynamic", "Snap movement to the dynamic grid"}, /* BFA - make description clearer */
+    {int(UVMoveType::Pixel), "PIXEL", 0, "Pixel", "Movement is measured in pixels"}, /* BFA - make description clearer */
+    {int(UVMoveType::Udim), "UDIM", 0, "UDIM", "Movement is measured in UDIM tiles"}, /* BFA - make description clearer */
+    {0, nullptr, 0, nullptr, nullptr},
+};
+
+/* BFA - Make "Move on Axis" description dynamic*/
+/* Append .type enum description, else use operator's description as-is as fallback */
+static std::string move_on_axis_description(bContext * /* C */,
+                                            wmOperatorType *ot,
+                                            PointerRNA *ptr)
+{
+  std::string description = std::string(ot->description);
+
+  PropertyRNA *prop = RNA_struct_find_property(ptr, "type");
+
+  if (RNA_property_is_set(ptr, prop)) {
+    const int prop_value = RNA_property_enum_get(ptr, prop);
+    description += ".\n";
+    description += shift_items[prop_value].description;
+  }
+
+  return description;
+}
+
 static wmOperatorStatus uv_move_on_axis_exec(bContext *C, wmOperator *op)
 
 {
@@ -387,12 +414,14 @@ static wmOperatorStatus uv_move_on_axis_exec(bContext *C, wmOperator *op)
 
 static void UV_OT_move_on_axis(wmOperatorType *ot)
 {
+  /* BFA - Move this enum outside of scope
   static const EnumPropertyItem shift_items[] = {
       {int(UVMoveType::Dynamic), "DYNAMIC", 0, "Dynamic", "Move by dynamic grid"},
       {int(UVMoveType::Pixel), "PIXEL", 0, "Pixel", "Move by pixel"},
       {int(UVMoveType::Udim), "UDIM", 0, "UDIM", "Move by UDIM"},
       {0, nullptr, 0, nullptr, nullptr},
   };
+  */
 
   static const EnumPropertyItem axis_items[] = {
       {int(UVMoveDirection::X), "X", 0, "X axis", "Move vertices on the X axis"},
@@ -405,6 +434,8 @@ static void UV_OT_move_on_axis(wmOperatorType *ot)
   ot->description = "Move UVs on an axis";
   ot->idname = "UV_OT_move_on_axis";
   ot->flag = OPTYPE_REGISTER | OPTYPE_UNDO;
+  ot->get_description =
+      move_on_axis_description; /* BFA - Generate description from 'type' property*/
 
   /* API callbacks. */
   ot->exec = uv_move_on_axis_exec;


### PR DESCRIPTION
Had to rewrite the enum descriptions as the original ones just said _"Move by dynamic grid", "Move by pixel", & "Move by UDIM"_.

|| Before | After |
| --- | --- | --- |
| Unspecified | <img width="268" height="68" alt="image" src="https://github.com/user-attachments/assets/c27a2b5d-1518-4d1b-925d-955079753d96" /> | <img width="267" height="66" alt="image" src="https://github.com/user-attachments/assets/a4962179-bee6-4e04-8faa-1e62b0366fa8" /> |
| Dynamic | <img width="370" height="68" alt="image" src="https://github.com/user-attachments/assets/a3746025-b06e-4173-90e0-4cf3cf5e223e" /> | <img width="371" height="82" alt="image" src="https://github.com/user-attachments/assets/2abede5f-a4d1-4598-b364-dfde063374c5" /> |
| Pixel | <img width="352" height="68" alt="image" src="https://github.com/user-attachments/assets/7bad18a3-2995-44be-99bc-7bb367595e9f" /> | <img width="351" height="79" alt="image" src="https://github.com/user-attachments/assets/8ee2331c-a549-488e-b1bd-af07b0ef8065" /> |
| UDIM | <img width="345" height="72" alt="image" src="https://github.com/user-attachments/assets/7657f5b5-6fa8-486f-bfef-6ccabb93e2c5" /> | <img width="343" height="82" alt="image" src="https://github.com/user-attachments/assets/a194709e-6c9d-4dc7-b905-5df5eba32a3d" /> |

Resolves: #5960 