### PR TITLE
Image & Movie Clip Editor - Mask Mode - Header > Overlay dropdown - Fix duplicated "Mask Display" label #6073

### DIFF
--- a/scripts/startup/bl_ui/properties_mask_common.py
+++ b/scripts/startup/bl_ui/properties_mask_common.py
@@ -262,7 +262,6 @@ class MASK_PT_display:
 
     def draw(self, context):
         layout = self.layout
-        layout.label(text="Mask Display")
 
         space_data = context.space_data
 


### PR DESCRIPTION
|| Before | After |
| --- | --- | --- |
| Image Editor | <img width="342" height="220" alt="Image" src="https://github.com/user-attachments/assets/e6baea05-65c9-4613-975a-1e9a45650179" /> | <img width="318" height="188" alt="image" src="https://github.com/user-attachments/assets/ff9b50ad-2e11-4460-979d-09d839212312" /> |
| Movie Clip Editor | <img width="323" height="284" alt="Image" src="https://github.com/user-attachments/assets/d9f5defb-237a-4ea6-861a-a2ef4daa656f" /> | <img width="306" height="261" alt="image" src="https://github.com/user-attachments/assets/60d59f23-9c51-4106-bb04-eda6de9ffd90" /> |

Resolves: #6073