### PR TITLE
UV Editor - Context Menu - Stitch missing icon #6486

### DIFF
--- a/scripts/startup/bl_ui/space_image.py
+++ b/scripts/startup/bl_ui/space_image.py
@@ -891,7 +891,7 @@ class IMAGE_MT_uvs_context_menu(Menu):
             # Remove
             layout.menu("IMAGE_MT_uvs_merge")
             layout.operator_context = "INVOKE_REGION_WIN"
-            layout.operator("uv.stitch")
+            layout.operator("uv.stitch", icon="STITCH")
             layout.operator_context = "EXEC_REGION_WIN"
             layout.menu("IMAGE_MT_uvs_split")
 


### PR DESCRIPTION
<img width="651" height="928" alt="image" src="https://github.com/user-attachments/assets/e7595986-da96-49a5-9215-e77d14d2955a" />

It's a context menu, not sure if documented. 