### PR TITLE
Fix: 6225-properties-editor---image-tab---image-or-movie---image-pane…

### DIFF
--- a/scripts/startup/bl_ui/properties_texture.py
+++ b/scripts/startup/bl_ui/properties_texture.py
@@ -431,7 +431,11 @@ class TEXTURE_PT_image_sampling(TextureTypePanel, Panel):
 
         row = col.row()
         row.use_property_split = False
-        row.prop(tex, "filter_size", text="Size")
+        row.label(text="Size") # BFA
+
+        row = row.row() # BFA
+        row.use_property_split = False
+        row.prop(tex, "filter_size", text="") # BFA
         row.prop_decorator(tex, "filter_size")
 
 


### PR DESCRIPTION
- Size label in front

<img width="415" height="94" alt="image" src="https://github.com/user-attachments/assets/00efb9a0-acc7-4190-b0ae-40abcdb5b4d1" />
