### PR TITLE
UI - Add Open Editors Temp Window Operators

### DIFF
--- a/scripts/startup/bl_ui/properties_material.py
+++ b/scripts/startup/bl_ui/properties_material.py
@@ -153,7 +153,13 @@ class EEVEE_MATERIAL_PT_context_material(MaterialButtonsPanel, Panel):
                 if ob.type != 'FONT':
                         row.operator("object.material_slot_select", text="Select", icon='RESTRICT_SELECT_OFF') # BFA - icon
                         row.operator("object.material_slot_deselect", text="Deselect", icon='RESTRICT_SELECT_ON') # BFA - icon
-
+            
+            # BFA - Open Shader Editor
+            if mat:
+                col = layout.column(align=True)
+                col.separator()
+                col.operator("material.open_node_editor", icon='NODE_MATERIAL')
+                
         elif mat:
             row.template_ID(space, "pin_id")
 

--- a/scripts/startup/bl_ui/properties_texture.py
+++ b/scripts/startup/bl_ui/properties_texture.py
@@ -126,6 +126,11 @@ class TEXTURE_PT_context(TextureButtonsPanel, Panel):
         if user or pin_id:
             col.separator()
 
+            # BFA - Open Texture Node Editor
+            if tex:
+                col.operator("texture.open_node_editor", icon='TEXTURE')
+                col.separator()
+
             if pin_id:
                 col.template_ID(space, "pin_id")
             else:

--- a/source/blender/editors/object/object_intern.hh
+++ b/source/blender/editors/object/object_intern.hh
@@ -238,6 +238,7 @@ void OBJECT_OT_laplaciandeform_bind(wmOperatorType *ot);
 void OBJECT_OT_surfacedeform_bind(wmOperatorType *ot);
 void OBJECT_OT_geometry_nodes_input_attribute_toggle(wmOperatorType *ot);
 void OBJECT_OT_geometry_node_tree_copy_assign(wmOperatorType *ot);
+void OBJECT_OT_geometry_nodes_open_editor(wmOperatorType *ot); /* BFA */
 void OBJECT_OT_grease_pencil_dash_modifier_segment_add(wmOperatorType *ot);
 void OBJECT_OT_grease_pencil_dash_modifier_segment_remove(wmOperatorType *ot);
 void OBJECT_OT_grease_pencil_dash_modifier_segment_move(wmOperatorType *ot);

--- a/source/blender/editors/object/object_modifier.cc
+++ b/source/blender/editors/object/object_modifier.cc
@@ -72,6 +72,7 @@
 #include "BKE_pointcloud.hh"
 #include "BKE_report.hh"
 #include "BKE_scene.hh"
+#include "BKE_screen.hh"
 #include "BKE_softbody.h"
 #include "BKE_volume.hh"
 
@@ -90,6 +91,7 @@
 #include "ED_armature.hh"
 #include "ED_grease_pencil.hh"
 #include "ED_node.hh"
+#include "ED_node_c.hh"
 #include "ED_object.hh"
 #include "ED_object_vgroup.hh"
 #include "ED_screen.hh"
@@ -4061,6 +4063,90 @@ void OBJECT_OT_grease_pencil_time_modifier_segment_move(wmOperatorType *ot)
 
   ot->prop = RNA_def_enum(ot->srna, "type", segment_move, 0, "Type", "");
 }
