### PR TITLE
Fix: 6335-3d-view---grease-pencil---vertex-paint-brush---make-sidebar…

### DIFF
--- a/scripts/startup/bl_ui/properties_paint_common.py
+++ b/scripts/startup/bl_ui/properties_paint_common.py
@@ -2400,7 +2400,9 @@ def brush_basic_grease_pencil_vertex_settings(layout, context, brush, *, compact
     gp_settings = brush.gpencil_settings
     if brush.gpencil_vertex_brush_type in {"DRAW", "REPLACE"}:
         row = layout.row(align=True)
-        row.prop(gp_settings, "vertex_mode", text="Mode", expand=True)
+        row.prop(gp_settings, "vertex_mode", text="Mode", expand=compact) # bfa - use compact!
+        # bfa - This sets expand to false for the sidebar, while keeping header true
+        # bfa - use 'not compact' for the opposite effect!
 
 
 classes = (


### PR DESCRIPTION
-- added compact to expand

This sets expand to false for the sidebar, while keeping header true,  use 'not compact' for the opposite effect!

<img width="1165" height="964" alt="image" src="https://github.com/user-attachments/assets/2f94ab62-3415-4fcf-af3b-04ee2479ce6b" />
