### PR TITLE
Power User Tools - Select Grease Pencil Layer under Cursor #6569

### DIFF
--- a/scripts/addons_core/bfa_power_user_tools/ops.py
+++ b/scripts/addons_core/bfa_power_user_tools/ops.py
@@ -542,7 +542,7 @@ class BFA_OT_gp_select_layer_under_mouse_isolate(bpy.types.Operator):
     """Select all strokes of the layer under the mouse cursor and isolate it"""
     bl_idname = "view3d.gp_select_layer_under_mouse_isolate"
     bl_label = "Layer and Isolate Under Mouse"
-    bl_description = "Detects the strokes and layer under the mouse in all modes, selects them, and isolates that layer"
+    bl_description = "Detects the strokes and layer under the mouse in all modes, selects them, then isolates the layer by locking the other layers"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod

--- a/scripts/addons_core/bfa_power_user_tools/ops.py
+++ b/scripts/addons_core/bfa_power_user_tools/ops.py
@@ -13,6 +13,7 @@
 
 import bpy
 import os
+import mathutils
 from . import properties
 
 op = bpy.types.Operator
@@ -392,7 +393,7 @@ class BFA_OT_viewport_silhuette_toggle(op):
             shading.show_xray = False
             shading.show_shadows = False
             shading.show_cavity = False
-            shading.color_type = 'MATERIAL'
+            shading.color_type = 'SINGLE'
             shading.single_color = (1, 1, 1)
             shading.show_backface_culling = True
 
@@ -403,6 +404,179 @@ class BFA_OT_viewport_silhuette_toggle(op):
         wm = context.window_manager
         if wm.BFA_UI_addon_props.BFA_PROP_toggle_viewport:
             self.layout.operator(BFA_PROP_toggle_viewport.bl_idname, icon=BFA_PROP_toggle_viewport.bl_icon)
