### PR TITLE
Properties - Sequencer Strip - Transform - Mirror needs indent to newline #6437

### DIFF
--- a/scripts/startup/bl_ui/properties_strip.py
+++ b/scripts/startup/bl_ui/properties_strip.py
@@ -1021,12 +1021,12 @@ class STRIP_PT_adjust_transform(StripButtonsPanel, Panel):
         col.prop(strip.transform, "filter", text="Filter")
 
         col = layout.column(align=True)
-        subcol = self.indented_layout(col, text="Position", align=True)
+        subcol = self.indented_layout(col, text="Position", align=True) # BFA - Indent
         subcol.prop(strip.transform, "offset_x", text="X")
         subcol.prop(strip.transform, "offset_y", text="Y")
 
         col = layout.column(align=True)
-        subcol = self.indented_layout(col, text="Scale", align=True)
+        subcol = self.indented_layout(col, text="Scale", align=True) # BFA - Indent
         subcol.prop(strip.transform, "scale_x", text="X")
         subcol.prop(strip.transform, "scale_y", text="Y")
 
@@ -1037,7 +1037,7 @@ class STRIP_PT_adjust_transform(StripButtonsPanel, Panel):
         col.prop(strip.transform, "origin")
 
         col = layout.column(align=True)
-        subcol = self.indented_layout(col, text="Mirror", text_ctxt=i18n_contexts.id_image, align=True)
+        subcol = self.indented_layout(col, text="Mirror", text_ctxt=i18n_contexts.id_image, align=True) # BFA - Indent
         subcol.prop(strip, "use_flip_x", text="X", toggle=True)
         subcol.prop(strip, "use_flip_y", text="Y", toggle=True)
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="306" height="340" alt="image" src="https://github.com/user-attachments/assets/0b0ec631-0368-41d6-ac3c-7427d5117bcf" /> | <img width="304" height="359" alt="image" src="https://github.com/user-attachments/assets/0434c127-ad65-4581-9674-d5e89fb1facc" /> |

Resolves: #6437