### PR TITLE
Fix: 6224-preferences---interface-tab---order-of-checkboxes

### DIFF
--- a/scripts/startup/bl_ui/space_userpref.py
+++ b/scripts/startup/bl_ui/space_userpref.py
@@ -242,11 +242,11 @@ class USERPREF_PT_interface_display(InterfacePanel, CenterAlignMixIn, Panel):
         flow = layout.grid_flow(row_major=False, columns=0, even_columns=True, even_rows=False, align=False)
         flow.use_property_split = False
         flow.prop(prefs, "use_recent_searches", text="Sort Search by Most Recent")
+        flow.prop(prefs, "show_hidden_ids", text="Show Hidden")
         # bfa - gooengine disable_search_on_keypress
         flow.prop(prefs, "disable_search_on_keypress", text="Disable Search on Key Press")
         # bfa - gooengine disable_material_icon
         flow.prop(prefs, "disable_material_icon", text="Disable Material Icon Rendering")
-        layout.prop(prefs, "show_hidden_ids", text="Show Hidden")
 
 
 class USERPREF_PT_interface_text(InterfacePanel, CenterAlignMixIn, Panel):


### PR DESCRIPTION
- Moved under Disable Search on Key Press (matches blender)

<img width="872" height="529" alt="image" src="https://github.com/user-attachments/assets/726c1e1c-cf7f-4965-965d-ec4edd39188a" />
