### PR TITLE
Fix: Improve layout of Group Sockets panel

### DIFF
--- a/source/blender/editors/space_node/drawnode.cc
+++ b/source/blender/editors/space_node/drawnode.cc
@@ -1518,6 +1518,7 @@ static void std_node_socket_interface_draw(ID *id,
     sub->active_set(interface_socket->default_input == NODE_DEFAULT_INPUT_VALUE);
     sub->use_property_split_set(false); /* bfa - use_property_split = False */
     sub->prop(&ptr, "hide_value", DEFAULT_FLAGS, std::nullopt, ICON_NONE);
+    sub->prop(&ptr, "hide_in_modifier", DEFAULT_FLAGS, std::nullopt, ICON_NONE); /* BFA - reorder sockets*/
     sub->use_property_split_set(true); /* bfa - split non-boolean props */
   }
 
@@ -1528,12 +1529,12 @@ static void std_node_socket_interface_draw(ID *id,
       col->use_property_split_set(true); /* bfa - split non-boolean props */
     }
     ui::Layout *sub = &col->column(false);
-    sub->active_set(!is_layer_selection_field(*interface_socket));
     sub->use_property_split_set(false); /* bfa - use_property_split = False */
-    sub->prop(&ptr, "hide_in_modifier", DEFAULT_FLAGS, std::nullopt, ICON_NONE);
-    sub->use_property_split_set(true); /* bfa - split non-boolean props */
-    if (nodes::socket_type_supports_fields(type) || nodes::socket_type_supports_grids(type)) {
-      sub->prop(&ptr, "structure_type", DEFAULT_FLAGS, IFACE_("Shape"), ICON_NONE);
+    if (!is_layer_selection_field(*interface_socket)){
+      sub->use_property_split_set(true); /* bfa - split non-boolean props */
+      if (nodes::socket_type_supports_fields(type) || nodes::socket_type_supports_grids(type)) {
+        sub->prop(&ptr, "structure_type", DEFAULT_FLAGS, IFACE_("Shape"), ICON_NONE);
+      }
     }
   }
 }


### PR DESCRIPTION
Just reordered the `Hide in Modifier` to come after `Hide Value`.
Not only is this ordering more sensible, but it makes managing the visibility of unused properties when `Layer Selection` is simpler.

| | Before | After |
| --- | --- | --- |
| Layer Selection Disabled | <img width="260" height="227" alt="image" src="https://github.com/user-attachments/assets/a2ea5b7f-e995-40de-bb03-53cf18cf0130" /> | <img width="257" height="221" alt="image" src="https://github.com/user-attachments/assets/2a893e3d-cecd-457b-892b-ceeb978de25a" /> |
| Layer Selection Enabled  | <img width="253" height="225" alt="image" src="https://github.com/user-attachments/assets/f33d7f7a-b3b3-4aaa-9d5d-03bb77d47b5a" /> | <img width="257" height="203" alt="image" src="https://github.com/user-attachments/assets/35f9f97b-fddd-4bdd-940a-a62fabf2e969" /> |

Resolves: #6020, #6029 