### PR TITLE
NLA Editor - Sidebar > Strip > Active Strip - Make properties follow BFA conventions #6133

### DIFF
--- a/source/blender/editors/space_nla/nla_buttons.cc
+++ b/source/blender/editors/space_nla/nla_buttons.cc
@@ -431,23 +431,35 @@ static void nla_panel_properties(const bContext *C, Panel *panel)
     extrapolation_col.prop(&strip_ptr, "extrapolation", UI_ITEM_NONE, std::nullopt, ICON_NONE);
     extrapolation_col.prop(&strip_ptr, "blend_type", UI_ITEM_NONE, std::nullopt, ICON_NONE);
 
-    /* Blend in/out + auto-blending:
-     * - blend in/out can only be set when auto-blending is off.
-     */
+    blender::ui::Layout *row; /* BFA */
+    
+    /* BFA - Show/Hide blending options based on animated influence */
+    if (!RNA_boolean_get(&strip_ptr, "use_animated_influence")) {
+      ui::Layout &blend_col = layout.column(true);
+      blend_col.label(IFACE_("Blend"), ICON_NONE);
 
-    layout.separator();
+      /* BFA - Indent blending properties*/
+      row = &blend_col.row(false);
+      row->separator();
+      ui::Layout *col = &row->column(true);
 
-    ui::Layout &blend_col = layout.column(true);
-    blend_col.active_set(RNA_boolean_get(&strip_ptr, "use_auto_blend") == false);
-    blend_col.prop(&strip_ptr, "blend_in", UI_ITEM_NONE, IFACE_("Blend In"), ICON_NONE);
-    blend_col.prop(&strip_ptr, "blend_out", UI_ITEM_NONE, IFACE_("Out"), ICON_NONE);
+      /* Blend in/out + auto-blending:
+       * - blend in/out can only be set when auto-blending is off.
+       */
+      if (!RNA_boolean_get(&strip_ptr, "use_auto_blend")) {
+        col->prop(&strip_ptr, "blend_in", UI_ITEM_NONE, IFACE_("In"), ICON_NONE); /* BFA - Change from "Blend In" to in */
+        col->prop(&strip_ptr, "blend_out", UI_ITEM_NONE, IFACE_("Out"), ICON_NONE);
+        col->separator(0.5f);
+      }
 
-    blender::ui::Layout *row = &layout.column(true).row(true);
-    row->active_set(RNA_boolean_get(&strip_ptr, "use_animated_influence") == false);
-    row->use_property_decorate_set(false); /* bfa - use_property_split = false*/
-    row->prop(
-        &strip_ptr, "use_auto_blend", UI_ITEM_NONE, std::nullopt, ICON_NONE); /* XXX as toggle? */
-
+      row = &col->row(true);
+      row->use_property_split_set(false); /* BFA - Align bool property left */
+      row->prop(&strip_ptr,
+                "use_auto_blend",
+                UI_ITEM_NONE,
+                std::nullopt,
+                ICON_NONE); /* XXX as toggle? */
+    };
     /* settings */
     layout.use_property_split_set(false);
     layout.use_property_decorate_set(false);


### PR DESCRIPTION
### Changes
- Align bool properties left
- Indent Blend In and Out properties
- Hide properties instead of deactivating
- Remove unnecessary separator spacers

### Before & After
|| Before | After |
| --- | --- | --- |
| Auto-blend OFF | <img width="271" height="376" alt="image" src="https://github.com/user-attachments/assets/8ae5db3b-64d6-40cc-a7b4-cdc5651956e5" /> | <img width="273" height="352" alt="image" src="https://github.com/user-attachments/assets/3157e2dd-47a6-4b6f-9bdd-735cb988e1d7" /> |
| Auto-blend ON | <img width="267" height="371" alt="image" src="https://github.com/user-attachments/assets/88a41c2b-ad62-467c-bf49-07039a9c49f6" /> | <img width="276" height="308" alt="image" src="https://github.com/user-attachments/assets/a41544a7-1c31-4afd-87a5-857f2987f595" /> |
| Use "Animated Influence" | <img width="270" height="379" alt="image" src="https://github.com/user-attachments/assets/14abfd17-59fa-4662-a5eb-cc19e6b655dc" /> | <img width="272" height="259" alt="image" src="https://github.com/user-attachments/assets/0debd0dc-196c-4a65-b425-b7470be9c65e" /> |

Resolves: #6133