### PR TITLE
Fix #6115: Dope Sheet Editor - Key menu - No moduel named bl_ui_utils 

### DIFF
--- a/scripts/startup/bl_ui/space_dopesheet.py
+++ b/scripts/startup/bl_ui/space_dopesheet.py
@@ -900,7 +900,7 @@ class DOPESHEET_MT_key(Menu):
         layout.operator("action.clean", icon="CLEAN_KEYS").channels = False
 
         # BFA - https://projects.blender.org/blender/blender/pulls/113335
-        from bl_ui_utils.layout import operator_context
+        from _bl_ui_utils.layout import operator_context
 
         with operator_context(layout, "INVOKE_REGION_CHANNELS"):
             layout.operator("action.clean", text="Clean Channels", icon="CLEAN_CHANNELS").channels = True


### PR DESCRIPTION
The error cause by `bl_ui_utils` was made into a "private" module by adding an underscore prefix `_` 
Related [PyAPI: make internal modules explicitly "private" #147773](https://projects.blender.org/blender/blender/pulls/147773)
Resolve: #6115 