### PR TITLE
Properties Editor - Camera - Background Images panel > Movie Clip - Use split layout for non-boolean properties #6216

### DIFF
--- a/scripts/startup/bl_ui/properties_data_camera.py
+++ b/scripts/startup/bl_ui/properties_data_camera.py
@@ -386,8 +386,6 @@ class DATA_PT_camera_background_image(CameraButtonsPanel, Panel):
                             sub.template_image_stereo_3d(bg.image.stereo_3d_format)
 
                 elif bg.source == 'MOVIE_CLIP':
-                    box.use_property_split = False
-
                     row = box.row()
                     row.use_property_split = False
                     split = row.split(factor = 0.5)
@@ -411,6 +409,7 @@ class DATA_PT_camera_background_image(CameraButtonsPanel, Panel):
 
                     column = box.column()
                     column.active = has_bg
+                    column.use_property_split = False # BFA - float left
                     column.prop(bg.clip_user, "use_render_undistorted")
                     column.use_property_split = True
                     column.prop(bg.clip_user, "proxy_render_size")


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="309" height="605" alt="image" src="https://github.com/user-attachments/assets/6cea9ab8-522d-485e-8fda-364f47775eb3" /> | <img width="310" height="630" alt="image" src="https://github.com/user-attachments/assets/521ce57a-5180-49d3-8ad2-319700e0d601" /> |
| <img width="307" height="462" alt="image" src="https://github.com/user-attachments/assets/310e64f4-1aab-452e-ad68-06517ab99f4b" /> | <img width="306" height="504" alt="image" src="https://github.com/user-attachments/assets/669ddb17-f43b-410a-b366-26ecd7eb5794" /> |

Resolves: #6216 