### PR TITLE
Fix: 6287-nla---sidebar---active-strip-panel---indent-and-large-space…

### DIFF
--- a/source/blender/editors/space_nla/nla_buttons.cc
+++ b/source/blender/editors/space_nla/nla_buttons.cc
@@ -474,9 +474,11 @@ static void nla_panel_properties(const bContext *C, Panel *panel)
                       RNA_boolean_get(&strip_ptr, "use_animated_time")));
     /* bfa */
     row = &column->row(false);
+    row->separator(); /* bfa - indent */
     row->prop(&strip_ptr, "use_reverse", UI_ITEM_NONE, std::nullopt, ICON_NONE);
 
     row = &column->row(false);
+    row->separator(); /* bfa - indent */
     row->prop(&strip_ptr, "use_animated_time_cyclic", UI_ITEM_NONE, std::nullopt, ICON_NONE);
 
     layout.use_property_split_set(true);


### PR DESCRIPTION
-- indented the 2 Playback props

<img width="264" height="408" alt="image" src="https://github.com/user-attachments/assets/ddd9cbc5-950d-490a-89c1-2917a5edb8f1" />
