### PR TITLE
6312 preferences   asset libraries   move library buttons now broken when trying to move an online repository experimental

### DIFF
--- a/scripts/startup/bl_operators/userpref.py
+++ b/scripts/startup/bl_operators/userpref.py
@@ -1353,7 +1353,7 @@ class PREFERENCES_OT_asset_library_move(Operator):
             self.report({'INFO'}, "Library is already at the end of the list.")
             return {'CANCELLED'}
 
-        # Use the new move function to reorder the collection
+        # BFA: Use the RNA move function to reorder asset libraries in the collection
         filepaths.asset_libraries.move(active_library_index, new_index)
 
         return {'FINISHED'}

--- a/source/blender/makesrna/intern/rna_userdef.cc
+++ b/source/blender/makesrna/intern/rna_userdef.cc
@@ -712,6 +712,7 @@ static void rna_userdef_asset_library_remove(bContext *C, ReportList *reports, P
   USERDEF_TAG_DIRTY;
 }
 
+/* BFA: Move asset library to new position and update active library index */
 static void rna_userdef_asset_library_move(bContext *C, ReportList *reports, int from_index, int to_index)
 {
   const int count = BLI_listbase_count(&U.asset_libraries);


### PR DESCRIPTION
Preferences: Add move up/down support for remote asset libraries

- Implemented `rna_userdef_asset_library_move` to allow reordering asset libraries, including remote libraries, in user preferences.
- Updates active asset library index and triggers asset browser refresh after move.
- Fixes missing move up/down operators for recently added remote asset libraries.

[Screencast_20260227_075105.webm](https://github.com/user-attachments/assets/ba9f0fca-3180-478b-af31-472f38e9d7fb)
