### PR TITLE
Shader Editor - Node Minimap - General Fixes #6559

### DIFF
--- a/scripts/startup/bl_ui/space_node.py
+++ b/scripts/startup/bl_ui/space_node.py
@@ -412,7 +412,7 @@ class NODE_PT_gizmo_display(Panel):
     bl_space_type = 'NODE_EDITOR'
     bl_region_type = 'HEADER'
     bl_label = "Gizmos"
-    bl_ui_units_x = 8
+    bl_ui_units_x = 12
 
     def draw(self, context):
         layout = self.layout

--- a/source/blender/blenloader/intern/versioning_520.cc
+++ b/source/blender/blenloader/intern/versioning_520.cc
@@ -580,27 +580,6 @@ void blo_do_versions_520(FileData * /*fd*/, Library * /*lib*/, Main *bmain)
     FOREACH_NODETREE_END;
   }
 
-  /* bfa node minimap */
-  if (!MAIN_VERSION_FILE_ATLEAST(bmain, 502, 21)) {
-    for (bScreen &screen : bmain->screens) {
-      for (ScrArea &area : screen.areabase) {
-        for (SpaceLink &space : area.spacedata) {
-          if (space.spacetype == SPACE_NODE) {
-            SpaceNode *space_node = reinterpret_cast<SpaceNode *>(&space);
-            space_node->minimap_aspect_ratio = 2.0f;
-            space_node->minimap_scale = 2.0f;
-            space_node->gizmo_flag |= SNODE_GIZMO_SHOW_MINIMAP |
-                                      SNODE_GIZMO_MINIMAP_SHOW_NODES_IN_FRAME |
-                                      SNODE_GIZMO_MINIMAP_USE_FRAME_COLORS |
-                                      SNODE_GIZMO_MINIMAP_USE_NODE_COLORS |
-                                      SNODE_GIZMO_MINIMAP_MOVE_TO_TOP |
-                                      SNODE_GIZMO_MINIMAP_AUTO_HIDE;
-          }
-        }
-      }
-    }
-  }
-
   /**
    * Always bump subversion in BKE_blender_version.h when adding versioning
    * code here, and wrap it inside a MAIN_VERSION_FILE_ATLEAST check.

--- a/source/blender/blenloader/intern/versioning_common.cc
+++ b/source/blender/blenloader/intern/versioning_common.cc
@@ -880,6 +880,32 @@ void do_versions_after_setup(Main *new_bmain,
       }
     }
   }
+
+  /* BFA Additions:
+   * Uses feature detection instead of version checking for:
+   * - Ensures Blender/Bforartists file save/load compatibility.
+   * - No version management overhead. */
+  for (bScreen &screen : new_bmain->screens) {
+    for (ScrArea &area : screen.areabase) {
+      for (SpaceLink &space : area.spacedata) {
+        if (space.spacetype == SPACE_NODE) {
+          SpaceNode *space_node = reinterpret_cast<SpaceNode *>(&space);
+          
+          /* BFA minimap - enable if not already configured. */
+          if ((space_node->gizmo_flag & SNODE_GIZMO_SHOW_MINIMAP) == 0) {
+            space_node->minimap_aspect_ratio = 2.0f;
+            space_node->minimap_scale = 2.0f;
+            space_node->gizmo_flag |= SNODE_GIZMO_SHOW_MINIMAP |
+                                      SNODE_GIZMO_MINIMAP_SHOW_NODES_IN_FRAME |
+                                      SNODE_GIZMO_MINIMAP_USE_FRAME_COLORS |
+                                      SNODE_GIZMO_MINIMAP_USE_NODE_COLORS |
+                                      SNODE_GIZMO_MINIMAP_MOVE_TO_TOP |
+                                      SNODE_GIZMO_MINIMAP_AUTO_HIDE;
+          }
+        }
+      }
+    }
+  }
 }
 
 }  // namespace blender

--- a/source/blender/makesrna/intern/rna_space.cc
+++ b/source/blender/makesrna/intern/rna_space.cc
@@ -8869,14 +8869,12 @@ static void rna_def_space_node(BlenderRNA *brna)
   /* bfa node minimap gizmo. */
   prop = RNA_def_property(srna, "minimap_aspect_ratio", PROP_FLOAT, PROP_NONE);
   RNA_def_property_float_sdna(prop, nullptr, "minimap_aspect_ratio");
-  RNA_def_property_float_default(prop, 2.0f);
   RNA_def_property_range(prop, 0.5f, 3.0f);
   RNA_def_property_ui_text(prop, "Aspect Ratio", "Sets the aspect ratio of the minimap. The higher the number, the wider the ratio.");
   RNA_def_property_update(prop, NC_SPACE | ND_SPACE_NODE_VIEW, nullptr);
 
   prop = RNA_def_property(srna, "minimap_scale", PROP_FLOAT, PROP_NONE);
   RNA_def_property_float_sdna(prop, nullptr, "minimap_scale");
-  RNA_def_property_float_default(prop, 2.0f);
   RNA_def_property_range(prop, 1.0f, 4.0f);
   RNA_def_property_ui_text(prop, "Minimap scale", "Sets the scale of the minimap");
   RNA_def_property_update(prop, NC_SPACE | ND_SPACE_NODE_VIEW, nullptr);
@@ -8906,12 +8904,12 @@ static void rna_def_space_node(BlenderRNA *brna)
 
   prop = RNA_def_property(srna, "minimap_top", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_sdna(prop, nullptr, "gizmo_flag", SNODE_GIZMO_MINIMAP_MOVE_TO_TOP);
-  RNA_def_property_ui_text(prop, "Minimap top", "Move the minimap to top right, otherwise it will be in the bottom right");
+  RNA_def_property_ui_text(prop, "Minimap Top", "Move the minimap to top right, otherwise it will be in the bottom right");
   RNA_def_property_update(prop, NC_SPACE | ND_SPACE_NODE_VIEW, nullptr);
 
   prop = RNA_def_property(srna, "minimap_auto_hide", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_sdna(prop, nullptr, "gizmo_flag", SNODE_GIZMO_MINIMAP_AUTO_HIDE);
-  RNA_def_property_ui_text(prop, "Minimap auto hide", "Auto hide the minimap when zoomed out fully");
+  RNA_def_property_ui_text(prop, "Minimap Auto Hide", "Auto hide the minimap when zoomed out fully");
   RNA_def_property_update(prop, NC_SPACE | ND_SPACE_NODE_VIEW, nullptr);
 
   /* Overlays */


### PR DESCRIPTION
-- Moved the minimap code versioning code to common in do_versions_after_setup.

- This ensures the feature to properly be enabled, regardless of saved .blend versions, this also helps without needing to manage versioning differences allows proper file save/load compatability between Blender/Bforartists.
- We probably could add more of our additions like the Node World Center has example, if no issues arise from doing so?

-- Fixed some Capitalization.
-- Adjusted the Panel Width.
-- Removed some unneeded RNA defaults.

