### PR TITLE
6251-properties-editor---object-properties-with-cycles---motion-blur-…

### DIFF
--- a/intern/cycles/blender/addon/ui.py
+++ b/intern/cycles/blender/addon/ui.py
@@ -1617,6 +1617,7 @@ class CYCLES_OBJECT_PT_motion_blur(CyclesButtonsPanel, Panel):
             row = col.row()
             row.separator() # indent
             row.prop(cob, "use_deform_motion", text="Deformation")
+            row.prop_decorator(cob, "use_deform_motion")
 
 
 class CYCLES_OBJECT_PT_shading_gi_approximation(CyclesButtonsPanel, Panel):


### PR DESCRIPTION
-- added the use_deform_motion (Deformation) missing decorator prop

<img width="395" height="88" alt="image" src="https://github.com/user-attachments/assets/fc6210c4-096d-48e4-a0bf-c644d214337d" />

