### PR TITLE
Dev: Allow reloading of toolshelf via Text Editor

### DIFF
--- a/scripts/startup/bl_ui/space_node_toolshelf.py
+++ b/scripts/startup/bl_ui/space_node_toolshelf.py
@@ -9,7 +9,7 @@ from bpy.app.translations import (
 import dataclasses
 
 from nodeitems_builtins import node_tree_group_type
-from .node_add_menu import draw_node_groups, add_empty_group
+from bl_ui.node_add_menu import draw_node_groups, add_empty_group
 
 
 # BFA - Custom panels for the sidebar toolshelf


### PR DESCRIPTION
A relative import prevented `space_node_toolshelf.py` from executing propertly from the Text Editor. This removes the option to live-edit the script via "Edit Source", slowing the process of tweaking the toolshelf.

This patch fixes replaces the relative import by replacing it with an absolute one. This should fix the issue. No user-facing changes are to be expected.

