### PR TITLE
Shader Nodes - Toolshelf - Fix incorrect toolshelf buttons for Closures #6368

### DIFF
--- a/scripts/startup/bl_ui/space_node_toolshelf.py
+++ b/scripts/startup/bl_ui/space_node_toolshelf.py
@@ -616,8 +616,8 @@ class NODES_PT_toolshelf_shader_add_utilities(bpy.types.Panel, NodePanel):
                 OperatorEntry("ShaderNodeMapRange", text=iface_("Map Range"), pad=20, settings={"data_type": "'FLOAT_VECTOR'"}),#
                 OperatorEntry(operator="node.add_repeat_zone", pad=18, text="Repeat Zone", icon="REPEAT"),
                 Separator,
-                OperatorEntry("NodeClosureInput", pad=18),
-                OperatorEntry("NodeClosureOutput", pad=16),
+                OperatorEntry(operator="node.add_closure_zone", text="Closure", icon="NODE_CLOSURE", pad=24),
+                OperatorEntry("NodeEvaluateClosure", pad=8),
                 OperatorEntry("NodeCombineBundle", pad=15),
                 OperatorEntry("NodeSeparateBundle", pad=15),
                 Separator,
@@ -2817,8 +2817,6 @@ class NODES_PT_toolshelf_gn_add_utilities_closure(bpy.types.Panel, NodePanel):
         # When adding a new node, test different padding amounts until the button text is left-aligned with the rest of the panel items.
         entries = (
             OperatorEntry(operator="node.add_closure_zone", text="Closure", icon="NODE_CLOSURE", pad=24),
-            #OperatorEntry("NodeClosureInput", pad=12),
-            #OperatorEntry("NodeClosureOutput", pad=8),
             OperatorEntry("NodeEvaluateClosure", pad=8),
         )
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="257" height="269" alt="image" src="https://github.com/user-attachments/assets/c3a1bfc7-9112-4f1c-9a2f-5fbb25aa5114" /> | <img width="263" height="265" alt="image" src="https://github.com/user-attachments/assets/ac71b26b-bbb8-4410-8069-69eeb3d9ba06" /> |

Resolves: #6368