### PR TITLE
Dopesheet - Rename "Select Linked" and "Select by Type" to not mentionn Select #6511

### DIFF
--- a/scripts/startup/bl_ui/space_dopesheet.py
+++ b/scripts/startup/bl_ui/space_dopesheet.py
@@ -727,8 +727,7 @@ class DOPESHEET_MT_select(Menu):
 
             layout.separator()
 
-            layout.operator("action.select_linked") # BFA - WIP
-            layout.operator_menu_enum("action.select_by_type", "type") # BFA - WIP
+            layout.operator_menu_enum("action.select_by_type", "type", text="Type",)
 
         props = layout.operator("action.select_leftright", text="Before Current Frame", icon="BEFORE_CURRENT_FRAME")
         props.extend = False


### PR DESCRIPTION
This also removed a double select linked that snuck in.

<img width="624" height="484" alt="bforartists_8TnO6gaVGA" src="https://github.com/user-attachments/assets/45273ab7-96ba-4a0b-991f-a914028b828d" />

📄 Documentation:
- New "Type" menu to select by type 