### PR TITLE
UI - Core - Make boolean properties always left-aligned

### DIFF
--- a/source/blender/editors/interface/interface_layout.cc
+++ b/source/blender/editors/interface/interface_layout.cc
@@ -2111,8 +2111,17 @@ void Layout::prop(PointerRNA *ptr,
       }
     }
     else {
-      Layout *layout_split =
-          &(layout_row ? layout_row : layout)->split(UI_ITEM_PROP_SEP_DIVIDE, true);
+      Layout *layout_split;
+      if (type != PROP_BOOLEAN){ /* BFA - Only use split if prop is not boolean */
+        layout_split =
+            &(layout_row ? layout_row : layout)->split(UI_ITEM_PROP_SEP_DIVIDE, true);
+      }
+      else{ /* BFA - Draw boolean properties left-aligned */
+        layout_split =
+            &(layout_row ? layout_row : layout)->row(true);
+        layout_split->alignment_set(LayoutAlign::Left);
+      }
+
       bool label_added = false;
       Layout *layout_sub = &layout_split->column(true);
       layout_sub->space_ = 0;


### PR DESCRIPTION
Always make booleans align left regardless if layout was split or not.
A great deal of regressions we get on our end is having to deal with booleans using a split layout in Blender main code, while non-split in ours. We save a lot of maintenance overhead on our part if we just enforce this as global behavior in `Layout::prop`.

| Before | After |
| --- | --- |
| <img width="310" height="257" alt="image" src="https://github.com/user-attachments/assets/04d5a2b2-34cf-4a69-a403-6c1da301f4dd" /> | <img width="304" height="248" alt="image" src="https://github.com/user-attachments/assets/a0b5ff99-3ca9-43d2-baa6-d0c7eb363706" /> |