### PR TITLE
Toolbar/Topbar - Manager Panel - Make different functions more distinguishable #6380

### DIFF
--- a/scripts/addons_core/bforartists_toolbar_settings.py
+++ b/scripts/addons_core/bforartists_toolbar_settings.py
@@ -54,25 +54,25 @@ class BFA_OT_toolbar_settings_prefs(AddonPreferences):
     ])
 
     bfa_topbar_types: EnumProperty(name='Topbar Types', description='', items=[
-        ('Files', 'Files', 'Files Options', 0, 0),
-        ('Mesh Edit', 'Mesh Edit', 'Mesh Edit Options', 0, 1),
-        ('Primitives', 'Primitives', 'Primitives Options', 0, 2),
-        ('Image', 'Image', '', 0, 3),
-        ('Tools', 'Tools', '', 0, 4),
-        ('Animation', 'Animation', '', 0, 5),
-        ('Edit', 'Edit', '', 0, 6),
-        ('Misc', 'Misc', '', 0, 7)
+        ('Files', 'Files', 'Files Options', "FILE_FOLDER", 0),
+        ('Mesh Edit', 'Mesh Edit', 'Mesh Edit Options', "EDITMODE_HLT", 1),
+        ('Primitives', 'Primitives', 'Primitives Options', "MESH_CUBE", 2),
+        ('Image', 'Image', '', "IMAGE", 3),
+        ('Tools', 'Tools', '', "TOOL_SETTINGS", 4),
+        ('Animation', 'Animation', '', "DECORATE_KEYFRAME", 5),
+        ('Edit', 'Edit', '', "EDIT", 6),
+        ('Misc', 'Misc', '', "PRESET", 7)
     ])
 
     bfa_toolbar_types: EnumProperty(name='Toolbar Types', description='', items=[
-        ('Files', 'Files', 'Files Options', 0, 0),
-        ('Mesh Edit', 'Mesh Edit', 'Mesh Edit Options', 0, 1),
-        ('Primitives', 'Primitives', 'Primitives Options', 0, 2),
-        ('Image', 'Image', '', 0, 3),
-        ('Tools', 'Tools', '', 0, 4),
-        ('Animation', 'Animation', '', 0, 5),
-        ('Edit', 'Edit', '', 0, 6),
-        ('Misc', 'Misc', '', 0, 7)
+        ('Files', 'Files', 'Files Options', "FILE_FOLDER", 0),
+        ('Mesh Edit', 'Mesh Edit', 'Mesh Edit Options', "EDITMODE_HLT", 1),
+        ('Primitives', 'Primitives', 'Primitives Options', "MESH_CUBE", 2),
+        ('Image', 'Image', '', "IMAGE", 3),
+        ('Tools', 'Tools', '', "TOOL_SETTINGS", 4),
+        ('Animation', 'Animation', '', "DECORATE_KEYFRAME", 5),
+        ('Edit', 'Edit', '', "EDIT", 6),
+        ('Misc', 'Misc', '', "PRESET", 7)
     ])
 
     #bfa_options: EnumProperty(name='Adv Options', description='', items=[

--- a/scripts/startup/bl_ui/space_toolbar.py
+++ b/scripts/startup/bl_ui/space_toolbar.py
@@ -89,6 +89,195 @@ class TOOLBAR_PT_type(Panel):
     bl_region_type = 'HEADER'
     bl_ui_units_x=16
 