+
+################## Grease Pencil Operators ##################
+
+# Shared hit-detection logic for both GP select operators
+def _gp_find_layers_under_mouse(context, event):
+    """Find all Grease Pencil layers that have strokes under the mouse cursor.
+    Returns (hit_layers_set, gp_data) or (None, None) on failure."""
+    region = context.region
+    region_data = context.region_data
+
+    if not region or not region_data:
+        return None, None
+
+    from bpy_extras.view3d_utils import location_3d_to_region_2d
+
+    mouse_x = event.mouse_region_x
+    mouse_y = event.mouse_region_y
+
+    obj = context.active_object
+    gp_data = obj.data
+    scene_frame = context.scene.frame_current
+    world_mat = obj.matrix_world
+
+    # Get brush from the current mode's tool settings for consistent hit radius
+    ts = context.tool_settings
+    brush = None
+    try:
+        if context.mode == 'PAINT_GREASE_PENCIL':
+            brush = ts.gpencil_paint.brush
+        elif context.mode == 'SCULPT_GREASE_PENCIL':
+            brush = ts.gpencil_sculpt.brush
+        elif context.mode == 'VERTEX_GREASE_PENCIL':
+            brush = ts.gpencil_vertex.brush
+        elif context.mode == 'WEIGHT_GREASE_PENCIL':
+            brush = ts.gpencil_weight.brush
+    except AttributeError:
+        brush = None
+    hit_threshold_px = brush.size / 2 if brush else 15
+
+    hit_layers = set()
+
+    for layer in gp_data.layers:
+        if layer.hide:
+            continue
+        if layer in hit_layers:
+            continue
+
+        # Find the active keyframe at current scene frame
+        active_frame = None
+        for frame in layer.frames:
+            if frame.frame_number <= scene_frame:
+                if active_frame is None or frame.frame_number > active_frame.frame_number:
+                    active_frame = frame
+
+        if active_frame is None:
+            continue
+
+        for stroke in active_frame.drawing.strokes:
+            for point in stroke.points:
+                # Project world position to 2D screen coordinates
+                world_pos = world_mat @ point.position
+                screen_pos = location_3d_to_region_2d(region, region_data, world_pos)
+                if screen_pos is None:
+                    continue  # Behind camera
+                dx = screen_pos.x - mouse_x
+                dy = screen_pos.y - mouse_y
+                dist = (dx * dx + dy * dy) ** 0.5
+                if dist < hit_threshold_px:
+                    hit_layers.add(layer)
+                    break
+            if layer in hit_layers:
+                break
+
+    return hit_layers, gp_data
+
+
+def _gp_select_hit_layers(hit_layers, gp_data):
+    """Deselect all strokes, then select strokes on hit_layers and set the first as active.
+    Returns list of layer names."""
+    # Deselect all strokes across all layers
+    for layer in gp_data.layers:
+        for frame in layer.frames:
+            for stroke in frame.drawing.strokes:
+                stroke.select = False
+
+    # Select all strokes in the found layers and set the first hit as active
+    layer_names = []
+    for i, layer in enumerate(hit_layers):
+        layer_names.append(layer.name)
+        if i == 0:
+            gp_data.layers.active = layer
+        for frame in layer.frames:
+            for stroke in frame.drawing.strokes:
+                stroke.select = True
+
+    return layer_names
+
+
+class BFA_OT_gp_select_layer_under_mouse(bpy.types.Operator):
+    """Select all strokes of the layer under the mouse cursor"""
+    bl_idname = "view3d.gp_select_layer_under_mouse"
+    bl_label = "Layer Under Mouse"
+    bl_description = "Detects the strokes and layer under the mouse in all modes and selects the layer or all strokes on that layer"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        obj = context.active_object
+        return obj and obj.type == 'GREASEPENCIL' and context.mode in {
+            'PAINT_GREASE_PENCIL',
+            'EDIT_GREASE_PENCIL',
+            'SCULPT_GREASE_PENCIL',
+            'VERTEX_GREASE_PENCIL',
+            'WEIGHT_GREASE_PENCIL',
+        }
+
+    def invoke(self, context, event):
+        hit_layers, gp_data = _gp_find_layers_under_mouse(context, event)
+        if hit_layers is None:
+            self.report({'WARNING'}, "No active 3D viewport")
+            return {'CANCELLED'}
+
+        if hit_layers:
+            layer_names = _gp_select_hit_layers(hit_layers, gp_data)
+            self.report({'INFO'}, f"Selected strokes on: {', '.join(layer_names)}")
+            return {'FINISHED'}
+        else:
+            self.report({'WARNING'}, "No stroke found under mouse")
+            return {'CANCELLED'}
+
+    def menu_func(self, context):
+        self.layout.operator(BFA_OT_gp_select_layer_under_mouse.bl_idname, icon='GREASEPENCIL')
+
+
+class BFA_OT_gp_select_layer_under_mouse_isolate(bpy.types.Operator):
+    """Select all strokes of the layer under the mouse cursor and isolate it"""
+    bl_idname = "view3d.gp_select_layer_under_mouse_isolate"
+    bl_label = "Layer and Isolate Under Mouse"
+    bl_description = "Detects the strokes and layer under the mouse in all modes, selects them, and isolates that layer"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        obj = context.active_object
+        return obj and obj.type == 'GREASEPENCIL' and context.mode in {
+            'PAINT_GREASE_PENCIL',
+            'EDIT_GREASE_PENCIL',
+            'SCULPT_GREASE_PENCIL',
+            'VERTEX_GREASE_PENCIL',
+            'WEIGHT_GREASE_PENCIL',
+        }
+
+    def invoke(self, context, event):
+        hit_layers, gp_data = _gp_find_layers_under_mouse(context, event)
+        if hit_layers is None:
+            self.report({'WARNING'}, "No active 3D viewport")
+            return {'CANCELLED'}
+
+        if hit_layers:
+            layer_names = _gp_select_hit_layers(hit_layers, gp_data)
+            self.report({'INFO'}, f"Selected and Isolated strokes on: {', '.join(layer_names)}")
+
+            # Isolate the active layer (lock all others)
+            bpy.ops.grease_pencil.layer_isolate(affect_visibility=False)
+
+            return {'FINISHED'}
+        else:
+            self.report({'WARNING'}, "No stroke found under mouse")
+            return {'CANCELLED'}
+
+    def menu_func(self, context):
+        self.layout.operator(BFA_OT_gp_select_layer_under_mouse_isolate.bl_idname, icon='LOCKED')
+
 
 
 ################## File Operators ##################
@@ -455,6 +629,9 @@ operator_list = [
     BFA_OT_viewport_silhuette_toggle,
     # File Operators
     BFA_OT_open_blend_file_window,
+    # Grease Pencil Operators
+    BFA_OT_gp_select_layer_under_mouse,
+    BFA_OT_gp_select_layer_under_mouse_isolate,
     # Add more operators as needed
 ]
 

