### PR TITLE
Fix: 6345-file-browser-keymap---replace-tool-props-keymap-with-tilde-key

### DIFF
--- a/scripts/presets/keyconfig/Bforartists.py
+++ b/scripts/presets/keyconfig/Bforartists.py
@@ -1974,10 +1974,10 @@ keyconfig_data = \
        ],
       },
      ),
-    ("screen.region_toggle",
-     {"type": 'T', "value": 'PRESS', "ctrl": True},
+    ("wm.call_menu_pie",
+     {"type": 'ACCENT_GRAVE', "value": 'PRESS'},
      {"properties":
-      [("region_type", 'TOOL_PROPS'),
+      [("name", 'FILEBROWSER_MT_view_pie'),
        ],
       },
      ),


### PR DESCRIPTION
-- This simply replaces the file browser tool props toggle, for the view pie menu (since #6344)

(Accidently pushed this to #6344, but reverted it) 