### PR TITLE
Topbar - Workspaces - Double "Duplicate Workspaces" entry #6093

### DIFF
--- a/source/blender/editors/screen/workspace_edit.cc
+++ b/source/blender/editors/screen/workspace_edit.cc
@@ -607,10 +607,11 @@ static void workspace_add_menu_draw(ui::Layout &layout)
 
   BLI_freelistN(&templates);
 
-  layout.separator();
-  layout.op("WORKSPACE_OT_duplicate",
+  /* BFA - Removed as this is redundant and logical in the context menu on the tab*/
+  /*layout.separator();*/
+  /*layout.op("WORKSPACE_OT_duplicate",
             CTX_IFACE_(BLT_I18NCONTEXT_OPERATOR_DEFAULT, "Duplicate Current"),
-            ICON_DUPLICATE);
+            ICON_DUPLICATE);*/
 }
 
 static void workspace_add_menu_register()


### PR DESCRIPTION
<img width="818" height="286" alt="image" src="https://github.com/user-attachments/assets/319d8ce6-4d5f-4bb0-ae9e-52d8cf6b0f28" />

Removed. This may already be documented. 