### PR TITLE
Node Editor - Group Sockets UI - Make "New Item" popover more compact #6042

### DIFF
--- a/scripts/startup/bl_ui/space_node.py
+++ b/scripts/startup/bl_ui/space_node.py
@@ -1371,13 +1371,17 @@ class NODE_PT_node_tree_interface_new_input(Panel):
     bl_ui_units_x = 7
 
     def draw(self, context):
-        layout = self.layout
-        layout.label(text="Add New Item")
-
+        layout = self.layout.column(align=True)
         layout.operator('node.interface_item_new_input', text='Input ', icon='GROUPINPUT').item_type = 'INPUT'
         layout.operator('node.interface_item_new_output', text='Output', icon='GROUPOUTPUT').item_type = 'OUTPUT'
+        
+        layout.separator(factor=0.5)
         layout.operator('node.interface_item_new_panel', text='Panel', icon='MENU_PANEL').item_type = 'PANEL'
-        layout.operator('node.interface_item_new_panel_toggle', text='Panel Toggle', icon='CHECKBOX_HLT')
+        layout.separator(factor=0.5)
+
+        active_item = context.space_data.edit_tree.interface.active
+        if active_item and active_item.item_type == 'PANEL':
+            layout.operator('node.interface_item_new_panel_toggle', text='Panel Toggle', icon='CHECKBOX_HLT')
 
 # BFA - menu
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="181" height="184" alt="image" src="https://github.com/user-attachments/assets/dc40bf7c-848f-493c-b34d-b40392faf98c" /> | <img width="178" height="123" alt="image" src="https://github.com/user-attachments/assets/b8987c57-4965-447b-b92b-cb71f4151e1a" /> |

Resolves: #6042 