### PR TITLE
Properties editor - Collections tab - Instancing panel - instance offet menu - add icons #6154

### DIFF
--- a/scripts/startup/bl_ui/properties_collection.py
+++ b/scripts/startup/bl_ui/properties_collection.py
@@ -90,9 +90,9 @@ class COLLECTION_MT_context_menu_instance_offset(Menu):
 
     def draw(self, _context):
         layout = self.layout
-        layout.operator("object.instance_offset_from_cursor")
-        layout.operator("object.instance_offset_from_object")
-        layout.operator("object.instance_offset_to_cursor")
+        layout.operator("object.instance_offset_from_cursor", icon='ORIGIN_TO_CURSOR')
+        layout.operator("object.instance_offset_from_object", icon='ORIGIN_TO_GEOMETRY')
+        layout.operator("object.instance_offset_to_cursor", icon='CURSORTOCENTER')
 
 
 class COLLECTION_PT_instancing(CollectionButtonsPanel, Panel):


### PR DESCRIPTION

<img width="364" height="564" alt="image" src="https://github.com/user-attachments/assets/070ef5a6-5941-40c8-a476-309cbe15b7f6" />

Added icons similar to the origin cursor icons for general know-how. No new icons.

