### PR TITLE
Fix: 6435-linux---wayland-icon-replace-blenders-for-bforartists-icon

### DIFF
--- a/source/blender/windowmanager/CMakeLists.txt
+++ b/source/blender/windowmanager/CMakeLists.txt
@@ -132,11 +132,11 @@ if(WITH_GHOST_WAYLAND)
   )
   # Full-color application icon for the Wayland window icon.
   data_to_c(
-    "${CMAKE_SOURCE_DIR}/release/freedesktop/icons/scalable/apps/blender.svg"
-    "${CMAKE_CURRENT_BINARY_DIR}/blender_app_icon.svg.c"
+    "${CMAKE_SOURCE_DIR}/release/freedesktop/icons/scalable/apps/bforartists.svg" # bfa - our icon
+    "${CMAKE_CURRENT_BINARY_DIR}/bforartists_app_icon.svg.c" # bfa - our icon
     SRC
-    # Name override to avoid conflicting with the UI icon `datatoc_blender_svg`.
-    "blender_app_icon_svg"
+    # Name override to avoid conflicting with the UI icon `datatoc_bforartists_svg`.
+    "bforartists_app_icon_svg" # bfa - our icon
   )
   add_definitions(-DWITH_GHOST_WAYLAND)
 endif()

--- a/source/blender/windowmanager/intern/wm_window_icon.cc
+++ b/source/blender/windowmanager/intern/wm_window_icon.cc
@@ -19,7 +19,7 @@
 
 #include "wm_window_icon.hh"
 
-extern "C" const char datatoc_blender_app_icon_svg[];
+extern "C" const char datatoc_bforartists_app_icon_svg[]; // bfa - our icon
 
 static void wm_ghost_icon_generate(const GHOST_IconGenerator * /*icon_generator*/,
                                    GHOST_IWindow * /*window*/,
@@ -29,9 +29,9 @@ static void wm_ghost_icon_generate(const GHOST_IconGenerator * /*icon_generator*
   const size_t buffer_size = size_t(icon_size) * icon_size * 4;
   const int stride = icon_size * 4;
 
-  /* Rasterize the Blender logo SVG into the icon buffer.
+  /* Rasterize the Bforartists logo SVG into the icon buffer.
    * `nsvgParse` modifies the source string, so make a copy. */
-  std::string svg_source = datatoc_blender_app_icon_svg;
+  std::string svg_source = datatoc_bforartists_app_icon_svg; // bfa - our icon
   NSVGimage *image = nsvgParse(svg_source.data(), "px", 96.0f);
   /* The bundled SVG is known to be valid. */
   if (image == nullptr || image->width == 0 || image->height == 0) [[unlikely]] {


### PR DESCRIPTION
-- replaced wayland icon

| Before | After |
|--------|--------|
| <img width="88" height="110" alt="Image" src="https://github.com/user-attachments/assets/f0f1e971-5018-4b73-8304-913113cf6a57" />| <img width="88" height="110" alt="Image" src="https://github.com/user-attachments/assets/758cfc45-4062-4e9a-b429-e0c8ccd247a3" /> |