### PR TITLE
Fix: 6502-node-editors---context-menu---frame-icons-needs-to-be-updated

### DIFF
--- a/scripts/startup/bl_ui/space_node.py
+++ b/scripts/startup/bl_ui/space_node.py
@@ -1079,8 +1079,8 @@ class NODE_MT_context_menu(Menu):
 
                 layout.separator()
 
-        layout.operator("node.join", text="Join in New Frame", icon='JOIN')
-        layout.operator("node.detach", text="Remove from Frame", icon='DELETE')
+        layout.operator("node.join", text="Join in New Frame", icon='NODE_FRAMEJOIN')
+        layout.operator("node.detach", text="Remove from Frame", icon='NODE_FRAMEREMOVE')
 
         layout.separator()
 


### PR DESCRIPTION
-- Changed right click context menu frame icons to match the toolbar tabs ones.

<img width="225" height="43" alt="image" src="https://github.com/user-attachments/assets/dea22f55-ae87-45eb-a4ad-7b3eb8d2166d" />


