### PR TITLE
Graph Editor & Dopesheet - Key - Mirror - Reorder and add separator #6535

### DIFF
--- a/scripts/startup/bl_ui/space_dopesheet.py
+++ b/scripts/startup/bl_ui/space_dopesheet.py
@@ -877,7 +877,7 @@ class DOPESHEET_MT_key(Menu):
 
         layout.menu("DOPESHEET_MT_key_transform", text="Transform")
         layout.menu("DOPESHEET_MT_key_snap")
-        layout.menu("DOPESHEET_MT_key_mirror")
+        layout.operator_menu_enum("action.mirror", "type", text="Mirror")
 
         layout.separator()
 
@@ -1012,19 +1012,6 @@ class DOPESHEET_MT_key_transform(Menu):
         layout.operator("transform.transform", text="Extend", icon="SHRINK_FATTEN").mode = "TIME_EXTEND"
         layout.operator("transform.transform", text="Slide", icon="PUSH_PULL").mode = "TIME_SLIDE"
         layout.operator("transform.transform", text="Scale", icon="TRANSFORM_SCALE").mode = "TIME_SCALE"
-
-
-class DOPESHEET_MT_key_mirror(Menu):
-    bl_label = "Mirror"
-
-    def draw(self, context):
-        layout = self.layout
-
-        layout.operator("action.mirror", text="By Times over Current Frame", icon="MIRROR_TIME").type = "CFRA"
-        layout.operator("action.mirror", text="By Values over Value=0", icon="MIRROR_CURSORVALUE").type = "XAXIS"
-        layout.operator(
-            "action.mirror", text="By Times over First Selected Marker", icon="MIRROR_MARKER"
-        ).type = "MARKER"
 
 
 class DOPESHEET_MT_key_snap(Menu):
@@ -1464,7 +1451,6 @@ classes = (
     DOPESHEET_MT_key,
     DOPESHEET_PT_view_view_options,  # BFA menu
     DOPESHEET_MT_key_transform,
-    DOPESHEET_MT_key_mirror,  # BFA menu
     DOPESHEET_MT_key_snap,  # BFA menu
     DOPESHEET_MT_gpencil_channel,
     DOPESHEET_MT_delete,

--- a/scripts/startup/bl_ui/space_graph.py
+++ b/scripts/startup/bl_ui/space_graph.py
@@ -680,7 +680,7 @@ class GRAPH_MT_key(Menu):
         layout.menu("GRAPH_MT_key_transform", text="Transform")
 
         layout.menu("GRAPH_MT_key_snap")
-        layout.menu("GRAPH_MT_key_mirror")
+        layout.operator_menu_enum("graph.mirror", "type", text="Mirror")
 
         layout.separator()
         layout.operator_menu_enum("graph.keyframe_insert", "type", text="Insert")
@@ -715,27 +715,6 @@ class GRAPH_MT_key(Menu):
         layout.menu("GRAPH_MT_key_density")
         layout.menu("GRAPH_MT_key_blending")
         layout.menu("GRAPH_MT_key_smoothing")
-
-
-class GRAPH_MT_key_mirror(Menu):
-    bl_label = "Mirror"
-
-    def draw(self, context):
-        layout = self.layout
-
-        layout.operator("graph.mirror", text="By Times over Current Frame", icon="MIRROR_TIME").type = "CFRA"
-        layout.operator(
-            "graph.mirror",
-            text="By Values over Cursor Value",
-            icon="MIRROR_CURSORVALUE",
-        ).type = "VALUE"
-        layout.operator("graph.mirror", text="By Times over Time=0", icon="MIRROR_TIME").type = "YAXIS"
-        layout.operator("graph.mirror", text="By Values over Value=0", icon="MIRROR_CURSORVALUE").type = "XAXIS"
-        layout.operator(
-            "graph.mirror",
-            text="By Times over First Selected Marker",
-            icon="MIRROR_MARKER",
-        ).type = "MARKER"
 
 
 class GRAPH_MT_key_snap(Menu):
@@ -880,7 +859,6 @@ classes = (
     GRAPH_MT_channel_extrapolation,  # BFA - menu
     GRAPH_MT_channel_move,  # BFA - menu
     GRAPH_MT_key,
-    GRAPH_MT_key_mirror,  # BFA - menu
     GRAPH_MT_key_density,
     GRAPH_MT_key_transform,
     GRAPH_MT_key_snap,

--- a/source/blender/editors/space_action/action_edit.cc
+++ b/source/blender/editors/space_action/action_edit.cc
@@ -2103,7 +2103,7 @@ static const EnumPropertyItem prop_actkeys_mirror_types[] = {
     {ACTKEYS_MIRROR_XAXIS,
      "XAXIS",
      ICON_MIRROR_CURSORVALUE,
-     "By Values Over Zero Value",
+     "By Values Over Value=0", /* BFA - Change label */
      "Flip values of selected keyframes (i.e. negative values become positive, and vice versa)"},
     {0, nullptr, 0, nullptr, nullptr},
 };

--- a/source/blender/editors/space_graph/graph_edit.cc
+++ b/source/blender/editors/space_graph/graph_edit.cc
@@ -2631,7 +2631,7 @@ static const EnumPropertyItem prop_graphkeys_mirror_types[] = {
     {GRAPHKEYS_MIRROR_YAXIS,
      "YAXIS",
      ICON_MIRROR_TIME,
-     "By Times Over Zero Time",
+     "By Times Over Time=0", /* BFA - Change label */
      "Flip times of selected keyframes, effectively reversing the order they appear in"},
     RNA_ENUM_ITEM_SEPR,
     {GRAPHKEYS_MIRROR_VALUE,
@@ -2643,7 +2643,7 @@ static const EnumPropertyItem prop_graphkeys_mirror_types[] = {
     {GRAPHKEYS_MIRROR_XAXIS,
      "XAXIS",
      ICON_MIRROR_CURSORVALUE,
-     "By Values Over Zero Value",
+     "By Values Over Value=0", /* BFA - Change label */
      "Flip values of selected keyframes (i.e. negative values become positive, and vice versa)"},
     {0, nullptr, 0, nullptr, nullptr},
 };


### PR DESCRIPTION
Remove our custom menus, `GRAPH_MT_key_mirror` & `DOPESHEET_MT_key_mirror`, and use enum order the same way as Blender.
Best to keep it as simple as this until we actually need the full control a custom menu grants us.

| Before | After |
| --- | --- |
| <img width="368" height="144" alt="image" src="https://github.com/user-attachments/assets/1eccd211-54f3-4eca-9f30-400e12a93f34" /> | <img width="375" height="163" alt="image" src="https://github.com/user-attachments/assets/bc207fee-575a-494c-9146-5d12faa6ed86" /> |
| <img width="367" height="97" alt="image" src="https://github.com/user-attachments/assets/20ab6ad3-07e7-4b97-ae07-682d0735ce10" /> | <img width="375" height="109" alt="image" src="https://github.com/user-attachments/assets/54ef24e3-a716-4439-8c0e-174addbed965" /> |

Resolves: #6535

