### PR TITLE
Node Editor - Sidebar > Relations tab - Hide Group panel when it has no content #6071

### DIFF
--- a/scripts/startup/bl_ui/space_node_toolshelf.py
+++ b/scripts/startup/bl_ui/space_node_toolshelf.py
@@ -199,6 +199,11 @@ class NODES_PT_relations_group_operations(bpy.types.Panel, NodePanel):
     bl_region_type = 'UI'
     bl_category = "Relations"
 
+    @classmethod
+    def poll(self, context):
+        tree = context.space_data.edit_tree 
+        return tree in context.blend_data.node_groups.values()
+
     def draw(self, context):
         layout = self.layout
         in_group = context.space_data.edit_tree in context.blend_data.node_groups.values()


### PR DESCRIPTION
 Before | After |
| --- | --- |
| <img width="273" height="180" alt="image" src="https://github.com/user-attachments/assets/ebb13c2b-30c9-4846-99ab-5e48ac46d324" /> | <img width="274" height="154" alt="image" src="https://github.com/user-attachments/assets/a01e44f7-baaa-49cc-8923-3474a31b58a3" /> |

Resolves: #6071