### PR TITLE
Fix: Default Asset Library - Register and unregister the correct library type #6310

### DIFF
--- a/scripts/addons_core/bfa_default_library/__init__.py
+++ b/scripts/addons_core/bfa_default_library/__init__.py
@@ -44,7 +44,7 @@ from . import utility
 bl_info = {
     "name": "Default Asset Library",
     "author": "Andres (Draise) Stephens, Ereaser45-Studios, Iyad Ahmed, Juan Carlos Aragon",
-    "version": (1, 2, 8),
+    "version": (1, 2, 9),
     "blender": (4, 4, 3),
     "location": "Asset Browser>Default Library",
     "description": "Adds a modular default asset library and addon with wizards and complementary operators",
@@ -56,14 +56,16 @@ bl_info = {
 }
 
 # Addon identification - MUST BE UNIQUE for each compiled parent addon
-PARENT_ADDON_UNIQUE_ID = "default_asset_library_1_2_7"
+# TO DO: Update hte version in the bl_info above as well for consistency
+PARENT_ADDON_UNIQUE_ID = "default_asset_library_1_2_9"
 PARENT_ADDON_DISPLAY_NAME = "Default Asset Library"
-PARENT_ADDON_VERSION = (1, 2, 8)
+PARENT_ADDON_VERSION = (1, 2, 9)
 
 # Child addon info - this is the functional addon
-CHILD_ADDON_UNIQUE_ID = "default_asset_library_functions_1_2_7"
+# TO DO: Update the child_addon/blender_manifest.toml to reflect this version as well for consistency
+CHILD_ADDON_UNIQUE_ID = "default_asset_library_functions_1_0_1"
 CHILD_ADDON_DISPLAY_NAME = "Default Asset Library Functions"
-CHILD_ADDON_VERSION = (1, 2, 8)
+CHILD_ADDON_VERSION = (1, 0, 1)
 
 # Library configuration - Only include libraries that exist in your packaged addon
 CENTRAL_LIB_SUBFOLDERS = [
@@ -144,9 +146,11 @@ def copy_child_addon_to_user_prefs():
                     shutil.copy2(src_file, dest_file)
                     #print(f"  ✓ Copied Python: {file}")
                 elif file.endswith('.toml'):
-                    # Skip manifest files - child addon is not a separate addon
-                    #print(f"  ⚠ Skipping manifest file: {file}")
-                    pass
+                    # Copy manifest files to avoid empty manifest warnings
+                    src_file = os.path.join(root, file)
+                    dest_file = os.path.join(dest_dir, file)
+                    shutil.copy2(src_file, dest_file)
+                    #print(f"  ✓ Copied manifest: {file}")
                 else:
                     # Copy other files (if any)
                     src_file = os.path.join(root, file)
@@ -156,10 +160,30 @@ def copy_child_addon_to_user_prefs():
 
         #print(f"✅ Child addon copied to: {child_addon_dst}")
 
-        # Verify the copy worked - only check for Python files
+        # Verify the copy worked - check for Python files and manifest
         init_file = p.join(child_addon_dst, "__init__.py")
+        manifest_file = p.join(child_addon_dst, "blender_manifest.toml")
 
         if p.exists(init_file):
+            # Double-check that manifest file was copied
+            if not p.exists(manifest_file):
+                # Try to copy from source again
+                source_manifest = p.join(child_addon_src, "blender_manifest.toml")
+                if p.exists(source_manifest):
+                    shutil.copy2(source_manifest, manifest_file)
+                    #print(f"✓ Re-copied manifest from source: {source_manifest}")
+                else:
+                    # Create a minimal blender_manifest.toml if missing
+                    with open(manifest_file, 'w') as f:
+                        f.write('''[build-system]
+                                requires = ["setuptools"]
+                                build-backend = "setuptools.build_meta"
+
+                                [project]
+                                name = "default_asset_library_functions"
+                                version = "1.0.1"
+                                ''')
+                    #print(f"✓ Created minimal blender_manifest.toml")
             #print(f"✅ Verification: __init__.py present")
             return True
         else:
@@ -803,7 +827,12 @@ def register_library(force_reregister=False):
         if lib_name in libraries_to_create:
             # Library doesn't exist, create it
             try:
-                bpy.ops.preferences.asset_library_add(directory=library_path)
+                # Check Blender version for compatibility with online assets
+                # Blender 5.1+ requires 'type' parameter, earlier versions don't support it
+                if bpy.app.version >= (5, 1, 0):
+                    bpy.ops.preferences.asset_library_add(directory=library_path, type='LOCAL')
+                else:
+                    bpy.ops.preferences.asset_library_add(directory=library_path)
 
                 # Find the newly created library and set its name
                 for i, lib in enumerate(prefs.filepaths.asset_libraries):
@@ -847,6 +876,26 @@ def unregister_library(full_cleanup=False):
         else:
             # Update library presence without removing tracking
             utility.update_addon_in_central_library(parent_addon_info, [], central_base, p.dirname(__file__))
+
+            # Check which libraries are still used by other addons
+            tracking_data = utility.read_addon_tracking(central_base)
+            used_libraries = set()
+            for addon_data in tracking_data.values():
+                used_libraries.update(addon_data.get('libraries', []))
+
+            # Remove libraries that are no longer used
+            try:
+                prefs = bpy.context.preferences
+                for lib_name in CENTRAL_LIB_SUBFOLDERS:
+                    if lib_name not in used_libraries:
+                        lib_path = p.join(central_base, lib_name)
+                        lib_index = get_lib_path_index(prefs, lib_name, lib_path)
+                        if lib_index != -1:
+                            bpy.ops.preferences.asset_library_remove(index=lib_index)
+                            print(f"✓ Removed unused library: {lib_name}")
+            except Exception as e:
+                print(f"⚠ Could not remove unused libraries from preferences: {e}")
+
 
         # Check if no other addons are using the central library
         active_addons = utility.get_active_addons_count(central_base)

--- a/scripts/addons_core/bfa_default_library/child_addon/blender_manifest.toml
+++ b/scripts/addons_core/bfa_default_library/child_addon/blender_manifest.toml
@@ -1,0 +1,77 @@
+# bl_extension.toml
+schema_version = "2.0.0"
+
+# Example of manifest file for a Blender extension
+# Change the values according to your extension
+id = "modular_child_addons"
+name = "Default Asset Library Functions"
+version = "1.0.1"
+blender_version_min = "4.4.0"
+author = "Andres (Draise) Stephens"
+maintainer = "Andres (Draise) Stephens"
+tagline = "Default Asset Library Functions for wizards and operators"
+type = "add-on"
+description = "These functions are bundled with the Default Asset Library addon for wizards and library operators. This is only a symbolic addon entry. You can safely uninstall without a problem."
+license = ["SPDX:GPL-3.0-or-later",]
+repository = "https://github.com/Bforartists/Bforartists"
+warning = "This is automatically copied to the user preferences when the Default Asset Library addon is installed or updated."
+
+# # Optional: link to documentation, support, source files, etc
+website = "https://www.bforartists.de/data/manualbfa4/28.1_Asset_Browser_-_Default_Asset_LIbrary.pdf"
+
+# # Optional: Blender version that the extension does not support, earlier versions are supported.
+# # This can be omitted and defined later on the extensions platform if an issue is found.
+# blender_version_max = "5.1.0"
+
+# License conforming to https://spdx.org/licenses/ (use "SPDX: prefix)
+# https://docs.blender.org/manual/en/dev/advanced/extensions/licenses.html
+# license = [
+#   "SPDX:GPL-3.0-or-later",
+# ]
+# # Optional: required by some licenses.
+# copyright = [
+#   "2002-2024 Developer Name",
+#   "1998 Company Name",
+# ]
+
+# # Optional: list of supported platforms. If omitted, the extension will be available in all operating systems.
+# platforms = ["windows-x64", "macos-arm64", "linux-x64"]
+# # Other supported platforms: "windows-arm64", "macos-x64"
+
+# # Optional: bundle 3rd party Python modules.
+# # https://docs.blender.org/manual/en/dev/advanced/extensions/python_wheels.html
+# wheels = [
+#   "./wheels/hexdump-3.3-py3-none-any.whl",
+#   "./wheels/jsmin-3.0.1-py3-none-any.whl",
+# ]
+
+# # Optional: add-ons can list which resources they will require:
+# # * files (for access of any filesystem operations)
+# # * network (for internet access)
+# # * clipboard (to read and/or write the system clipboard)
+# # * camera (to capture photos and videos)
+# # * microphone (to capture audio)
+# #
+# # If using network, remember to also check `bpy.app.online_access`
+# # https://docs.blender.org/manual/en/dev/advanced/extensions/addons.html#internet-access
+# #
+# # For each permission it is important to also specify the reason why it is required.
+# # Keep this a single short sentence without a period (.) at the end.
+# # For longer explanations use the documentation or detail page.
+#
+# [permissions]
+# network = "Need to sync motion-capture data to server"
+# files = "Import/export FBX from/to disk"
+# clipboard = "Copy and paste bone transforms"
+
+# # Optional: advanced build settings.
+# # https://docs.blender.org/manual/en/dev/advanced/extensions/command_line_arguments.html#command-line-args-extension-build
+# [build]
+# # These are the default build excluded patterns.
+# # You only need to edit them if you want different options.
+# paths_exclude_pattern = [
+#   "__pycache__/",
+#   "/.git/",
+#   "/*.zip",
+# ]
+

--- a/scripts/addons_core/bfa_default_library/child_addon/operators/__init__.py
+++ b/scripts/addons_core/bfa_default_library/child_addon/operators/__init__.py
@@ -16,6 +16,9 @@
 #
 # ##### END GPL LICENSE BLOCK #####
 
+# Uninstalling this should not be done by the user
+# import bpy
+
 # -----------------------------------------------------------------------------
 # Operators Module Initialization
 # Central registry for all operator classes


### PR DESCRIPTION
- Now it registers the new library type, to make room for online assets
- It also removes them in a more robust way (to add and remove from user opt in)
- Fixed the missing manifest. It's a bit of a dummy one, a user can activate, deactivate and remove it, but it won't affect the default asset library functions and wizards. This is handled by the addon itself. Addon missing manifest #6291

No user facing changes to document