+    @classmethod
+    def poll(cls, context):
+        return (True)
+
+    @classmethod
+    def draw_show_hide_section(cls, context, layout):
+        preferences = context.preferences
+        addon_prefs = preferences.addons["bforartists_toolbar_settings"].preferences
+
+        header = layout.row()
+        header.alignment = 'CENTER'
+        header.label(text="Show/Hide Settings")
+
+        if (addon_prefs.bfa_toolbar_types == 'Files'):
+            if context.area.file_toolbars:
+                row = layout.grid_flow(columns=2, align=True)
+                row.prop(addon_prefs, "file_load_save",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "file_recover",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "file_link_append",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "file_import_menu",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "file_export_menu",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "file_import_common",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "file_import_common2",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "file_import_uncommon",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "file_export_common",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "file_export_common2",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "file_export_uncommon",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "file_render",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "file_render_opengl",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "file_render_misc",toggle=addon_prefs.bfa_button_style)
+            else:
+                row = layout.row()
+                row.alignment = 'Center'.upper()
+                row.alert = True
+                row.label(text='Files is hidden', icon="NONE")
+
+        if (addon_prefs.bfa_toolbar_types == 'Mesh Edit'):
+            if context.area.meshedit_toolbars:
+                row = layout.grid_flow(columns=2, align=True)
+                row.prop(addon_prefs, "mesh_vertices_splitconnect",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "mesh_vertices_misc",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "mesh_edges_subdiv",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "mesh_edges_sharp",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "mesh_edges_freestyle",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "mesh_edges_misc",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "mesh_faces_general",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "mesh_faces_freestyle",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "mesh_faces_tris",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "mesh_faces_rotatemisc",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "mesh_cleanup",toggle=addon_prefs.bfa_button_style)
+            else:
+                row = layout.row()
+                row.alignment = 'Center'.upper()
+                row.alert = True
+                row.label(text='Mesh Edit is hidden', icon="NONE")
+
+        if (addon_prefs.bfa_toolbar_types == 'Primitives'):
+            if context.area.primitives_toolbars:
+                row = layout.grid_flow(columns=2, align=True)
+                row.prop(addon_prefs, "primitives_mesh",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "primitives_curve",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "primitives_surface",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "primitives_metaball",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "primitives_volume",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "primitives_point_cloud",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "primitives_gpencil",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "primitives_gpencil_lineart",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "primitives_light",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "primitives_other",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "primitives_empties",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "primitives_image",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "primitives_lightprobe",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "primitives_forcefield",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "primitives_collection",toggle=addon_prefs.bfa_button_style)
+            else:
+                row = layout.row()
+                row.alignment = 'Center'.upper()
+                row.alert = True
+                row.label(text='Primitives is hidden', icon="NONE")
+
+        if (addon_prefs.bfa_toolbar_types == 'Image'):
+            if context.area.image_toolbars:
+                row = layout.grid_flow(columns=2, align=True)
+                row.prop(addon_prefs, "image_uv_mirror",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "image_uv_rotate",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "image_uv_align",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "image_uv_unwrap",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "image_uv_modify",toggle=addon_prefs.bfa_button_style)
+            else:
+                row = layout.row()
+                row.alignment = 'Center'.upper()
+                row.alert = True
+                row.label(text='Image is hidden', icon="NONE")
+
+        if (addon_prefs.bfa_toolbar_types == 'Tools'):
+            if context.area.tools_toolbars:
+                row = layout.grid_flow(columns=2, align=True)
+                row.prop(addon_prefs, "tools_parent",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "tools_objectdata",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "tools_link_to_scn",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "tools_linked_objects",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "tools_join",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "tools_origin",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "tools_shading",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "tools_datatransfer",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "tools_relations",toggle=addon_prefs.bfa_button_style)
+            else:
+                row = layout.row()
+                row.alignment = 'Center'.upper()
+                row.alert = True
+                row.label(text='Tools is hidden', icon="NONE")
+
+        if (addon_prefs.bfa_toolbar_types == 'Animation'):
+            if context.area.animation_toolbars:
+                row = layout.grid_flow(columns=2, align=True)
+                row.prop(addon_prefs, "animation_keyframes",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "animation_range",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "animation_play",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "animation_sync",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "animation_keyframetype",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "animation_keyingset",toggle=addon_prefs.bfa_button_style)
+            else:
+                row = layout.row()
+                row.alignment = 'Center'.upper()
+                row.alert = True
+                row.label(text='Animation is hidden', icon="NONE")
+
+        if (addon_prefs.bfa_toolbar_types == 'Edit'):
+            if context.area.edit_toolbars:
+                row = layout.grid_flow(columns=2, align=True)
+                row.prop(addon_prefs, "edit_edit",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "edit_weightinedit",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "edit_objectapply",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "edit_objectapply2",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "edit_objectapplydeltas",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "edit_objectclear",toggle=addon_prefs.bfa_button_style)
+            else:
+                row = layout.row()
+                row.alignment = 'Center'.upper()
+                row.alert = True
+                row.label(text='Edit is hidden', icon="NONE")
+
+        if (addon_prefs.bfa_toolbar_types == 'Misc'):
+            if context.area.misc_toolbars:
+                row = layout.grid_flow(columns=2, align=True)
+                row.prop(addon_prefs, "misc_viewport",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "misc_undoredo",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "misc_undohistory",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "misc_repeat",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "misc_scene",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "misc_viewlayer",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "misc_last",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "misc_operatorsearch",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "misc_info",toggle=addon_prefs.bfa_button_style)
+            else:
+                row = layout.row()
+                row.alignment = 'Center'.upper()
+                row.alert = True
+                row.label(text='Misc is hidden', icon="NONE")
+
+    @staticmethod
+    def icon_op_button(layout, operator_id, condition, icon_on, icon_off):
+        if condition:
+            layout.active_default = True
+            layout.operator(operator_id, text="", icon=icon_on)
+        else:
+            layout.active_default = False
+            layout.operator(operator_id, text="", icon=icon_off)
+    
+    @staticmethod
+    def draw_reset_section(layout):
+        row = layout.row(heading='', align=True)
+        row.alignment = 'Center'.upper()
+
+        row.label(text='Defaults')
+        row.separator()
+        row.operator("bfa.reset_toolbar", text='All')
+
+        grid = layout.grid_flow(row_major=False, columns=2, even_columns=True, even_rows=True, align=True)
+
+        grid.operator("bfa.reset_toolbar_files", text='Files')
+        grid.operator("bfa.reset_toolbar_meshedit", text='Mesh Edit')
+        grid.operator("bfa.reset_toolbar_primitives", text='Primitives')
+        grid.operator("bfa.reset_toolbar_image", text='Image')
+        grid.operator("bfa.reset_toolbar_tools", text='Tools')
+        grid.operator("bfa.reset_toolbar_animation", text='Animation')
+        grid.operator("bfa.reset_toolbar_edit", text='Edit')
+        grid.operator("bfa.reset_toolbar_misc", text='Misc')
+
     def draw(self, context):
         layout = self.layout
         screen = bpy.ops.screen
