### PR TITLE
Render Menu - Improve operator labels #6549

### DIFF
--- a/scripts/startup/bl_ui/space_topbar.py
+++ b/scripts/startup/bl_ui/space_topbar.py
@@ -642,17 +642,17 @@ class TOPBAR_MT_render(Menu):
 
             layout.separator()
 
-        layout.operator("sound.mixdown", text="Mixdown Audio", icon="PLAY_AUDIO")
+        layout.operator("sound.mixdown", text="Render Audio", icon="PLAY_AUDIO")
 
         layout.separator()
         # BFA - Exposed hidden operators
-        layout.operator("render.opengl", text="OpenGL Render Image", icon="RENDER_STILL_VIEW")
-        layout.operator("render.opengl", text="OpenGL Render Animation", icon="RENDER_ANI_VIEW").animation = True
+        layout.operator("render.opengl", text="Render Viewport", icon="RENDER_STILL_VIEW")
+        layout.operator("render.opengl", text="Render Viewport Animation", icon="RENDER_ANI_VIEW").animation = True
 
         layout.separator()
 
         layout.operator("render.view_show", text="Show/Hide Render", icon="HIDE_RENDERVIEW")
-        layout.operator("render.play_rendered_anim", text="Play rendered Animation", icon="PLAY")
+        layout.operator("render.play_rendered_anim", icon="PLAY")
 
         layout.separator()
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="300" height="278" alt="image" src="https://github.com/user-attachments/assets/be5a5828-26a2-40f5-8d8f-6a471afce8bd" /> | <img width="303" height="274" alt="image" src="https://github.com/user-attachments/assets/e56338bb-d4ff-47f2-8097-0a21baebd243" /> |

Changes:
- `Mixdown Audio` -> `Render Audio`
- `OpenGL Render (...)` -> `Render Viewport (...)`
- Fix capitalization `Play rendered Animation`

Resolves: #6549 