### PR TITLE
Fix: 6234-file-browser---display-settings---double-label-sort-by

### DIFF
--- a/scripts/startup/bl_ui/space_filebrowser.py
+++ b/scripts/startup/bl_ui/space_filebrowser.py
@@ -159,8 +159,6 @@ class FILEBROWSER_PT_display(FileBrowserPanel, Panel):
 
         layout.prop(params, "recursion_level", text="Recursions")
 
-        layout.label(text="Sort By")  # BFA - added label
-
         layout.column().prop(params, "sort_method", text="Sort By", expand=True)
         layout.use_property_split = False
         layout.prop(params, "use_sort_invert")


### PR DESCRIPTION
-- removed the second Sort By label, already one in the sort_method

<img width="384" height="269" alt="image" src="https://github.com/user-attachments/assets/f586aebf-8057-4f88-b6b8-ed06f343ba96" />
