### PR TITLE
Bug: Node Editors - Missing data management in Node groups #6528

### DIFF
--- a/source/blender/editors/space_node/drawnode.cc
+++ b/source/blender/editors/space_node/drawnode.cc
@@ -254,10 +254,10 @@ NodeResizeDirection node_get_resize_direction(const SpaceNode &snode,
 }
 
 /* ****************** BUTTON CALLBACKS FOR COMMON NODES ***************** */
-
+/* BFA - Added the nodegroup buttons to a top level in the nodegroup*/
 static void node_draw_buttons_group(ui::Layout &layout, bContext *C, PointerRNA *ptr)
 {
-  template_id_browse(&layout, C, ptr, "node_tree", nullptr, nullptr, nullptr);
+  ui::template_id(&layout, C, ptr, "node_tree", "node.new_node_tree", nullptr, nullptr);
 }
 
 static void node_buts_frame_ex(ui::Layout &layout, bContext * /*C*/, PointerRNA *ptr)

--- a/source/blender/editors/space_node/drawnode.cc
+++ b/source/blender/editors/space_node/drawnode.cc
@@ -254,7 +254,7 @@ NodeResizeDirection node_get_resize_direction(const SpaceNode &snode,
 }
 
 /* ****************** BUTTON CALLBACKS FOR COMMON NODES ***************** */
-/* BFA - Added the nodegroup buttons to a top level in the nodegroup*/
+/* BFA - Added the nodegroup buttons to a top level in the nodegroup for usability*/
 static void node_draw_buttons_group(ui::Layout &layout, bContext *C, PointerRNA *ptr)
 {
   ui::template_id(&layout, C, ptr, "node_tree", "node.new_node_tree", nullptr, nullptr);


### PR DESCRIPTION
Change the file browser of nodegroup to not use the `template_id_browse` which uses conditionals to hide many user properties to then use this:
`ui::template_id(&layout, C, ptr, "node_tree", "node.new_node_tree", nullptr, nullptr);`

New controls, or old ones? Check documentation.
<img width="300" height="263" alt="bforartists_Q0hyhUWX2h" src="https://github.com/user-attachments/assets/6b7b9c90-d4e7-4434-9676-a3e96871a592" />

