### PR TITLE
Node Editors - New "Cut" node operator to paste later #6240

### DIFF
--- a/scripts/presets/keyconfig/Bforartists-macOS.py
+++ b/scripts/presets/keyconfig/Bforartists-macOS.py
@@ -6091,6 +6091,7 @@ keyconfig_data = \
     ("node.render_changed", {"type": 'Z', "value": 'PRESS'}, None),
     ("node.clipboard_copy", {"type": 'C', "value": 'PRESS', "oskey": True}, None),
     ("node.clipboard_paste", {"type": 'V', "value": 'PRESS', "oskey": True}, None),
+    ("node.delete_copy_reconnect", {"type": 'X', "value": 'PRESS', "oskey": True}, None),
     ("node.viewer_border", {"type": 'B', "value": 'PRESS', "oskey": True}, None),
     ("node.clear_viewer_border", {"type": 'B', "value": 'PRESS', "alt": True, "oskey": True}, None),
     ("node.translate_attach",

--- a/scripts/presets/keyconfig/Bforartists.py
+++ b/scripts/presets/keyconfig/Bforartists.py
@@ -5013,6 +5013,7 @@ keyconfig_data = \
     ("node.render_changed", {"type": 'Z', "value": 'PRESS'}, None),
     ("node.clipboard_copy", {"type": 'C', "value": 'PRESS', "ctrl": True}, None),
     ("node.clipboard_paste", {"type": 'V', "value": 'PRESS', "ctrl": True}, None),
+    ("node.delete_copy_reconnect", {"type": 'X', "value": 'PRESS', "ctrl": True}, None),
     ("node.viewer_border", {"type": 'B', "value": 'PRESS', "ctrl": True}, None),
     ("node.clear_viewer_border", {"type": 'B', "value": 'PRESS', "ctrl": True, "alt": True}, None),
     ("node.translate_attach",

--- a/scripts/startup/bl_ui/space_node.py
+++ b/scripts/startup/bl_ui/space_node.py
@@ -691,7 +691,7 @@ class NODE_MT_node(Menu):
         layout.operator("transform.resize", icon="TRANSFORM_SCALE")
 
         layout.separator()
-        layout.operator("node.delete_copy_reconnect", text="Cut")
+        layout.operator("node.delete_copy_reconnect", text="Cut", icon='CUT') # BFA
         layout.operator_context = 'EXEC_DEFAULT'
         layout.operator("node.clipboard_copy", text="Copy", icon='COPYDOWN')
         row = layout.row()
@@ -1040,7 +1040,7 @@ class NODE_MT_context_menu(Menu):
 
             layout.separator()
 
-        layout.operator("node.delete_copy_reconnect", text="Cut") # BFA - WIP
+        layout.operator("node.delete_copy_reconnect", text="Cut", icon='CUT') # BFA
         layout.operator("node.clipboard_copy", text="Copy", icon="COPYDOWN")
         layout.operator("node.clipboard_paste", text="Paste", icon="PASTEDOWN")
 


### PR DESCRIPTION
Added icon and set shortcut to Ctrl/Oskey + X, since this is common for cut in other programs.

<img width="279" height="178" alt="image" src="https://github.com/user-attachments/assets/d2a60c93-7324-4954-bf45-3bc2d6be1b0f" />

Blender does not use that shortcut due to conflict with "Delete with Reconnect".
Since we don't have said conflict, using said hotkey should be fine.

Resolves: #6240