### PR TITLE
Graph/Driver Editor: Remove Duplicate channel toggle

### DIFF
--- a/scripts/startup/bl_ui/space_graph.py
+++ b/scripts/startup/bl_ui/space_graph.py
@@ -316,7 +316,6 @@ class GRAPH_MT_view(Menu):
         layout.prop(st, "show_region_channels")  # BFA - channels
         layout.prop(st, "show_region_ui")
         layout.prop(st, "show_region_hud")
-        layout.prop(st, "show_region_channels")
         if st.mode != 'DRIVERS':
             layout.prop(st, "show_region_footer", text="Playback Controls")
         layout.separator()


### PR DESCRIPTION
Removed duplicate property layout for 'show_region_channels'.

Resolve #6123 