### PR TITLE
Properties - Strip > Time panel - Remove duplicated "Show Retiming Keys" property #6565

### DIFF
--- a/scripts/startup/bl_ui/properties_strip.py
+++ b/scripts/startup/bl_ui/properties_strip.py
@@ -916,12 +916,6 @@ class STRIP_PT_time(StripButtonsPanel, Panel):
                 split.alignment = 'LEFT'
                 split.label(text="{:d}-{:d} ({:d})".format(sta, end, end - sta + 1), translate=False)
 
-        sub = layout.row(align=True)
-        split = sub.split(factor=factor + max_factor)
-        split.alignment = 'RIGHT'
-        split.label(text="")
-        split.prop(strip, "show_retiming_keys")
-
 
 class STRIP_PT_adjust_sound(StripButtonsPanel, Panel):
     bl_label = "Sound"


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="430" height="407" alt="image" src="https://github.com/user-attachments/assets/14236bdd-6edf-4892-a116-fee91ded8864" /> | <img width="430" height="384" alt="image" src="https://github.com/user-attachments/assets/6a9b983f-b7e2-498c-b569-cf63f7dba850" /> |

Resolves: #6565