### PR TITLE
Compositor - Sidebar > Options - Performance panel - Remove broken property "use_view_border" #6468

### DIFF
--- a/scripts/startup/bl_ui/space_node.py
+++ b/scripts/startup/bl_ui/space_node.py
@@ -1270,10 +1270,6 @@ class NODE_PT_quality(Panel):
         if rd.compositor_device == 'GPU':
             col.prop(rd, "compositor_precision", text="Precision")
 
-        col = layout.column()
-        col.use_property_split = False
-        col.prop(tree, "use_viewer_border")
-
 
 class NODE_PT_overlay(Panel):
     bl_space_type = 'NODE_EDITOR'


### PR DESCRIPTION
Property is no longer used, so it should be removed.
Since panel was already broken from this property, no user-facing changes stem from this change.

Resolves: #6468
