### PR TITLE
Fix: Compositor - Asset Shelf - Reassign default asset librarie categories in versioning #6212

### DIFF
--- a/source/blender/blenkernel/intern/blendfile.cc
+++ b/source/blender/blenkernel/intern/blendfile.cc
@@ -1647,7 +1647,7 @@ UserDef *BKE_blendfile_userdef_from_defaults()
         userdef, "NODE_AST_compositor", "Utilities");
   }
 
-  /* start bfa asset shelf default catalogs */
+  /* start BFA asset shelf default catalogs */
   {
     /* 3D Viewport*/
     BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
@@ -1657,8 +1657,7 @@ UserDef *BKE_blendfile_userdef_from_defaults()
     BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
         userdef, "VIEW3D_AST_object", "Materials");
     BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
-        userdef, "VIEW3D_AST_object", "Geometry Nodegroups/Grease Pencil");
-
+        userdef, "VIEW3D_AST_object", "Generate");
 
     /* Node editors*/
 
@@ -1689,11 +1688,26 @@ UserDef *BKE_blendfile_userdef_from_defaults()
     BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
         userdef, "NODE_AST_geometry_node_groups", "Geometry Nodegroups/Mesh");
 
+
     /*Compositor*/
     BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
-      userdef, "NODE_AST_compositor", "Compositor Nodegroups/Texture/Shapes");
+        userdef, "NODE_AST_compositor", "Compositor Nodegroups/Color");
+    BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
+        userdef, "NODE_AST_compositor", "Compositor Nodegroups/Creative");
+    BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
+        userdef, "NODE_AST_compositor", "Compositor Nodegroups/Distortion");
+    BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
+        userdef, "NODE_AST_compositor", "Compositor Nodegroups/Filters");
+    BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
+        userdef, "NODE_AST_compositor", "Compositor Nodegroups/Lenses");
+    BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
+        userdef, "NODE_AST_compositor", "Compositor Nodegroups/Output");
+    BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
+        userdef, "NODE_AST_compositor", "Compositor Nodegroups/Texture");
+    BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
+        userdef, "NODE_AST_compositor", "Compositor Nodegroups/Utilities");
   }
-  /* end bfa asset shelf default catalogs */
+  /* end BFA asset shelf default catalogs */
 
 
   return userdef;

--- a/source/blender/blenloader/intern/versioning_userdef.cc
+++ b/source/blender/blenloader/intern/versioning_userdef.cc
@@ -1788,11 +1788,21 @@ void blo_do_versions_userdef(UserDef *userdef)
 
   if (!USER_VERSION_ATLEAST(500, 116)) {
     BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
-        userdef, "NODE_AST_compositor", "Camera & Lens Effects");
+        userdef, "NODE_AST_compositor", "Compositor Nodegroups/Color");
     BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
-        userdef, "NODE_AST_compositor", "Creative");
+        userdef, "NODE_AST_compositor", "Compositor Nodegroups/Creative");
     BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
-        userdef, "NODE_AST_compositor", "Utilities");
+        userdef, "NODE_AST_compositor", "Compositor Nodegroups/Distortion");
+    BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
+        userdef, "NODE_AST_compositor", "Compositor Nodegroups/Filters");
+    BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
+        userdef, "NODE_AST_compositor", "Compositor Nodegroups/Lenses");
+    BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
+        userdef, "NODE_AST_compositor", "Compositor Nodegroups/Output");
+    BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
+        userdef, "NODE_AST_compositor", "Compositor Nodegroups/Texture");
+    BKE_preferences_asset_shelf_settings_ensure_catalog_path_enabled(
+        userdef, "NODE_AST_compositor", "Compositor Nodegroups/Utilities");
   }
 
   if (!USER_VERSION_ATLEAST(501, 17)) {


### PR DESCRIPTION
Added top level categories to compositor, and added it to versioning too Added the Generate category for the built in modifiers for discovery.

No documentation needed from what I know. These are mentioned in the Default Asset Library chapter.

