### PR TITLE
Fix: 6235-spreadsheet-editor---double-entry-show-internal-attributes

### DIFF
--- a/scripts/startup/bl_ui/space_spreadsheet.py
+++ b/scripts/startup/bl_ui/space_spreadsheet.py
@@ -66,10 +66,6 @@ class SPREADSHEET_MT_view(bpy.types.Menu):
 
         layout.separator()
 
-        layout.prop(sspreadsheet, "show_internal_attributes", text="Internal Attributes")
-
-        layout.separator()
-
         layout.menu("INFO_MT_area")
 
 


### PR DESCRIPTION
- removed show_internal_attributes from the view has we have it on the header.