### PR TITLE
Dopesheet - Action Editor Mode - Removed Action Layer Next buttons #6010

### DIFF
--- a/scripts/startup/bl_ui/space_dopesheet.py
+++ b/scripts/startup/bl_ui/space_dopesheet.py
@@ -376,8 +376,6 @@ class DOPESHEET_HT_editor_buttons:
             layout.separator_spacer()
             cls._draw_action_selector(context, layout)
             row = layout.row(align=True)
-            row.operator("action.layer_prev", text="", icon="TRIA_DOWN")
-            row.operator("action.layer_next", text="", icon="TRIA_UP")
 
             row = layout.row(align=True)
             row.operator("action.push_down", text="Push Down", icon="NLA_PUSHDOWN")


### PR DESCRIPTION
No-longer used.

<img width="1078" height="256" alt="image" src="https://github.com/user-attachments/assets/9bc32a3e-4aeb-4e2e-bce9-ec32baac4582" />