@@ -106,252 +295,28 @@ class TOOLBAR_PT_type(Panel):
 
         # Reset Settings Panel
         if (bpy.context.scene.bfa_toolbar_defaults == True):
-
-            row = box.row(heading='', align=True)
-            row.alignment = 'Center'.upper()
-
-            row.label(text='Defaults')
-            row.separator()
-            row.operator("bfa.reset_toolbar", text='All')
-
-            grid = box.grid_flow(row_major=False, columns=2, even_columns=True, even_rows=True, align=True)
-
-            grid.operator("bfa.reset_toolbar_files", text='Files')
-            grid.operator("bfa.reset_toolbar_meshedit", text='Mesh Edit')
-            grid.operator("bfa.reset_toolbar_primitives", text='Primitives')
-            grid.operator("bfa.reset_toolbar_image", text='Image')
-            grid.operator("bfa.reset_toolbar_tools", text='Tools')
-            grid.operator("bfa.reset_toolbar_animation", text='Animation')
-            grid.operator("bfa.reset_toolbar_edit", text='Edit')
-            grid.operator("bfa.reset_toolbar_misc", text='Misc')
-
-        grid = layout.grid_flow(row_major=False, columns=2, even_columns=True, even_rows=True, align=True)
-        col_amount = 2
-
-        # Main Panels Preferences
-        box = grid.box()
-        row = box.row()
-        row.alignment = 'Center'.upper()
-
-        row.label(text='Types', icon='DOWNARROW_HLT')
-        row = box.grid_flow(columns=col_amount, align=True)
-
-        # File toolbar button
-        if context.area.file_toolbars:
-            row.active_default = True
-        else:
-            row.active_default = False
-        row.operator("screen.header_toolbar_file", text = "Files")
-
-        # Mesh Edit toolbar button
-        if context.area.meshedit_toolbars:
-            row.active_default = True
-        else:
-            row.active_default = False
-        row.operator("screen.header_toolbar_meshedit", text = "Mesh Edit")
-
-        # Primitives toolbar button
-        if context.area.primitives_toolbars:
-            row.active_default = True
-        else:
-            row.active_default = False
-        row.operator("screen.header_toolbar_primitives", text = "Primitives")
-
-        # Image toolbar button
-        if context.area.image_toolbars:
-            row.active_default = True
-        else:
-            row.active_default = False
-        row.operator("screen.header_toolbar_image", text = "Image")
-
-        # Tools toolbar button
-        if context.area.tools_toolbars:
-            row.active_default = True
-        else:
-            row.active_default = False
-        row.operator("screen.header_toolbar_tools", text = "Tools")
-
-        # Animation toolbar button
-        if context.area.animation_toolbars:
-            row.active_default = True
-        else:
-            row.active_default = False
-        row.operator("screen.header_toolbar_animation", text = "Animation")
-
-        # Edit toolbar button
-        if context.area.edit_toolbars:
-            row.active_default = True
-        else:
-            row.active_default = False
-        row.operator("screen.header_toolbar_edit", text = "Edit")
-
-        # Misc toolbar button
-        if context.area.misc_toolbars:
-            row.active_default = True
-        else:
-            row.active_default = False
-        row.operator("screen.header_toolbar_misc", text = "Misc")
+            self.draw_reset_section(box)
 
         # Sub panels Settings
-        box = grid.box()
-        row = box.row()
-        row.alignment = 'Center'.upper()
-
-        row.label(text='Options', icon="RIGHTARROW")
-        row = box.grid_flow(columns=col_amount, align=True)
-        row.prop(addon_prefs, 'bfa_toolbar_types', text='Types', icon="NONE", emboss=True, expand=True)
-
         box = layout.box()
-        row = box.row(heading='', align=False)
-        row.alignment = 'Center'.upper()
-        row.label(text='Show / Hide Toolbars')
+        row = box.row(align=True)
+        col1 = row.column(align=True)
+        col2 = row.column(align=True)
 
