### PR TITLE
Cleanup: Node Editor - Tools > Node tab > Group panel - Remove padding in operator labels 

### DIFF
--- a/scripts/startup/bl_ui/space_node_tabs.py
+++ b/scripts/startup/bl_ui/space_node_tabs.py
@@ -336,13 +336,13 @@ class NODE_PT_group(toolshelf_calculate, Panel):
             col = layout.column(align=True)
             col.scale_y = 2
 
-            col.operator("node.group_make", text = " Make Group      ", icon = "NODE_MAKEGROUP")
-            col.operator("node.group_insert", text = " Insert into Group ", icon = "NODE_GROUPINSERT")
-            col.operator("node.group_ungroup", text = " Ungroup           ", icon = "NODE_UNGROUP")
+            col.operator("node.group_make", icon="NODE_MAKEGROUP")
+            col.operator("node.group_insert", icon="NODE_GROUPINSERT")
+            col.operator("node.group_ungroup", icon="NODE_UNGROUP")
 
             col = layout.column(align=True)
             col.scale_y = 2
-            col.operator("node.group_edit", text = " Toggle Edit Group", icon = "NODE_EDITGROUP").exit = False
+            col.operator("node.group_edit", icon="NODE_EDITGROUP").exit = False
 
         # icon buttons
         else:


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="285" height="215" alt="image" src="https://github.com/user-attachments/assets/fee4c635-1c23-4a53-8f89-71c2f4a0f2f4" /> | <img width="289" height="220" alt="image" src="https://github.com/user-attachments/assets/4f8e2e6c-cad3-471f-a362-0619113485cf" /> |

Resolves: #6084