### PR TITLE
Fix: 6227-properties-editor---bone-properties-tab---viewport-display-…

### DIFF
--- a/scripts/startup/bl_ui/properties_data_bone.py
+++ b/scripts/startup/bl_ui/properties_data_bone.py
@@ -478,15 +478,24 @@ class BONE_PT_display_custom_shape(BoneButtonsPanel, Panel):
                 sub.prop(pchan, "custom_shape_scale_xyz", text="Scale")
                 
                 sub.prop_search(pchan, "custom_shape_transform", ob.pose, "bones", text="Override Transform")
-                sub.separator()
 
-                subsub = sub.column()
-                subsub.active = bool(pchan and pchan.custom_shape and pchan.custom_shape_transform)
-                subsub.prop(pchan, "use_transform_at_custom_shape")
-                subsubsub = subsub.column()
-                subsubsub.active = subsub.active and pchan.use_transform_at_custom_shape
-                subsubsub.prop(pchan, "use_transform_around_custom_shape")
-
+                # bfa - Only show the transform properties if custom_shape_transform has a bone selected
+                if pchan and pchan.custom_shape and pchan.custom_shape_transform:
+                    subsub = sub.row()
+                    subsub.use_property_split = False
+                    subsub.active = bool(pchan and pchan.custom_shape and pchan.custom_shape_transform)
+                    subsub.prop(pchan, "use_transform_at_custom_shape")
+                    subsub.prop_decorator(pchan, "use_transform_at_custom_shape")
+                    
+                    # bfa - Only show Use as Pivot when Affect Gizmo is enabled
+                    if pchan.use_transform_at_custom_shape:
+                        sub = col.column()
+                        subsubsub = sub.row()
+                        subsubsub.separator()
+                        subsubsub.use_property_split = False
+                        subsubsub.prop(pchan, "use_transform_around_custom_shape")
+                        subsubsub.prop_decorator(pchan, "use_transform_around_custom_shape")
+                        
                 row = sub.row()
                 row.use_property_split = False
                 row.prop(pchan, "use_custom_shape_bone_size")


### PR DESCRIPTION
- Hide Affect Gizmo and Use as Pivot when no bone is selected
- Indented Use as Pivot, since its a child of Affect Gizmo

<img width="411" height="423" alt="image" src="https://github.com/user-attachments/assets/d377ba6f-0fb8-42b0-aa81-4e11df3a4c09" />

<img width="411" height="443" alt="image" src="https://github.com/user-attachments/assets/9d55c343-2307-45e9-bc3e-07fe00bac970" />

<img width="411" height="443" alt="image" src="https://github.com/user-attachments/assets/688ed457-36e5-44d5-b248-1fa431ee4c00" />


[Screencast_20260127_155752.webm](https://github.com/user-attachments/assets/901c4d38-8bdb-4137-9d5b-61c2cea1c74e)