--- a/scripts/addons_core/bfa_power_user_tools/prefs.py
+++ b/scripts/addons_core/bfa_power_user_tools/prefs.py
@@ -56,6 +56,12 @@ class BFA_UI_preferences(bpy.types.AddonPreferences):
         col.label(text="File Operators:", icon="FILE_FOLDER")
         layout.prop(wm.BFA_UI_addon_props, "BFA_PROP_toggle_file")
 
+        row = layout.row()
+        col = row.column(align=True)
+        col.label(text="File Operators:", icon="GREASEPENCIL")
+        layout.prop(wm.BFA_UI_addon_props, "BFA_PROP_toggle_gplayerselect")
+
+
 preferences_classes = [
     BFA_UI_preferences,
 ]

--- a/scripts/addons_core/bfa_power_user_tools/properties.py
+++ b/scripts/addons_core/bfa_power_user_tools/properties.py
@@ -23,6 +23,7 @@ class BFA_UI_toggles(PropertyGroup):
     BFA_PROP_toggle_viewport: BoolProperty(name='Viewport Silhuette Toggle', description='Adds the viewport overlay silhuette toggle to the header of the 3D View editors. \nLocated header customizable buttons overlays in the 3D View under the drop down to the top right', default=True)
     BFA_PROP_toggle_file: BoolProperty(name='Open Blend File Folder Operator', description='Adds the Open Blend File Folder operators in the File header menu. \nLocated in File header under the External Data sub-menu', default=True)
     BFA_PROP_toggle_timelinetoggle: BoolProperty(name='Shows a toggle to Timeline in Dopesheet', description='Shows a quick toggle in the Dopsheet and Timeline to toggle to and from each other\nLocated in the Timeline and Dopesheet header', default=True)
