### PR TITLE
Fix: 6175-properties-editor---modifiers---grease-pencil---lineart-mod…

### DIFF
--- a/source/blender/modifiers/intern/MOD_lineart.cc
+++ b/source/blender/modifiers/intern/MOD_lineart.cc
@@ -498,8 +498,8 @@ static void occlusion_panel_draw(const bContext * /*C*/, Panel *panel)
   col.active_set(show_in_front);
 
   ui::Layout *row;         /* bfa - added row */
-  row = &layout.row(true); /* bfa - our layout */
-  row->use_property_decorate_set(false);
+  row = &col.row(true); /* bfa - our layout */
+  row->use_property_split_set(false); /* bfa - use_property_split = False */
   row->separator(); /* bfa - Indent */
   row->prop(ptr, "use_multiple_levels", UI_ITEM_NONE, IFACE_("Range"), ICON_NONE);
   row->decorator(ptr, "use_multiple_levels", 0); /* bfa - decorator */


### PR DESCRIPTION
- align prop left
- put range back on top of level start/end like it used to be.

<img width="460" height="227" alt="image" src="https://github.com/user-attachments/assets/f1136adb-a7af-4e93-a65f-86a65209fb78" />
