### PR TITLE
Fix: 6443-bli_vectorhh---set-back-to-use-default_inline_buffer_capacity

### DIFF
--- a/source/blender/blenlib/BLI_vector.hh
+++ b/source/blender/blenlib/BLI_vector.hh
@@ -67,7 +67,7 @@ template<
      * When T is large, the small buffer optimization is disabled by default to avoid large
      * unexpected allocations on the stack. It can still be enabled explicitly though.
      */
-    int64_t InlineBufferCapacity = 1,//default_inline_buffer_capacity(sizeof(T)),
+    int64_t InlineBufferCapacity = default_inline_buffer_capacity(sizeof(T)),
     /**
      * The allocator used by this vector. Should rarely be changed, except when you don't want that
      * MEM_* is used internally.


### PR DESCRIPTION
-- Fixes the leak error


```
Error: Not freed memory blocks: 1, total unfreed memory 0.000015 MB
Freeing memory after the leak detector has run. This can happen when using static variables in C++ that are defined outside of functions. To fix this error, use the 'construct on first use' idiom.
``` 