### PR TITLE
NLA Editor - Sidebar - Strip Tab - Put checkbox in front of Strip name and icon #6262

### DIFF
--- a/source/blender/editors/space_nla/nla_buttons.cc
+++ b/source/blender/editors/space_nla/nla_buttons.cc
@@ -373,6 +373,7 @@ static void nla_panel_stripname(const bContext *C, Panel *panel)
   /* strip type */
   ui::Layout &row = layout.row(true);
 
+  /* BFA - Move checkbox left */
   block_emboss_set(block, ui::EmbossType::NoneOrStatus);
   row.prop(&strip_ptr, "mute", UI_ITEM_NONE, "", ICON_NONE);
   block_emboss_set(block, ui::EmbossType::Emboss);


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="291" height="127" alt="image" src="https://github.com/user-attachments/assets/7881ed1c-73a5-47af-bfbc-f27a94815e1e" /> | <img width="293" height="127" alt="image" src="https://github.com/user-attachments/assets/08666f74-bb9f-4a23-ac32-13ff6325f9c4" /> |

Resolves: #6262