### PR TITLE
Tools - Sidebar - Weird spacing in three-column layout #6418

### DIFF
--- a/scripts/startup/bl_ui/space_toolsystem_common.py
+++ b/scripts/startup/bl_ui/space_toolsystem_common.py
@@ -613,7 +613,7 @@ class ToolSelectPanelHelper:
         column_index = 0
         while True:
             if is_sep is True:
-                if column_index != column_last:
+                if column_index > column_last: # BFA - Fix spacing issue in when layout is three-column. 
                     row.label(text="")
                 col = layout.column(align=True)
                 row = col.row(align=True)


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="196" height="548" alt="Image" src="https://github.com/user-attachments/assets/4fa4f465-58e7-4f5b-838d-cde1abc4ed0b" /> | <img width="181" height="494" alt="image" src="https://github.com/user-attachments/assets/a198b36c-8d4a-4814-b455-c7e437d24682" /> |
| <img width="170" height="239" alt="Image" src="https://github.com/user-attachments/assets/79b5dd6f-bb0a-4ebe-94f7-9be3367ac2bb" /> | <img width="183" height="225" alt="image" src="https://github.com/user-attachments/assets/c4eaf76e-2219-4021-b052-28b7a50bbd72" /> |

Resolves: #6418