### PR TITLE
Fix: 6303-sequencer---make-connectdisconnect-strips-contextual-as-a-s…

### DIFF
--- a/scripts/startup/bl_ui/space_sequencer.py
+++ b/scripts/startup/bl_ui/space_sequencer.py
@@ -48,6 +48,30 @@ def selected_strips_count(context):
 
     return total_count, nonsound_count
 
+# BFA - Helper function to check if selected strips are connected
+def are_selected_strips_connected(context):
+    """Check if selected strips are connected together."""
+    selected_strips = getattr(context, "selected_strips", None)
+    if not selected_strips or len(selected_strips) <= 1:
+        return False
+    
+    # Check if all selected strips are connected to each other
+    # We need to check if each strip has connections to the other selected strips
+    selected_strip_set = set(selected_strips)
+    
+    for strip in selected_strips:
+        connected_strips = getattr(strip, "connections", [])
+        # Check if any of the connected strips are in our selection
+        found_connection = False
+        for conn_strip in connected_strips:
+            if conn_strip in selected_strip_set:
+                found_connection = True
+                break
+        if not found_connection:
+            return False
+    
+    return True
+
 
 class SEQUENCER_PT_active_tool(ToolActivePanelHelper, Panel):
     bl_space_type = "SEQUENCE_EDITOR"
@@ -493,7 +517,7 @@ class SEQUENCER_MT_view(Menu):
         preferences = context.preferences
         addon_prefs = preferences.addons["bforartists_toolbar_settings"].preferences
 
-        # bfa - we have it already separated with correct invoke.
+        # BFA - we have it already separated with correct invoke.
 
         # if st.view_type == 'PREVIEW':
         #     # Specifying the REGION_PREVIEW context is needed in preview-only
@@ -1568,10 +1592,14 @@ class SEQUENCER_MT_strip(Menu):
             layout.menu("SEQUENCER_MT_strip_input")
 
             layout.separator()
-            layout.operator("sequencer.connect", icon="LINKED").toggle = True
-            layout.operator("sequencer.disconnect", icon="UNLINKED")
+            
+            # BFA - Show connect or disconnect based on connection state
+            if are_selected_strips_connected(context):
+                layout.operator("sequencer.disconnect", icon="UNLINKED")
+            else:
+                layout.operator("sequencer.connect", icon="LINKED").toggle = False
 
-        # bfa - preview mode only
+        # BFA - preview mode only
         if has_preview:
             layout.separator()
             layout.menu("SEQUENCER_MT_strip_lock_mute")
@@ -1792,9 +1820,12 @@ class SEQUENCER_MT_context_menu(Menu):
         layout.menu("SEQUENCER_MT_strip_lock_mute")
 
         layout.separator()
-
-        layout.operator("sequencer.connect", icon="LINKED").toggle = True
-        layout.operator("sequencer.disconnect", icon="UNLINKED")
+        
+        # BFA - Show connect or disconnect based on connection state
+        if are_selected_strips_connected(context):
+            layout.operator("sequencer.disconnect", icon="UNLINKED")
+        else:
+            layout.operator("sequencer.connect", icon="LINKED").toggle = False
 
     def draw_retime(self, context):
         layout = self.layout

--- a/scripts/startup/bl_ui/space_sequencer_tabs.py
+++ b/scripts/startup/bl_ui/space_sequencer_tabs.py
@@ -17,6 +17,7 @@ from bl_ui.space_toolsystem_common import (
     ToolActivePanelHelper,
     toolsystem_column_count, # BFA - Helper function
 )
+from bl_ui.space_sequencer import are_selected_strips_connected # BFA - Helper function
 from rna_prop_ui import PropertyPanel
 
 
@@ -562,6 +563,67 @@ class SEQUENCER_PT_sequencer_striptab_retiming(Panel):
         else:
             self.draw_strip_context(context)
 
+class SEQUENCER_PT_sequencer_striptab_connect(Panel):
+    bl_label = "Connect"
+    bl_space_type = 'SEQUENCE_EDITOR'
+    bl_region_type = 'TOOLS'
+    bl_category = "Strip"
+    bl_options = {'HIDE_BG', 'DEFAULT_CLOSED'}
+
+     # just show when the toolshelf tabs toggle in the view menu is on.
+    @classmethod
+    def poll(cls, context):
+        space = context.space_data
+        return space.show_toolshelf_tabs and space.view_type in {'SEQUENCER'}
+    
+    def draw(self, context):
+        layout = self.layout
+        strip = context.active_strip
+
+        column_count = toolsystem_column_count(context.region)
+
+        obj = context.object
+
+        layout.operator_context = 'INVOKE_REGION_WIN'
+
+        #text buttons
+        if column_count == 4:
+
+            col = layout.column(align=True)
+            col.scale_y = 2
+
+            # Show connect or disconnect based on connection state
+            if are_selected_strips_connected(context):
+                col.operator("sequencer.disconnect", icon="UNLINKED")
+            else:
+                col.operator("sequencer.connect", icon="LINKED").toggle = False
+        
+        # icon buttons
+        else:
+            col = layout.column(align=True)
+            col.scale_x = 2
+            col.scale_y = 2
+
+            if column_count == 3:
+                # Show connect or disconnect based on connection state
+                if are_selected_strips_connected(context):
+                    col.operator("sequencer.disconnect", icon="UNLINKED")
+                else:
+                    col.operator("sequencer.connect", icon="LINKED").toggle = False
+
+            elif column_count == 2:
+                # Show connect or disconnect based on connection state
+                if are_selected_strips_connected(context):
+                    col.operator("sequencer.disconnect", text="", icon='UNLINKED')
+                else:
+                    col.operator("sequencer.connect", text="", icon='LINKED').toggle = False
+
+            elif column_count == 1:
+                # Show connect or disconnect based on connection state
+                if are_selected_strips_connected(context):
+                    col.operator("sequencer.disconnect", text="", icon='UNLINKED')
+                else:
+                    col.operator("sequencer.connect", text="", icon='LINKED').toggle = False
 
 classes = (
     SEQUENCER_PT_imagetab_clear,
@@ -569,6 +631,7 @@ classes = (
     SEQUENCER_PT_sequencer_striptab_transform,
     SEQUENCER_PT_sequencer_striptab_split,
     SEQUENCER_PT_sequencer_striptab_retiming,
+    SEQUENCER_PT_sequencer_striptab_connect,
 )
 
 if __name__ == "__main__":  # only for live edit.


### PR DESCRIPTION
-- Made the sequencers connect/disconnect operations a single operator. 
-- Exposed to the Toolshelf under Strip - Connect.

[Screencast_20260403_152730.webm](https://github.com/user-attachments/assets/0340c7a0-25e4-450a-8dc6-1a516b6ab60b)

