### PR TITLE
Fix: 6328-import---drag-and-drop-menu-for-svg-needs-icons

### DIFF
--- a/scripts/addons_core/io_curve_svg/__init__.py
+++ b/scripts/addons_core/io_curve_svg/__init__.py
@@ -35,6 +35,7 @@ from bpy_extras.io_utils import (
     ImportHelper,
     poll_file_object_drop,
 )
+from addon_utils import get_icon_value # bfa - added icon - get_icon_value function needed!
 
 
 class ImportSVG(bpy.types.Operator, ImportHelper):
@@ -77,6 +78,7 @@ class IO_FH_svg_as_curves(bpy.types.FileHandler):
     bl_label = "SVG as Curves"
     bl_import_operator = "import_curve.svg"
     bl_file_extensions = ".svg"
+    bl_icon = get_icon_value('LOAD_SVG') # bfa - added icon - get_icon_value function needed!
 
     @classmethod
     def poll_drop(cls, context):

--- a/scripts/modules/addon_utils.py
+++ b/scripts/modules/addon_utils.py
@@ -15,6 +15,7 @@ __all__ = (
     "extensions_refresh",
     "stale_pending_remove_paths",
     "stale_pending_stage_paths",
+    "get_icon_value", # bfa - added icon - get_icon_value function needed!
 )
 
 import bpy as _bpy
@@ -2002,6 +2003,37 @@ def _extensions_warnings_get():
 
 
 _extensions_warnings_get._is_first = True
+
+# bfa - added get_icon_value function
+def get_icon_value(icon_name):
+    """Get the integer value for an icon name from Blender's RNA system.
+    
+    This function provides dynamic icon lookup needed for FileHandler bl_icon properties.
+    IMPORTANT: Icon integer values can change when new icons are added to Blender,
+    so hardcoded values will break over time. This function ensures reliable icon lookup.
+    
+    This function extends Blender's existing icon access patterns to provide
+    integer values needed for FileHandler bl_icon properties.
+    
+    Usage:
+        bl_icon = get_icon_value('LOAD_SVG')     # Returns 759
+        bl_icon = get_icon_value('ICON_NONE')    # Returns 0
+        bl_icon = get_icon_value('MESH_CUBE')    # Returns 28
+    
+    Args:
+        icon_name (str): The icon name (e.g., 'LOAD_SVG', 'ICON_NONE', 'MESH_CUBE')
+    
+    Returns:
+        int: The integer value for the icon, or 0 if not found.
+    """
+    try:
+        icon_enum = _bpy.types.UILayout.bl_rna.functions["prop"].parameters["icon"].enum_items
+        for item in icon_enum:
+            if hasattr(item, 'identifier') and item.identifier == icon_name:
+                return item.value
+        return 0
+    except:
+        return 0
 
 
 def _is_first_reset():

--- a/source/blender/blenkernel/BKE_file_handler.hh
+++ b/source/blender/blenkernel/BKE_file_handler.hh
@@ -36,6 +36,8 @@ struct FileHandlerType {
    * start with a `.` and be separated by `;`. For Example: `".blend;.ble"`.
    */
   char file_extensions_str[FH_MAX_FILE_EXTENSIONS_STR];
+  /** bfa - Icon identifier for file handler. */
+  int icon;
 
   /** Check if file handler can be used on file drop. */
   bool (*poll_drop)(const bContext *C, FileHandlerType *file_handle_type);

--- a/source/blender/blenkernel/intern/file_handler.cc
+++ b/source/blender/blenkernel/intern/file_handler.cc
@@ -41,6 +41,11 @@ void file_handler_add(std::unique_ptr<FileHandlerType> file_handler)
 {
   BLI_assert(file_handler_find(file_handler->idname) == nullptr);
 
+  /* bfa - Initialize icon to none if not set. */
+  if (file_handler->icon == 0) {
+    file_handler->icon = 0;
+  }
+
   /** Load all extensions from the string list into the list. */
   const char char_separator = ';';
   const char *char_begin = file_handler->file_extensions_str;

--- a/source/blender/editors/io/io_drop_import_file.cc
+++ b/source/blender/editors/io/io_drop_import_file.cc
@@ -153,7 +153,7 @@ static wmOperatorStatus wm_drop_import_file_invoke(bContext *C,
     wmOperatorType *ot = WM_operatortype_find(file_handler->import_operator, false);
     PointerRNA file_props = layout.op(ot,
                                       CTX_TIP_(ot->translation_context, ot->name),
-                                      ICON_NONE,
+                                      file_handler->icon, /* bfa - added icon */
                                       wm::OpCallContext::InvokeDefault,
                                       UI_ITEM_NONE);
     file_handler_import_operator_write_ptr(file_handler, file_props, paths);

--- a/source/blender/editors/io/io_grease_pencil.cc
+++ b/source/blender/editors/io/io_grease_pencil.cc
@@ -602,6 +602,7 @@ void grease_pencil_file_handler_add()
   STRNCPY_UTF8(fh->import_operator, "WM_OT_grease_pencil_import_svg");
   STRNCPY_UTF8(fh->label, "SVG as Grease Pencil");
   STRNCPY_UTF8(fh->file_extensions_str, ".svg");
+  fh->icon = ICON_LOAD_SVG_GPENCIL; /* bfa - added icon */
   fh->poll_drop = poll_file_object_drop;
   bke::file_handler_add(std::move(fh));
 }

--- a/source/blender/makesrna/intern/rna_ui.cc
+++ b/source/blender/makesrna/intern/rna_ui.cc
@@ -2664,6 +2664,12 @@ static void rna_def_file_handler(BlenderRNA *brna)
       "start with a \".\" and be separated by \";\"."
       "\nFor Example: ``\".blend;.ble\"``");
 
+  /* bfa - added icon for file handler */
+  prop = RNA_def_property(srna, "bl_icon", PROP_INT, PROP_NONE);
+  RNA_def_property_int_sdna(prop, nullptr, "type->icon");
+  RNA_def_property_flag(prop, PROP_REGISTER_OPTIONAL);
+  RNA_def_property_ui_text(prop, "Icon", "Icon to display for the file handler");
+
   PropertyRNA *parm;
   FunctionRNA *func;
 


### PR DESCRIPTION
-- added menu icons for the drag drop menu selection option.
-- added get_icon_value function (read below)

(This is done in via addon_utils, so it can be imported for other file handlers in future when/if needed, this function is needed, since file handler rna requires a integer, and also when we add more or remove icons, their ids can change, this just automatically finds the icons integer id number.)

<img width="311" height="80" alt="image" src="https://github.com/user-attachments/assets/33e878d3-6ec4-4fa7-9727-3f5663ed129f" />


