### PR TITLE
Fix: Improve layout of Group Properties panel

### DIFF
--- a/scripts/startup/bl_ui/space_node.py
+++ b/scripts/startup/bl_ui/space_node.py
@@ -1566,10 +1566,10 @@ class NODE_PT_node_tree_properties(Panel):
         row.operator("node.default_group_width_set", text="", icon='NODE')
 
         if group.bl_idname == "GeometryNodeTree":
-            row = layout.row()
-            row.active = group.is_modifier
-            row.use_property_split = False # BFA - Align booleans left
-            row.prop(group, "show_modifier_manage_panel")
+            if group.is_modifier: # BFA - Hide property instead of greying it out
+                row = layout.row()
+                row.use_property_split = False # BFA - Align booleans left
+                row.prop(group, "show_modifier_manage_panel")
 
             header, body = layout.panel("group_usage")
             header.label(text="Usage")


### PR DESCRIPTION
Had to tackle these two at the same time since they act on the same code.

|| Before | After |
| --- | --- | --- |
| #6019 | <img width="262" height="246" alt="image" src="https://github.com/user-attachments/assets/69620d36-1ca3-4b24-85fd-b0113129b6f8" /> | <img width="258" height="234" alt="image" src="https://github.com/user-attachments/assets/7b4a61d5-1f2f-497a-ac80-9b6d978f2494" /> |
| #6027 | <img width="259" height="83" alt="image" src="https://github.com/user-attachments/assets/b9dd513c-3240-4295-bfdf-2c81e21455f2" /> | <img width="262" height="60" alt="image" src="https://github.com/user-attachments/assets/216962df-5650-4d2a-94a3-6a684f2a58e1" /> |

Resolves: #6019, #6027 