+
+/* -------------------------------------------------------------------- */
+/** \name BFA - Open Geometry Nodes Editor Operator
+ * \{ */
+
+static wmOperatorStatus geometry_nodes_open_editor_exec(bContext *C, wmOperator *op)
+{
+  Object *ob = CTX_data_active_object(C);
+  if (!ob) {
+    return OPERATOR_CANCELLED;
+  }
+
+  /* BFA - resolve modifier from operator property */
+  std::string modifier_name = RNA_string_get(op->ptr, "modifier");
+  ModifierData *md = BKE_modifiers_findby_name(ob, modifier_name.c_str());
+  if (!md || md->type != eModifierType_Nodes) {
+    return OPERATOR_CANCELLED;
+  }
+
+  NodesModifierData *nmd = reinterpret_cast<NodesModifierData *>(md);
+  if (!nmd->node_group || ID_MISSING(nmd->node_group)) {
+    BKE_report(op->reports, RPT_ERROR, "Geometry Nodes modifier has no node group assigned");
+    return OPERATOR_CANCELLED;
+  }
+
+  ScrArea *area = ED_screen_temp_space_open(
+      C, IFACE_("Geometry Nodes Editor"), SPACE_NODE, USER_TEMP_SPACE_DISPLAY_WINDOW, false);
+  if (!area) {
+    BKE_report(op->reports, RPT_ERROR, "Failed to open Geometry Nodes Editor");
+    return OPERATOR_CANCELLED;
+  }
+
+  /* BFA - configure SpaceNode for geometry nodes editing */
+  SpaceNode *snode = static_cast<SpaceNode *>(area->spacedata.first);
+  STRNCPY(snode->tree_idname, "GeometryNodeTree");
+  snode->node_tree_sub_type = SNODE_GEOMETRY_MODIFIER;
+  snode->selected_node_group = nullptr;
+
+  /* BFA - push the modifier's node group into the node editor stack */
+  ARegion *region = BKE_area_find_region_type(area, RGN_TYPE_WINDOW);
+  ED_node_tree_start(region, snode, nmd->node_group, &ob->id, nullptr);
+  blender::ed::space_node::tree_update(C);
+
+  /* BFA - refresh UI after node tree context change */
+  WM_event_add_notifier(C, NC_OBJECT | ND_MODIFIER | ND_NODES, nullptr);
+
+  return OPERATOR_FINISHED;
+}
+
+static bool geometry_nodes_open_editor_poll(bContext *C)
+{
+  Object *ob = CTX_data_active_object(C);
+  if (!ob) {
+    return false;
+  }
+  for (ModifierData &md : ob->modifiers) {
+    if (md.type == eModifierType_Nodes) {
+      NodesModifierData *nmd = reinterpret_cast<NodesModifierData *>(&md);
+      if (nmd->node_group && !ID_MISSING(nmd->node_group)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+void OBJECT_OT_geometry_nodes_open_editor(wmOperatorType *ot)
+{
+  ot->name = "Open Geometry Nodes Editor";
+  ot->idname = "OBJECT_OT_geometry_nodes_open_editor";
+  ot->description = "Open a Geometry Nodes Editor window for this modifier's node group";
+
+  ot->exec = geometry_nodes_open_editor_exec;
+  ot->poll = geometry_nodes_open_editor_poll;
+
+  ot->flag = OPTYPE_REGISTER | OPTYPE_UNDO;
+
+  /* BFA - hidden property so the UI button knows which modifier to target */
+  ot->prop = RNA_def_string(
+      ot->srna, "modifier", nullptr, MAX_NAME, "Modifier", "Name of the modifier to edit");
+  RNA_def_property_flag(ot->prop, PROP_HIDDEN);
+}
+
+/** \} */
 
 /** \} */
 

--- a/source/blender/editors/object/object_ops.cc
+++ b/source/blender/editors/object/object_ops.cc
@@ -144,6 +144,7 @@ void operatortypes_object()
   WM_operatortype_append(OBJECT_OT_skin_armature_create);
   WM_operatortype_append(OBJECT_OT_geometry_nodes_input_attribute_toggle);
   WM_operatortype_append(OBJECT_OT_geometry_node_tree_copy_assign);
+  WM_operatortype_append(OBJECT_OT_geometry_nodes_open_editor); /* BFA */
   WM_operatortype_append(OBJECT_OT_grease_pencil_dash_modifier_segment_add);
   WM_operatortype_append(OBJECT_OT_grease_pencil_dash_modifier_segment_remove);
   WM_operatortype_append(OBJECT_OT_grease_pencil_dash_modifier_segment_move);

--- a/source/blender/editors/render/render_intern.hh
+++ b/source/blender/editors/render/render_intern.hh
@@ -32,6 +32,10 @@ void MATERIAL_OT_new(wmOperatorType *ot);
 void TEXTURE_OT_new(wmOperatorType *ot);
 void WORLD_OT_new(wmOperatorType *ot);
 
+/* BFA - Open Node Editor Operators */
+void MATERIAL_OT_open_node_editor(wmOperatorType *ot);
+void TEXTURE_OT_open_node_editor(wmOperatorType *ot);
+
 void MATERIAL_OT_copy(wmOperatorType *ot);
 void MATERIAL_OT_paste(wmOperatorType *ot);
 

--- a/source/blender/editors/render/render_ops.cc
+++ b/source/blender/editors/render/render_ops.cc
@@ -37,6 +37,10 @@ void ED_operatortypes_render()
   WM_operatortype_append(TEXTURE_OT_new);
   WM_operatortype_append(WORLD_OT_new);
 
+  /* BFA - Open Node Editor Operators */
+  WM_operatortype_append(MATERIAL_OT_open_node_editor);
+  WM_operatortype_append(TEXTURE_OT_open_node_editor);
+
   WM_operatortype_append(MATERIAL_OT_copy);
   WM_operatortype_append(MATERIAL_OT_paste);
 

--- a/source/blender/editors/render/render_shading.cc
+++ b/source/blender/editors/render/render_shading.cc
@@ -59,6 +59,7 @@
 #include "BKE_object.hh"
 #include "BKE_report.hh"
 #include "BKE_scene.hh"
+#include "BKE_screen.hh" /* BFA */
 #include "BKE_texture.h"
 #include "BKE_vfont.hh"
 #include "BKE_workspace.hh"
@@ -85,6 +86,7 @@
 #include "ED_curve.hh"
 #include "ED_mesh.hh"
 #include "ED_node.hh"
+#include "ED_node_c.hh" /* BFA */
 #include "ED_object.hh"
 #include "ED_paint.hh"
 #include "ED_render.hh"
@@ -3235,6 +3237,127 @@ void TEXTURE_OT_slot_paste(wmOperatorType *ot)
   /* flags */
   ot->flag = OPTYPE_REGISTER | OPTYPE_UNDO | OPTYPE_INTERNAL;
 }
+
+/* -------------------------------------------------------------------- */
+/** \name BFA - Open Shader Editor Operator
+ * \{ */
+
+static wmOperatorStatus material_open_node_editor_exec(bContext *C, wmOperator *op)
+{
+  Material *ma = static_cast<Material *>(
+      CTX_data_pointer_get_type(C, "material", RNA_Material).data);
+  if (!ma) {
+    BKE_report(op->reports, RPT_ERROR, "No active material");
+    return OPERATOR_CANCELLED;
+  }
+
+  if (!ma->nodetree) {
+    BKE_report(op->reports, RPT_ERROR, "Material has no node tree");
+    return OPERATOR_CANCELLED;
+  }
+
+  ScrArea *area = ED_screen_temp_space_open(
+      C, IFACE_("Shader Editor"), SPACE_NODE, USER_TEMP_SPACE_DISPLAY_WINDOW, false);
+  if (!area) {
+    BKE_report(op->reports, RPT_ERROR, "Failed to open Shader Editor");
+    return OPERATOR_CANCELLED;
+  }
+
+  SpaceNode *snode = static_cast<SpaceNode *>(area->spacedata.first);
+  STRNCPY(snode->tree_idname, "ShaderNodeTree");
+  snode->shaderfrom = SNODE_SHADER_OBJECT;
+  snode->selected_node_group = nullptr;
+
+  ARegion *region = BKE_area_find_region_type(area, RGN_TYPE_WINDOW);
+  ED_node_tree_start(region, snode, ma->nodetree, &ma->id, nullptr);
+  blender::ed::space_node::tree_update(C);
+
+  WM_event_add_notifier(C, NC_MATERIAL | ND_NODES, nullptr);
+
+  return OPERATOR_FINISHED;
+}
+
+static bool material_open_node_editor_poll(bContext *C)
+{
+  Material *ma = static_cast<Material *>(
+      CTX_data_pointer_get_type(C, "material", RNA_Material).data);
+  return ma != nullptr && ma->nodetree != nullptr;
+}
+
+void MATERIAL_OT_open_node_editor(wmOperatorType *ot)
+{
+  ot->name = "Open Shader Editor";
+  ot->idname = "MATERIAL_OT_open_node_editor";
+  ot->description = "Open a Shader Editor window for this material";
+  ot->exec = material_open_node_editor_exec;
+  ot->poll = material_open_node_editor_poll;
+  ot->flag = OPTYPE_REGISTER | OPTYPE_UNDO;
+}
+
+/** \} */
+
+/* -------------------------------------------------------------------- */
+/** \name BFA - Open Texture Node Editor Operator
+ * \{ */
+
+static wmOperatorStatus texture_open_node_editor_exec(bContext *C, wmOperator *op)
+{
+  Tex *tex = static_cast<Tex *>(CTX_data_pointer_get_type(C, "texture", RNA_Texture).data);
+  if (!tex) {
+    BKE_report(op->reports, RPT_ERROR, "No active texture");
+    return OPERATOR_CANCELLED;
+  }
+
+  if (!tex->use_nodes) {
+    tex->use_nodes = true;
+    if (tex->nodetree == nullptr) {
+      ED_node_texture_default(C, tex);
+    }
+  }
+
+  if (!tex->nodetree) {
+    BKE_report(op->reports, RPT_ERROR, "Texture has no node tree");
+    return OPERATOR_CANCELLED;
+  }
+
+  ScrArea *area = ED_screen_temp_space_open(
+      C, IFACE_("Texture Node Editor"), SPACE_NODE, USER_TEMP_SPACE_DISPLAY_WINDOW, false);
+  if (!area) {
+    BKE_report(op->reports, RPT_ERROR, "Failed to open Texture Node Editor");
+    return OPERATOR_CANCELLED;
+  }
+
+  SpaceNode *snode = static_cast<SpaceNode *>(area->spacedata.first);
+  STRNCPY(snode->tree_idname, "TextureNodeTree");
+  snode->texfrom = SNODE_TEX_BRUSH;
+  snode->selected_node_group = nullptr;
+
+  ARegion *region = BKE_area_find_region_type(area, RGN_TYPE_WINDOW);
+  ED_node_tree_start(region, snode, tex->nodetree, &tex->id, nullptr);
+  blender::ed::space_node::tree_update(C);
+
+  WM_event_add_notifier(C, NC_TEXTURE | ND_NODES, nullptr);
+
+  return OPERATOR_FINISHED;
+}
+
+static bool texture_open_node_editor_poll(bContext *C)
+{
+  Tex *tex = static_cast<Tex *>(CTX_data_pointer_get_type(C, "texture", RNA_Texture).data);
+  return tex != nullptr;
+}
+
+void TEXTURE_OT_open_node_editor(wmOperatorType *ot)
+{
+  ot->name = "Open Texture Node Editor";
+  ot->idname = "TEXTURE_OT_open_node_editor";
+  ot->description = "Open a Texture Node Editor window for this texture";
+  ot->exec = texture_open_node_editor_exec;
+  ot->poll = texture_open_node_editor_poll;
+  ot->flag = OPTYPE_REGISTER | OPTYPE_UNDO;
+}
+
+/** \} */
 
 /** \} */
 

--- a/source/blender/nodes/intern/geometry_nodes_caller_ui.cc
+++ b/source/blender/nodes/intern/geometry_nodes_caller_ui.cc
@@ -1023,6 +1023,15 @@ void draw_geometry_nodes_modifier_ui(const bContext &C,
       draw_manage_panel(&C, *panel_layout, modifier_ptr, nmd);
     }
   }
+
+  /* BFA - Open Geometry Nodes Editor Operator */
+  if (nmd.node_group != nullptr && !ID_MISSING(nmd.node_group)) {
+    layout.separator();
+    PointerRNA op_ptr = layout.op("OBJECT_OT_geometry_nodes_open_editor",
+                                    IFACE_("Open Geometry Nodes Editor"),
+                                    ICON_NODETREE);
+    RNA_string_set(&op_ptr, "modifier", nmd.modifier.name);
+  }
 }
 
 void draw_geometry_nodes_operator_redo_ui(const bContext &C,


### PR DESCRIPTION
-- Added Open Editor Window Operators to the following locations:

Material Properties
Geometry Nodes Modifier (like Compositor Modifier) 
Texture Properties

**Note**: These currently open at 800x600 editor window size, this is the fallback for temp windows, I do have a fix that allows to set a larger size without affecting other temp editor window sizes that can be done after this PR and #6595 are merged in.

<img width="2560" height="1402" alt="Screenshot_20260531_143445" src="https://github.com/user-attachments/assets/44278619-b0bb-4c4f-ac34-2529fba72bb7" />
<img width="2560" height="1403" alt="Screenshot_20260531_143514" src="https://github.com/user-attachments/assets/42b57dcd-f755-45db-bc77-4bb352540cd7" />
<img width="2560" height="1401" alt="Screenshot_20260531_144754" src="https://github.com/user-attachments/assets/69e284fe-c1b1-459f-9600-af5260856703" />


