### PR TITLE
6500-compositor---add-blank-image-to-sidebar

### DIFF
--- a/scripts/startup/bl_ui/space_node_toolshelf.py
+++ b/scripts/startup/bl_ui/space_node_toolshelf.py
@@ -802,6 +802,7 @@ class NODES_PT_toolshelf_compositor_add_input(bpy.types.Panel, NodePanel):
         # There is currently no way to determine the correct padding length other than trial-and-error.
         # When adding a new node, test different padding amounts until the button text is left-aligned with the rest of the panel items.
         entries = (
+            OperatorEntry("CompositorNodeBlankImage", pad=14),
             OperatorEntry("CompositorNodeBokehImage", pad=13),
             OperatorEntry("NodeGroupInput", pad=15),
             OperatorEntry("CompositorNodeImage", pad=24),


### PR DESCRIPTION
-- added the Blank Image operator to the Add Menu Sidebar

<img width="229" height="314" alt="image" src="https://github.com/user-attachments/assets/dd4aad0a-a5e7-4f30-aab8-91ca32e1d98e" />
