### PR TITLE
Toolbar - Manager - Directly show toggle properties instead of using operators

### DIFF
--- a/scripts/startup/bl_ui/space_toolbar.py
+++ b/scripts/startup/bl_ui/space_toolbar.py
@@ -10,6 +10,10 @@ from bpy.types import (
 )
 from bpy.app.translations import contexts as i18n_contexts
 
+from bl_ui.utils import (
+    icon_button,
+)
+
 ######################################## Toolbar ########################################
 
 class TOOLBAR_HT_header(Header):
@@ -306,14 +310,15 @@ class TOOLBAR_PT_type(Panel):
         col1.prop(addon_prefs, 'bfa_toolbar_types', expand=True)
 
         # TODO - Convert to props and use bl_ui.utils.icon_button
-        self.icon_op_button(col2, "screen.header_toolbar_file", context.area.file_toolbars, icon_on='HIDE_OFF', icon_off='HIDE_ON')
-        self.icon_op_button(col2, "screen.header_toolbar_meshedit", context.area.meshedit_toolbars, icon_on='HIDE_OFF', icon_off='HIDE_ON')
-        self.icon_op_button(col2, "screen.header_toolbar_primitives", context.area.primitives_toolbars, icon_on='HIDE_OFF', icon_off='HIDE_ON')
-        self.icon_op_button(col2, "screen.header_toolbar_image", context.area.image_toolbars, icon_on='HIDE_OFF', icon_off='HIDE_ON')
-        self.icon_op_button(col2, "screen.header_toolbar_tools", context.area.tools_toolbars, icon_on='HIDE_OFF', icon_off='HIDE_ON')
-        self.icon_op_button(col2, "screen.header_toolbar_animation", context.area.animation_toolbars, icon_on='HIDE_OFF', icon_off='HIDE_ON')
-        self.icon_op_button(col2, "screen.header_toolbar_edit", context.area.edit_toolbars, icon_on='HIDE_OFF', icon_off='HIDE_ON')
-        self.icon_op_button(col2, "screen.header_toolbar_misc", context.area.misc_toolbars, icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        area = context.area
+        icon_button(col2, area, "file_toolbars", icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        icon_button(col2, area, "meshedit_toolbars", icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        icon_button(col2, area, "primitives_toolbars", icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        icon_button(col2, area, "image_toolbars", icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        icon_button(col2, area, "tools_toolbars", icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        icon_button(col2, area, "animation_toolbars", icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        icon_button(col2, area, "edit_toolbars", icon_on='HIDE_OFF', icon_off='HIDE_ON')
+        icon_button(col2, area, "misc_toolbars", icon_on='HIDE_OFF', icon_off='HIDE_ON')
         
         box = layout.box().column(align=True)
         self.draw_show_hide_section(context, box)

--- a/source/blender/makesrna/intern/rna_screen.cc
+++ b/source/blender/makesrna/intern/rna_screen.cc
@@ -88,6 +88,13 @@ static void rna_Screen_bar_update(Main * /*bmain*/, Scene * /*scene*/, PointerRN
   screen->do_refresh = true;
 }
 
+/* BFA - UI redraw callback for toolbar properties */
+static void rna_Area_toolbar_redraw(Main * /*bmain*/, Scene * /*scene*/, PointerRNA *ptr)
+{
+  ScrArea *area = (ScrArea *)ptr->data;
+  ED_area_tag_redraw(area);
+}
+
 static void rna_Screen_redraw_update(Main * /*bmain*/, Scene * /*scene*/, PointerRNA *ptr)
 {
   bScreen *screen = static_cast<bScreen *>(ptr->data);
@@ -491,41 +498,49 @@ static void rna_def_area(BlenderRNA *brna)
   prop = RNA_def_property(srna, "file_toolbars", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_negative_sdna(prop, nullptr, "toolbar_flag", HEADER_TOOLBAR_FILE); // bfa - now uses toolbar_flag
   RNA_def_property_ui_text(prop, "File Toolbars", "Shows or hides the File Toolbars");
+  RNA_def_property_update(prop, NC_SPACE | ND_SPACE_TOOLBAR, "rna_Area_toolbar_redraw");
 
   // bfa - show hide the Mesh Edit toolbars
   prop = RNA_def_property(srna, "meshedit_toolbars", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_negative_sdna(prop, nullptr, "toolbar_flag", HEADER_TOOLBAR_MESHEDIT); // bfa - now uses toolbar_flag
   RNA_def_property_ui_text(prop, "Mesh Edit Toolbars", "Shows or hides the Mesh Edit Toolbars");
+  RNA_def_property_update(prop, NC_SPACE | ND_SPACE_TOOLBAR, "rna_Area_toolbar_redraw");
 
   // bfa - show hide the Primitives toolbars
   prop = RNA_def_property(srna, "primitives_toolbars", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_negative_sdna(prop, nullptr, "toolbar_flag", HEADER_TOOLBAR_PRIMITIVES); // bfa - now uses toolbar_flag
   RNA_def_property_ui_text(prop, "Primitives Toolbars", "Shows or hides the Primitives Toolbars");
+  RNA_def_property_update(prop, NC_SPACE | ND_SPACE_TOOLBAR, "rna_Area_toolbar_redraw");
 
   // bfa - show hide the Image toolbars
   prop = RNA_def_property(srna, "image_toolbars", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_negative_sdna(prop, nullptr, "toolbar_flag", HEADER_TOOLBAR_IMAGE); // bfa - now uses toolbar_flag
   RNA_def_property_ui_text(prop, "Image Toolbars", "Shows or hides the Image Toolbars");
+  RNA_def_property_update(prop, NC_SPACE | ND_SPACE_TOOLBAR, "rna_Area_toolbar_redraw");
 
   // bfa - show hide the Tools toolbars
   prop = RNA_def_property(srna, "tools_toolbars", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_negative_sdna(prop, nullptr, "toolbar_flag", HEADER_TOOLBAR_TOOLS); // bfa - now uses toolbar_flag
   RNA_def_property_ui_text(prop, "Tools Toolbars", "Shows or hides the Tools Toolbars");
+  RNA_def_property_update(prop, NC_SPACE | ND_SPACE_TOOLBAR, "rna_Area_toolbar_redraw");
 
   // bfa - show hide the Animation toolbars
   prop = RNA_def_property(srna, "animation_toolbars", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_negative_sdna(prop, nullptr, "toolbar_flag", HEADER_TOOLBAR_ANIMATION); // bfa - now uses toolbar_flag
   RNA_def_property_ui_text(prop, "Animation Toolbars", "Shows or hides the Animation Toolbars");
+  RNA_def_property_update(prop, NC_SPACE | ND_SPACE_TOOLBAR, "rna_Area_toolbar_redraw");
 
   // bfa - show hide the Edit toolbars
   prop = RNA_def_property(srna, "edit_toolbars", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_negative_sdna(prop, nullptr, "toolbar_flag", HEADER_TOOLBAR_EDIT); // bfa - now uses toolbar_flag
   RNA_def_property_ui_text(prop, "Edit Toolbars", "Shows or hides the Edit Toolbars");
+  RNA_def_property_update(prop, NC_SPACE | ND_SPACE_TOOLBAR, "rna_Area_toolbar_redraw");
 
   // bfa - show hide the Misc toolbars
   prop = RNA_def_property(srna, "misc_toolbars", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_negative_sdna(prop, nullptr, "toolbar_flag", HEADER_TOOLBAR_MISC); // bfa - now uses toolbar_flag
   RNA_def_property_ui_text(prop, "Misc Toolbars", "Shows or hides the Misc Toolbars");
+  RNA_def_property_update(prop, NC_SPACE | ND_SPACE_TOOLBAR, "rna_Area_toolbar_redraw");
 
   // bfa - show hide the File topbars
   prop = RNA_def_property(srna, "file_topbars", PROP_BOOLEAN, PROP_NONE);


### PR DESCRIPTION
Directly draw the show/hide toggle properties in the Toolbar manager, in a similar manner to the Topbar. This allows the user to quickly set multiple toggles via click-dragging rather than pressing one-at-a-time.

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/4904cdd8-6719-47c3-937c-9ad6f5de183b"></video> | <video src="https://github.com/user-attachments/assets/a060409f-1da6-4daa-a218-631bfe33455d"></video> |

The reason operators were used instead of properties was because the toolbar did not update when a property was toggled, because it doesn't trigger an area redraw like an operator does. The same result can be achieved by adding an `update` callback to the properties.

Also resolves #6383.