### PR TITLE
3D View - Object Mode - Mesh - Context Menu - Join has no icon #6056

### DIFF
--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -4231,7 +4231,7 @@ class VIEW3D_MT_object_context_menu(Menu):
 
             if obj.type in {"MESH", "CURVE", "SURFACE", "ARMATURE", "GREASEPENCIL"}:
                 if selected_objects_len > 1:
-                    layout.operator("object.join")
+                    layout.operator("object.join", icon="JOIN")
 
             if obj.type in {
                 "MESH",


### PR DESCRIPTION
Context menu, nothing to document I think? It shows only when two ore more objects are selected. 