-        if (addon_prefs.bfa_toolbar_types == 'Files'):
-            if context.area.file_toolbars:
-                row = box.grid_flow(columns=2, align=True)
-                row.prop(addon_prefs, "file_load_save",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "file_recover",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "file_link_append",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "file_import_menu",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "file_export_menu",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "file_import_common",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "file_import_common2",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "file_import_uncommon",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "file_export_common",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "file_export_common2",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "file_export_uncommon",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "file_render",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "file_render_opengl",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "file_render_misc",toggle=addon_prefs.bfa_button_style)
-            else:
-                row = box.row()
-                row.alignment = 'Center'.upper()
-                row.alert = True
-                row.label(text='Files is hidden', icon="NONE")
+        col1.prop(addon_prefs, 'bfa_toolbar_types', expand=True)
 
-        if (addon_prefs.bfa_toolbar_types == 'Mesh Edit'):
-            if context.area.meshedit_toolbars:
-                row = box.grid_flow(columns=2, align=True)
-                row.prop(addon_prefs, "mesh_vertices_splitconnect",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "mesh_vertices_misc",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "mesh_edges_subdiv",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "mesh_edges_sharp",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "mesh_edges_freestyle",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "mesh_edges_misc",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "mesh_faces_general",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "mesh_faces_freestyle",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "mesh_faces_tris",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "mesh_faces_rotatemisc",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "mesh_cleanup",toggle=addon_prefs.bfa_button_style)
-            else:
-                row = box.row()
-                row.alignment = 'Center'.upper()
-                row.alert = True
-                row.label(text='Mesh Edit is hidden', icon="NONE")
-
-        if (addon_prefs.bfa_toolbar_types == 'Primitives'):
-            if context.area.primitives_toolbars:
-                row = box.grid_flow(columns=2, align=True)
-                row.prop(addon_prefs, "primitives_mesh",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "primitives_curve",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "primitives_surface",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "primitives_metaball",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "primitives_volume",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "primitives_point_cloud",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "primitives_gpencil",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "primitives_gpencil_lineart",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "primitives_light",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "primitives_other",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "primitives_empties",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "primitives_image",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "primitives_lightprobe",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "primitives_forcefield",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "primitives_collection",toggle=addon_prefs.bfa_button_style)
-            else:
-                row = box.row()
-                row.alignment = 'Center'.upper()
-                row.alert = True
-                row.label(text='Primitives is hidden', icon="NONE")
-
-        if (addon_prefs.bfa_toolbar_types == 'Image'):
-            if context.area.image_toolbars:
-                row = box.grid_flow(columns=2, align=True)
-                row.prop(addon_prefs, "image_uv_mirror",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "image_uv_rotate",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "image_uv_align",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "image_uv_unwrap",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "image_uv_modify",toggle=addon_prefs.bfa_button_style)
-            else:
-                row = box.row()
-                row.alignment = 'Center'.upper()
-                row.alert = True
-                row.label(text='Image is hidden', icon="NONE")
-
-        if (addon_prefs.bfa_toolbar_types == 'Tools'):
-            if context.area.tools_toolbars:
-                row = box.grid_flow(columns=2, align=True)
-                row.prop(addon_prefs, "tools_parent",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "tools_objectdata",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "tools_link_to_scn",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "tools_linked_objects",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "tools_join",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "tools_origin",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "tools_shading",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "tools_datatransfer",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "tools_relations",toggle=addon_prefs.bfa_button_style)
-            else:
-                row = box.row()
-                row.alignment = 'Center'.upper()
-                row.alert = True
-                row.label(text='Tools is hidden', icon="NONE")
-
-        if (addon_prefs.bfa_toolbar_types == 'Animation'):
-            if context.area.animation_toolbars:
-                row = box.grid_flow(columns=2, align=True)
-                row.prop(addon_prefs, "animation_keyframes",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "animation_range",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "animation_play",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "animation_sync",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "animation_keyframetype",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "animation_keyingset",toggle=addon_prefs.bfa_button_style)
-            else:
-                row = box.row()
-                row.alignment = 'Center'.upper()
-                row.alert = True
-                row.label(text='Animation is hidden', icon="NONE")
-
-        if (addon_prefs.bfa_toolbar_types == 'Edit'):
-            if context.area.edit_toolbars:
-                row = box.grid_flow(columns=2, align=True)
-                row.prop(addon_prefs, "edit_edit",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "edit_weightinedit",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "edit_objectapply",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "edit_objectapply2",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "edit_objectapplydeltas",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "edit_objectclear",toggle=addon_prefs.bfa_button_style)
-            else:
-                row = box.row()
-                row.alignment = 'Center'.upper()
-                row.alert = True
-                row.label(text='Edit is hidden', icon="NONE")
-
-        if (addon_prefs.bfa_toolbar_types == 'Misc'):
-            if context.area.misc_toolbars:
-                row = box.grid_flow(columns=2, align=True)
-                row.prop(addon_prefs, "misc_viewport",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "misc_undoredo",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "misc_undohistory",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "misc_repeat",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "misc_scene",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "misc_viewlayer",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "misc_last",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "misc_operatorsearch",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "misc_info",toggle=addon_prefs.bfa_button_style)
-            else:
-                row = box.row()
-                row.alignment = 'Center'.upper()
-                row.alert = True
-                row.label(text='Misc is hidden', icon="NONE")
+        # TODO - Convert to props and use bl_ui.utils.icon_button
+        self.icon_op_button(col2, "screen.header_toolbar_file", context.area.file_toolbars, icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        self.icon_op_button(col2, "screen.header_toolbar_meshedit", context.area.meshedit_toolbars, icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        self.icon_op_button(col2, "screen.header_toolbar_primitives", context.area.primitives_toolbars, icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        self.icon_op_button(col2, "screen.header_toolbar_image", context.area.image_toolbars, icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        self.icon_op_button(col2, "screen.header_toolbar_tools", context.area.tools_toolbars, icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        self.icon_op_button(col2, "screen.header_toolbar_animation", context.area.animation_toolbars, icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        self.icon_op_button(col2, "screen.header_toolbar_edit", context.area.edit_toolbars, icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        self.icon_op_button(col2, "screen.header_toolbar_misc", context.area.misc_toolbars, icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        
+        box = layout.box().column(align=True)
+        self.draw_show_hide_section(context, box)
 
         col = layout.column()
         col.label( text = "Extra Options:")

--- a/scripts/startup/bl_ui/space_topbar_toolbar.py
+++ b/scripts/startup/bl_ui/space_topbar_toolbar.py
@@ -14,6 +14,9 @@ from bpy.props import BoolProperty, EnumProperty, IntProperty
 
 import bpy.utils.previews
 
+from bl_ui.utils import (
+    icon_button,
+)
 
 from bpy.app.translations import (
     pgettext_iface as iface_,
@@ -110,6 +113,182 @@ class TOPBAR_PT_main(Panel):
     def poll(cls, context):
         return (True)
 
+    @classmethod
+    def draw_show_hide_section(cls, context, layout):
+        preferences = context.preferences
+        addon_prefs = preferences.addons["bforartists_toolbar_settings"].preferences
+
+        header = layout.row()
+        header.alignment = 'CENTER'
+        header.label(text="Show/Hide Settings")
+
+        if (addon_prefs.bfa_topbar_types == 'Files'):
+            if addon_prefs.topbar_file_cbox:
+                row = layout.grid_flow(columns=2, align=True)
+                row.prop(addon_prefs, "topbar_file_load_save",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_file_recover",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_file_link_append",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_file_import_menu",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_file_export_menu",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_file_import_common",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_file_import_common2",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_file_import_uncommon",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_file_export_common",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_file_export_common2",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_file_export_uncommon",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_file_render",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_file_render_opengl",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_file_render_misc",toggle=addon_prefs.bfa_button_style)
+            else:
+                row = layout.row()
+                row.alignment = 'Center'.upper()
+                row.alert = True
+                row.label(text='Files is hidden', icon="NONE")
+
+        if (addon_prefs.bfa_topbar_types == 'Mesh Edit'):
+            if addon_prefs.topbar_mesh_cbox:
+                row = layout.grid_flow(columns=2, align=True)
+                row.prop(addon_prefs, "topbar_mesh_vertices_splitconnect",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_mesh_vertices_misc",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_mesh_edges_subdiv",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_mesh_edges_sharp",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_mesh_edges_freestyle",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_mesh_edges_misc",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_mesh_faces_general",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_mesh_faces_freestyle",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_mesh_faces_tris",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_mesh_faces_rotatemisc",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_mesh_cleanup",toggle=addon_prefs.bfa_button_style)
+            else:
+                row = layout.row()
+                row.alignment = 'Center'.upper()
+                row.alert = True
+                row.label(text='Mesh Edit is hidden', icon="NONE")
+
+        if (addon_prefs.bfa_topbar_types == 'Primitives'):
+            if addon_prefs.topbar_primitives_cbox:
+                row = layout.grid_flow(columns=2, align=True)
+                row.prop(addon_prefs, "topbar_primitives_mesh",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_primitives_curve",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_primitives_surface",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_primitives_metaball",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_primitives_volume",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_primitives_point_cloud",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_primitives_gpencil",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_primitives_gpencil_lineart",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_primitives_light",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_primitives_other",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_primitives_empties",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_primitives_image",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_primitives_lightprobe",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_primitives_forcefield",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_primitives_collection",toggle=addon_prefs.bfa_button_style)
+            else:
+                row = layout.row()
+                row.alignment = 'Center'.upper()
+                row.alert = True
+                row.label(text='Primitives is hidden', icon="NONE")
+
+        if (addon_prefs.bfa_topbar_types == 'Image'):
+            if addon_prefs.topbar_image_cbox:
+                row = layout.grid_flow(columns=2, align=True)
+                row.prop(addon_prefs, "topbar_image_uv_mirror",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_image_uv_rotate",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_image_uv_align",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_image_uv_unwrap",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_image_uv_modify",toggle=addon_prefs.bfa_button_style)
+            else:
+                row = layout.row()
+                row.alignment = 'Center'.upper()
+                row.alert = True
+                row.label(text='Image is hidden', icon="NONE")
+
+        if (addon_prefs.bfa_topbar_types == 'Tools'):
+            if addon_prefs.topbar_tools_cbox:
+                row = layout.grid_flow(columns=2, align=True)
+                row.prop(addon_prefs, "topbar_tools_parent",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_tools_objectdata",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_tools_link_to_scn",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_tools_linked_objects",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_tools_join",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_tools_origin",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_tools_shading",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_tools_datatransfer",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_tools_relations",toggle=addon_prefs.bfa_button_style)
+            else:
+                row = layout.row()
+                row.alignment = 'Center'.upper()
+                row.alert = True
+                row.label(text='Tools is hidden', icon="NONE")
+
+        if (addon_prefs.bfa_topbar_types == 'Animation'):
+            if addon_prefs.topbar_animation_cbox:
+                row = layout.grid_flow(columns=2, align=True)
+                row.prop(addon_prefs, "topbar_animation_keyframes",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_animation_range",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_animation_play",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_animation_sync",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_animation_keyframetype",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_animation_keyingset",toggle=addon_prefs.bfa_button_style)
+            else:
+                row = layout.row()
+                row.alignment = 'Center'.upper()
+                row.alert = True
+                row.label(text='Animation is hidden', icon="NONE")
+
+        if (addon_prefs.bfa_topbar_types == 'Edit'):
+            if addon_prefs.topbar_edit_cbox:
+                row = layout.grid_flow(columns=2, align=True)
+                row.prop(addon_prefs, "topbar_edit_edit",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_edit_weightinedit",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_edit_objectapply",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_edit_objectapply2",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_edit_objectapplydeltas",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_edit_objectclear",toggle=addon_prefs.bfa_button_style)
+            else:
+                row = layout.row()
+                row.alignment = 'Center'.upper()
+                row.alert = True
+                row.label(text='Edit is hidden', icon="NONE")
+
+        if (addon_prefs.bfa_topbar_types == 'Misc'):
+            if addon_prefs.topbar_misc_cbox:
+                row = layout.grid_flow(columns=2, align=True)
+                row.prop(addon_prefs, "topbar_misc_viewport",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_misc_undoredo",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_misc_undohistory",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_misc_repeat",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_misc_scene",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_misc_viewlayer",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_misc_last",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_misc_operatorsearch",toggle=addon_prefs.bfa_button_style)
+                row.prop(addon_prefs, "topbar_misc_info",toggle=addon_prefs.bfa_button_style)
+            else:
+                row = layout.row()
+                row.alignment = 'Center'.upper()
+                row.alert = True
+                row.label(text='Misc is hidden', icon="NONE")
+
+    @staticmethod
+    def draw_reset_section(layout):
+        row = layout.row(heading='', align=True)
+        row.alignment = 'Center'.upper()
+
+        row.label(text='Defaults')
+        row.separator()
+        row.operator("bfa.reset_topbar", text='All')
+
+        grid = layout.grid_flow(row_major=False, columns=2, even_columns=True, even_rows=True, align=True)
+
+        grid.operator("bfa.reset_files", text='Files')
+        grid.operator("bfa.reset_meshedit", text='Mesh Edit')
+        grid.operator("bfa.reset_primitives", text='Primitives')
+        grid.operator("bfa.reset_image", text='Image')
+        grid.operator("bfa.reset_tools", text='Tools')
+        grid.operator("bfa.reset_animation", text='Animation')
+        grid.operator("bfa.reset_edit", text='Edit')
+        grid.operator("bfa.reset_misc", text='Misc')
+
     def draw(self, context):
         layout = self.layout
 
@@ -127,204 +306,27 @@ class TOPBAR_PT_main(Panel):
 
         # Reset Settings Panel
         if (bpy.context.scene.bfa_defaults == True):
-
-            row = box.row(heading='', align=True)
-            row.alignment = 'Center'.upper()
-
-            row.label(text='Defaults')
-            row.separator()
-            row.operator("bfa.reset_topbar", text='All')
-
-            grid = box.grid_flow(row_major=False, columns=2, even_columns=True, even_rows=True, align=True)
-
-            grid.operator("bfa.reset_files", text='Files')
-            grid.operator("bfa.reset_meshedit", text='Mesh Edit')
-            grid.operator("bfa.reset_primitives", text='Primitives')
-            grid.operator("bfa.reset_image", text='Image')
-            grid.operator("bfa.reset_tools", text='Tools')
-            grid.operator("bfa.reset_animation", text='Animation')
-            grid.operator("bfa.reset_edit", text='Edit')
-            grid.operator("bfa.reset_misc", text='Misc')
-
-        grid = layout.grid_flow(row_major=False, columns=2, even_columns=True, even_rows=True, align=True)
-        col_amount = 2
-
-        # Main Panels Preferences
-        box = grid.box()
-        row = box.row()
-        row.alignment = 'Center'.upper()
-
-        row.label(text='Types', icon='DOWNARROW_HLT')
-        row = box.grid_flow(columns=col_amount, align=True)
-        row.prop(addon_prefs, "topbar_file_cbox", toggle=True)
-        row.prop(addon_prefs, "topbar_mesh_cbox", toggle=True)
-        row.prop(addon_prefs, "topbar_primitives_cbox", toggle=True)
-        row.prop(addon_prefs, "topbar_image_cbox", toggle=True)
-        row.prop(addon_prefs, "topbar_tools_cbox", toggle=True)
-        row.prop(addon_prefs, "topbar_animation_cbox", toggle=True)
-        row.prop(addon_prefs, "topbar_edit_cbox", toggle=True)
-        row.prop(addon_prefs, "topbar_misc_cbox", toggle=True)
-
+            self.draw_reset_section(box)
+        
         # Sub panels Settings
-        box = grid.box()
-        row = box.row()
-        row.alignment = 'Center'.upper()
-
-        row.label(text='Options', icon="RIGHTARROW")
-        row = box.grid_flow(columns=col_amount, align=True)
-        row.prop(addon_prefs, 'bfa_topbar_types', text='Types', icon="NONE", emboss=True, expand=True)
-
         box = layout.box()
-        row = box.row(heading='', align=False)
-        row.alignment = 'Center'.upper()
-        row.label(text='Show / Hide Toolbars')
+        row = box.row(align=True)
+        col1 = row.column(align=True)
+        col2 = row.column(align=True)
 
-        if (addon_prefs.bfa_topbar_types == 'Files'):
-            if addon_prefs.topbar_file_cbox:
-                row = box.grid_flow(columns=2, align=True)
-                row.prop(addon_prefs, "topbar_file_load_save",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_file_recover",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_file_link_append",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_file_import_menu",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_file_export_menu",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_file_import_common",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_file_import_common2",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_file_import_uncommon",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_file_export_common",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_file_export_common2",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_file_export_uncommon",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_file_render",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_file_render_opengl",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_file_render_misc",toggle=addon_prefs.bfa_button_style)
-            else:
-                row = box.row()
-                row.alignment = 'Center'.upper()
-                row.alert = True
-                row.label(text='Files is hidden', icon="NONE")
+        col1.prop(addon_prefs, 'bfa_topbar_types', expand=True)
 
-        if (addon_prefs.bfa_topbar_types == 'Mesh Edit'):
-            if addon_prefs.topbar_mesh_cbox:
-                row = box.grid_flow(columns=2, align=True)
-                row.prop(addon_prefs, "topbar_mesh_vertices_splitconnect",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_mesh_vertices_misc",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_mesh_edges_subdiv",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_mesh_edges_sharp",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_mesh_edges_freestyle",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_mesh_edges_misc",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_mesh_faces_general",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_mesh_faces_freestyle",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_mesh_faces_tris",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_mesh_faces_rotatemisc",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_mesh_cleanup",toggle=addon_prefs.bfa_button_style)
-            else:
-                row = box.row()
-                row.alignment = 'Center'.upper()
-                row.alert = True
-                row.label(text='Mesh Edit is hidden', icon="NONE")
-
-        if (addon_prefs.bfa_topbar_types == 'Primitives'):
-            if addon_prefs.topbar_primitives_cbox:
-                row = box.grid_flow(columns=2, align=True)
-                row.prop(addon_prefs, "topbar_primitives_mesh",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_primitives_curve",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_primitives_surface",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_primitives_metaball",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_primitives_volume",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_primitives_point_cloud",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_primitives_gpencil",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_primitives_gpencil_lineart",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_primitives_light",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_primitives_other",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_primitives_empties",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_primitives_image",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_primitives_lightprobe",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_primitives_forcefield",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_primitives_collection",toggle=addon_prefs.bfa_button_style)
-            else:
-                row = box.row()
-                row.alignment = 'Center'.upper()
-                row.alert = True
-                row.label(text='Primitives is hidden', icon="NONE")
-
-        if (addon_prefs.bfa_topbar_types == 'Image'):
-            if addon_prefs.topbar_image_cbox:
-                row = box.grid_flow(columns=2, align=True)
-                row.prop(addon_prefs, "topbar_image_uv_mirror",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_image_uv_rotate",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_image_uv_align",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_image_uv_unwrap",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_image_uv_modify",toggle=addon_prefs.bfa_button_style)
-            else:
-                row = box.row()
-                row.alignment = 'Center'.upper()
-                row.alert = True
-                row.label(text='Image is hidden', icon="NONE")
-
-        if (addon_prefs.bfa_topbar_types == 'Tools'):
-            if addon_prefs.topbar_tools_cbox:
-                row = box.grid_flow(columns=2, align=True)
-                row.prop(addon_prefs, "topbar_tools_parent",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_tools_objectdata",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_tools_link_to_scn",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_tools_linked_objects",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_tools_join",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_tools_origin",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_tools_shading",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_tools_datatransfer",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_tools_relations",toggle=addon_prefs.bfa_button_style)
-            else:
-                row = box.row()
-                row.alignment = 'Center'.upper()
-                row.alert = True
-                row.label(text='Tools is hidden', icon="NONE")
-
-        if (addon_prefs.bfa_topbar_types == 'Animation'):
-            if addon_prefs.topbar_animation_cbox:
-                row = box.grid_flow(columns=2, align=True)
-                row.prop(addon_prefs, "topbar_animation_keyframes",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_animation_range",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_animation_play",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_animation_sync",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_animation_keyframetype",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_animation_keyingset",toggle=addon_prefs.bfa_button_style)
-            else:
-                row = box.row()
-                row.alignment = 'Center'.upper()
-                row.alert = True
-                row.label(text='Animation is hidden', icon="NONE")
-
-        if (addon_prefs.bfa_topbar_types == 'Edit'):
-            if addon_prefs.topbar_edit_cbox:
-                row = box.grid_flow(columns=2, align=True)
-                row.prop(addon_prefs, "topbar_edit_edit",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_edit_weightinedit",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_edit_objectapply",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_edit_objectapply2",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_edit_objectapplydeltas",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_edit_objectclear",toggle=addon_prefs.bfa_button_style)
-            else:
-                row = box.row()
-                row.alignment = 'Center'.upper()
-                row.alert = True
-                row.label(text='Edit is hidden', icon="NONE")
-
-        if (addon_prefs.bfa_topbar_types == 'Misc'):
-            if addon_prefs.topbar_misc_cbox:
-                row = box.grid_flow(columns=2, align=True)
-                row.prop(addon_prefs, "topbar_misc_viewport",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_misc_undoredo",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_misc_undohistory",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_misc_repeat",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_misc_scene",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_misc_viewlayer",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_misc_last",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_misc_operatorsearch",toggle=addon_prefs.bfa_button_style)
-                row.prop(addon_prefs, "topbar_misc_info",toggle=addon_prefs.bfa_button_style)
-            else:
-                row = box.row()
-                row.alignment = 'Center'.upper()
-                row.alert = True
-                row.label(text='Misc is hidden', icon="NONE")
+        icon_button(col2, addon_prefs, "topbar_file_cbox", icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        icon_button(col2, addon_prefs, "topbar_mesh_cbox", icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        icon_button(col2, addon_prefs, "topbar_primitives_cbox", icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        icon_button(col2, addon_prefs, "topbar_image_cbox", icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        icon_button(col2, addon_prefs, "topbar_tools_cbox", icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        icon_button(col2, addon_prefs, "topbar_animation_cbox", icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        icon_button(col2, addon_prefs, "topbar_edit_cbox", icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        icon_button(col2, addon_prefs, "topbar_misc_cbox", icon_on='HIDE_OFF', icon_off='HIDE_ON')
+    
+        box = layout.box().column(align=True)
+        self.draw_show_hide_section(context, box)
 
         col = layout.column()
         col.label( text = "Extra Options:")

--- a/scripts/startup/bl_ui/utils.py
+++ b/scripts/startup/bl_ui/utils.py
@@ -38,3 +38,17 @@ class PresetPanel:
         layout.operator_context = 'EXEC_DEFAULT'
 
         Menu.draw_preset(self, context)
+
+
+def icon_button(layout, data, property_name, icon_on, icon_off, invert_checkbox=False, **kwargs):
+    condition = (getattr(data, property_name) ^ invert_checkbox) # XOR both conditions
+    icon = icon_on if condition else icon_off
+
+    return layout.prop(
+        data, 
+        property_name, 
+        icon_only=True, 
+        icon=icon, 
+        invert_checkbox=invert_checkbox, 
+        **kwargs
+        )


### PR DESCRIPTION
Rework the Toolbar/Topbar to better present its properties.
- Turned the enum into a vertical list.
- Turned the toggles as side buttons with icons HIDE_OFF/HIDE_ON.

Also, on the technical side, the draw function has been split up into multiple subfunctions. This is to make it easier to implement other upcoming refactors.

| Before | After |
| --- | --- |
| <img width="363" height="622" alt="image" src="https://github.com/user-attachments/assets/187fbd42-9dee-420a-ad31-52ca3d178b15" /> | <img width="362" height="657" alt="image" src="https://github.com/user-attachments/assets/577abdf3-41d5-4f56-9466-37d0da6d3cd6" /> |

For reference on how quick it is to edit sections, here's a video of the topbar in action.
Note: The toolbar can't do this drag-behavior as the toggles are operator buttons, not props.

<video src="https://github.com/user-attachments/assets/e15113b2-6fff-454a-a735-af55d2859a4c"></video>

Resolves: #6380