### PR TITLE
Compositor - Add Sidebar - Add "Creative" Tab and panel #6055

### DIFF
--- a/scripts/startup/bl_ui/space_node_toolshelf.py
+++ b/scripts/startup/bl_ui/space_node_toolshelf.py
@@ -928,11 +928,11 @@ class NODES_PT_toolshelf_compositor_add_creative(bpy.types.Panel, NodePanel):
         # There is currently no way to determine the correct padding length other than trial-and-error.
         # When adding a new node, test different padding amounts until the button text is left-aligned with the rest of the panel items.
         entries = (
-            OperatorEntry("CompositorNodeKuwahara", pad=1),
-            OperatorEntry("CompositorNodePixelate", pad=7),
-            OperatorEntry("CompositorNodePosterize", pad=9),
+            OperatorEntry("CompositorNodeKuwahara", pad=12),
+            OperatorEntry("CompositorNodePixelate", pad=16),
+            OperatorEntry("CompositorNodePosterize", pad=13),
         )
-
+        
         self.draw_entries(context, layout, entries)
 
 


### PR DESCRIPTION
Add the "Creative" category in the node toolshelf. 
| Add Menu | Toolshelf |
| --- | --- |
| <img width="400" height="87" alt="image" src="https://github.com/user-attachments/assets/835d0325-a61f-426e-92f4-62dd941d75b3" /> | <img width="279" height="153" alt="image" src="https://github.com/user-attachments/assets/2f946022-5aff-47f4-b742-75c11edfa02c" /> |

Also removed its entries that used to exist under "Filter".

| Before | After |
| --- | --- |
| <img width="285" height="432" alt="image" src="https://github.com/user-attachments/assets/58e28273-f975-49ea-9d65-242535eef76b" /> | <img width="273" height="340" alt="image" src="https://github.com/user-attachments/assets/6170f6d4-8d82-4437-9928-2b6851c5bb92" /> |

Resolves: #6055 