### PR TITLE
UI - Core - Split boolean properties not expanding full space when in toggle mode #6447

### DIFF
--- a/source/blender/editors/interface/interface_layout.cc
+++ b/source/blender/editors/interface/interface_layout.cc
@@ -2123,7 +2123,6 @@ void Layout::prop(PointerRNA *ptr,
       else{ /* BFA - Draw boolean properties left-aligned */
         layout_split =
             &(layout_row ? layout_row : layout)->row(true);
-        layout_split->alignment_set(LayoutAlign::Left);
       }
 
       bool label_added = false;


### PR DESCRIPTION
Caused by the drawing function overwriting alignment, skip doing this and only use current alignment.

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/ebf4e0db-0c30-4911-a475-7b87041a2cca"></video> | <video src="https://github.com/user-attachments/assets/35011b19-07c8-4c99-8ed9-b3ea7bc274e2"></video> |

Resolves: #6447