### PR TITLE
Fix: 6226-properties-editor---bone-properties-tab---viewport-display-…

### DIFF
--- a/scripts/startup/bl_ui/properties_data_bone.py
+++ b/scripts/startup/bl_ui/properties_data_bone.py
@@ -501,18 +501,11 @@ class BONE_PT_display_custom_shape(BoneButtonsPanel, Panel):
                     row.label(icon='DISCLOSURE_TRI_RIGHT', text = "      ")
                 row.prop_decorator(bone, "show_wire")
 
-                # Disabled on Mac due to drawing issues with lacking geometry shader support. See #124691.
-                is_darwin = platform.system() == "Darwin"
-
                 if bone.show_wire:
                     row = sub.row()
                     row.use_property_split = True
                     row.separator()
                     row.prop(pchan, "custom_shape_wire_width")
-
-                if is_darwin:
-                    row = sub.row()
-                    row.label(text="Custom wire width not available on MacOS", icon='INFO')
 
 
 class BONE_PT_inverse_kinematics(BoneButtonsPanel, Panel):


### PR DESCRIPTION
- Fixs the error, This was for a MacOS shader issue, [it was fixed 9 months ago ](https://projects.blender.org/blender/blender/commit/6faef7b149dd718dd69610b5beec9110cad0d86a), so error occured now.

- also allows the Wire Width slider to appear!

<img width="1250" height="816" alt="image" src="https://github.com/user-attachments/assets/c6392d8a-1e72-42d0-b2f9-089da901a15b" />