+    BFA_PROP_toggle_gplayerselect: BoolProperty(name='Shows Grease Pencil Selection in all Modes', description='Shows a quick select operator in the Select Menu in all Grease Pencil modes\nthat can be used to select a layer under mouse location. Hotkey recommended use only.', default=True)
 
 property_classes = [
     BFA_UI_toggles,

--- a/scripts/addons_core/bfa_power_user_tools/ui.py
+++ b/scripts/addons_core/bfa_power_user_tools/ui.py
@@ -25,19 +25,23 @@ wm = context.window_manager
 def seperator(self, context):
     self.layout.separator()
 
-# Timeline Editor Key Menu - NOT USED
-class BFA_MT_timeline_key(bpy.types.Menu):
-    bl_idname = "BFA_MT_timeline_key"
-    bl_label = "Key"
+# Grease Pencil Select Menu - shared across draw, sculpt, vertex paint, and weight paint modes
+class BFA_MT_gp_select(bpy.types.Menu):
+    bl_idname = "BFA_MT_gp_select"
+    bl_label = "Select"
 
     def draw(self, context):
         layout = self.layout
-        layout.separator()
+        layout.operator("view3d.gp_select_layer_under_mouse", icon='GREASEPENCIL')
+        layout.operator("view3d.gp_select_layer_under_mouse_isolate", icon='LOCKED')
 
     def menu_func(self, context):
         wm = context.window_manager
-        if wm.BFA_UI_addon_props.BFA_PROP_toggle_insertframes or wm.BFA_UI_addon_props.BFA_PROP_toggle_animationpanel:
-            self.layout.menu(BFA_MT_timeline_key.bl_idname)
+        if wm.BFA_UI_addon_props.BFA_PROP_toggle_gplayerselect:
+            self.layout.menu(BFA_MT_gp_select.bl_idname)
+
+
+
 
 
 # Timeline Editor Header Operators
@@ -62,8 +66,11 @@ def BFA_HT_timeline_skipframes(self, context):
 
 
 menu_classes = [
-    BFA_MT_timeline_key,
+    BFA_MT_gp_select,
 ]
+
+# Store keymap items for cleanup
+ui_keymap_items = []
 
 
 def register():
@@ -105,6 +112,26 @@ def register():
     ## Timeline Editor
     bpy.types.DOPESHEET_HT_header.append(BFA_HT_timeline_skipframes)
 
+
+
+    ## Grease Pencil Edit & Vertex Paint - add operator to existing Select menu
+    bpy.types.VIEW3D_MT_select_edit_grease_pencil.append(ops.BFA_OT_gp_select_layer_under_mouse.menu_func)
+    bpy.types.VIEW3D_MT_select_edit_grease_pencil.append(ops.BFA_OT_gp_select_layer_under_mouse_isolate.menu_func)
+
+    ## Register Grease Pencil keymap for the operator to work under mouse
+    wm = bpy.context.window_manager
+    kc = wm.keyconfigs.addon
+    if kc:
+        km = kc.keymaps.new(name="Grease Pencil", space_type='EMPTY')
+        kmi = km.keymap_items.new(
+            ops.BFA_OT_gp_select_layer_under_mouse.bl_idname,
+            type='NONE',
+            value='PRESS',
+            any=True,
+        )
+        # Store for unregister
+        ui_keymap_items.append((km, kmi))
+
 def unregister():
     ## 3D View Editor
     bpy.types.VIEW3D_MT_object.remove(seperator)
@@ -140,6 +167,14 @@ def unregister():
 
     ## Timeline Editor
     bpy.types.DOPESHEET_HT_header.remove(BFA_HT_timeline_skipframes)
+
+    ## Grease Pencil Edit & Vertex Paint Select menu
+    bpy.types.VIEW3D_MT_select_edit_grease_pencil.remove(ops.BFA_OT_gp_select_layer_under_mouse.menu_func)
+
+    ## Remove keymap items
+    for km, kmi in ui_keymap_items:
+        km.keymap_items.remove(kmi)
+    ui_keymap_items.clear()
 
 
     for cls in menu_classes:

--- a/scripts/startup/bl_ui/space_toolsystem_toolbar.py
+++ b/scripts/startup/bl_ui/space_toolsystem_toolbar.py
@@ -2577,7 +2577,7 @@ class _defs_grease_pencil_paint:
                 row = col.row(align=True)
                 row.template_ID(settings, "palette", new="palette.new")
                 if settings.palette:
-                    col.template_palette(settings, "palette", color=True)
+                    col.template_palette(settings, "palette")
 
         return dict(
             idname="builtin.eyedropper",

--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -1159,7 +1159,8 @@ class VIEW3D_HT_header(Header):
         row = layout.row(align=True)
         if context.preferences.addons.get("bfa_power_user_tools"):
             if context.window_manager.BFA_UI_addon_props.BFA_PROP_toggle_viewport:
-                row.operator("view3d.viewport_silhouette_toggle", text="", icon="IMAGE_ALPHA")
+                from bfa_power_user_tools.ops import previous_viewport_settings
+                row.operator("view3d.viewport_silhouette_toggle", text="", icon="IMAGE_ALPHA", depress=bool(previous_viewport_settings))
 
         row = layout.row(align=True)
         row.prop(shading, "type", text="", expand=True)
@@ -1216,6 +1217,11 @@ class VIEW3D_MT_editor_menus(Menu):
         layout.menu("SCREEN_MT_user_menu", text="Quick")  # BFA
         layout.menu("VIEW3D_MT_view")
         layout.menu("VIEW3D_MT_view_navigation")  # BFA
+
+        if mode_string in {"PAINT_GREASE_PENCIL", "SCULPT_GREASE_PENCIL", "WEIGHT_GREASE_PENCIL"}:
+            if context.preferences.addons.get("bfa_power_user_tools"):
+                if context.window_manager.BFA_UI_addon_props.BFA_PROP_toggle_gplayerselect:
+                    layout.menu("BFA_MT_gp_select", text="Select")
 
         # Select Menu
         if mode_string in {"PAINT_WEIGHT", "PAINT_VERTEX", "PAINT_TEXTURE"}:

--- a/scripts/startup/bl_ui/space_view3d_toolbar.py
+++ b/scripts/startup/bl_ui/space_view3d_toolbar.py
@@ -1969,7 +1969,7 @@ class VIEW3D_PT_tools_grease_pencil_brush_vertex_palette(View3DPanel, Panel):
         row = col.row(align=True)
         row.template_ID(settings, "palette", new="palette.new")
         if settings.palette:
-            col.template_palette(settings, "palette", color=True)
+            col.template_palette(settings, "palette")
 
 
 class VIEW3D_PT_tools_grease_pencil_paint_appearance(GreasePencilDisplayPanel, Panel, View3DPanel):


### PR DESCRIPTION
<img width="726" height="563" alt="image" src="https://github.com/user-attachments/assets/745662b3-e8d7-4575-8e17-a4e2435de97a" />

Added two new operators:
1. Select layer under mouse
2. Select layer and isolate it, while locking others under mouse

Detection is based on the brush radius of the time.

They way this works, is that under a user defined hotkey you select the layer. I don't like addons registering hotkeys, so will leave that up to the user. Per usual, this is optional, and opt-out from the addon which already is an opt-in for a power user.

The location is in the Select menus in the consistent order everywhere in the 3D Viewport.