### PR TITLE
Region Context Menu - Fix capitalization on Flip Region operators #6086

### DIFF
--- a/source/blender/editors/interface/interface_context_menu.cc
+++ b/source/blender/editors/interface/interface_context_menu.cc
@@ -1341,8 +1341,8 @@ void popup_context_menu_for_panel(bContext *C, ARegion *region, Panel *panel)
               UI_ITEM_NONE);
     const short region_alignment = RGN_ALIGN_ENUM_FROM_MASK(region->alignment);
     const char *but_flip_str = region_alignment == RGN_ALIGN_LEFT ?
-                                   IFACE_("Flip region to Right") :
-                                   IFACE_("Flip region to Left");
+                                   IFACE_("Flip Region to Right") :
+                                   IFACE_("Flip Region to Left");
     layout.op("SCREEN_OT_region_flip",
               but_flip_str,
               ICON_FLIP,


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="223" height="122" alt="Image" src="https://github.com/user-attachments/assets/fbe98435-0651-4b70-ab31-64eabd2f93de" /> | <img width="190" height="108" alt="image" src="https://github.com/user-attachments/assets/a8f41acd-0a12-4809-bf04-3581ae5bf959" /> |
| <img width="209" height="118" alt="Image" src="https://github.com/user-attachments/assets/c6c1d6f0-2ad4-4458-95cf-5e7bf5de509d" /> | <img width="193" height="116" alt="image" src="https://github.com/user-attachments/assets/2edfd997-c447-492a-90c2-9c091db9abd5" /> |

Resolves: #6086