### PR TITLE
Fix: 3D View - Header - Selectatbility and visibility icon broken #6183

### DIFF
--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -8816,7 +8816,7 @@ class VIEW3D_PT_object_type_visibility(Panel):
             ("meta", "Meta", "OUTLINER_OB_META"),
             ("font", "Text", "OUTLINER_OB_FONT"),
             (None, None, None),
-            ("curves", "Hair Curves", "HAIR_DATA"),
+            ("curves", "Hair Curves", "OUTLINER_OB_CURVES"),
             ("pointcloud", "Point Cloud", "OUTLINER_OB_POINTCLOUD"),
             ("volume", "Volume", "OUTLINER_OB_VOLUME"),
             ("grease_pencil", "Grease Pencil", "OUTLINER_OB_GREASEPENCIL"),


### PR DESCRIPTION
Search and replace resulted in only one occurrence
I search "HAIR_DATA" and ICON_HAIR_DATA to include C and Python usages
<img width="189" height="432" alt="image" src="https://github.com/user-attachments/assets/f57a9fd7-5bd3-49c0-94c1-04d5539eb8da" />
