### PR TITLE
Fix: 6438-top-bar---remove-showhide-topbar-button-redundant

### DIFF
--- a/scripts/startup/bl_ui/space_topbar_toolbar.py
+++ b/scripts/startup/bl_ui/space_topbar_toolbar.py
@@ -292,7 +292,6 @@ class TOPBAR_PT_main(Panel):
         row.label(text='Topbar Manager')
 
         row.alignment = 'CENTER'
-        row.prop(bpy.context.screen, 'show_bfa_topbar', text='', icon='TOPBAR', emboss=True)
         row.prop(bpy.context.scene, 'bfa_defaults', text='', icon='OPTIONS', emboss=True)
 
         # Reset Settings Panel


### PR DESCRIPTION
-- Removed the Topbar toggle from the Topbar Manager

