### PR TITLE
Video Sequencer & Properties - Strip Tab - Put checkbox in front of Strip name and icon #6276

### DIFF
--- a/scripts/startup/bl_ui/properties_strip.py
+++ b/scripts/startup/bl_ui/properties_strip.py
@@ -90,8 +90,12 @@ class STRIP_PT_strip(StripButtonsPanel, Panel):
 
         row = layout.row(align=True)
         row.use_property_decorate = False
+        
+        # BFA - Put checkbox to the left of other elements
+        row.prop(strip, "mute", toggle=True, icon_only=True, emboss=False)
+        row.separator(factor=0.5)
+        
         row.label(text="", icon=icon_header)
-        row.separator()
         row.prop(strip, "name", text="")
 
         sub = row.row(align=True)
@@ -100,9 +104,6 @@ class STRIP_PT_strip(StripButtonsPanel, Panel):
         else:
             icon = 'STRIP_' + strip.color_tag
             sub.popover(panel="STRIP_PT_color_tag_picker", text="", icon=icon)
-
-        row.separator()
-        row.prop(strip, "mute", toggle=True, icon_only=True, emboss=False)
 
 
 class STRIP_PT_adjust_crop(StripButtonsPanel, Panel):

--- a/scripts/startup/bl_ui/space_sequencer.py
+++ b/scripts/startup/bl_ui/space_sequencer.py
@@ -2027,8 +2027,12 @@ class SEQUENCER_PT_strip(SequencerButtonsPanel, Panel):
 
         row = layout.row(align=True)
         row.use_property_decorate = False
+        
+        # BFA - Put checkbox to the left of other elements
+        row.prop(strip, "mute", toggle=True, icon_only=True, emboss=False)
+        row.separator(factor=0.5)
+        
         row.label(text="", icon=icon_header)
-        row.separator()
         row.prop(strip, "name", text="")
 
         sub = row.row(align=True)
@@ -2037,9 +2041,6 @@ class SEQUENCER_PT_strip(SequencerButtonsPanel, Panel):
         else:
             icon = "STRIP_" + strip.color_tag
             sub.popover(panel="SEQUENCER_PT_color_tag_picker", text="", icon=icon)
-
-        row.separator()
-        row.prop(strip, "mute", toggle=True, icon_only=True, emboss=False)
 
 # BFA - Legacy
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="368" height="150" alt="image" src="https://github.com/user-attachments/assets/bc6ecb91-5943-4a01-9e0d-44d6f6664248" /> | <img width="370" height="152" alt="image" src="https://github.com/user-attachments/assets/cc74e52d-6664-4205-b3e3-4558f75d1d74" /> |
| <img width="306" height="108" alt="image" src="https://github.com/user-attachments/assets/1e5fb0d8-ce0d-48e6-af51-361305e3ccf3" /> | <img width="302" height="107" alt="image" src="https://github.com/user-attachments/assets/0c0c9e62-cf77-4372-af95-f0796af59c63" /> |

Resolves: #6276 
