### PR TITLE
Properties Editor - Strip Modifiers tab

### DIFF
--- a/scripts/startup/bl_ui/properties_strip_modifier.py
+++ b/scripts/startup/bl_ui/properties_strip_modifier.py
@@ -5,8 +5,12 @@
 import bpy # BFA
 
 from bpy.types import (
+    Menu,
+    Operator,
     Panel,
 )
+
+from bl_ui.generic_column_menu import InvokeMenuOperator
 
 
 class StripModButtonsPanel:
@@ -19,6 +23,36 @@ class StripModButtonsPanel:
         return context.active_strip is not None
 
 
+# BFA - Modifier Assets
+class SEQUENCER_MT_modifier_add_assets(Menu):
+    bl_label = "Assets"
+    bl_description = "Add a modifier nodegroup to the strip"
+    bl_options = {'SEARCH_ON_KEY_PRESS'}
+
+    def draw(self, context):
+        layout = self.layout
+
+        if layout.operator_context == 'EXEC_REGION_WIN':
+            layout.operator_context = 'INVOKE_REGION_WIN'
+            layout.operator(
+                "wm.search_single_menu", text="Search...", icon="VIEWZOOM"
+            ).menu_idname = self.bl_idname
+            layout.separator()
+
+        layout.operator_context = 'EXEC_REGION_WIN'
+        layout.menu_contents("SEQUENCER_MT_modifier_add_root_catalogs")
+
+
+# BFA - Modifier Assets
+class SEQUENCER_OT_add_asset_modifier_menu(InvokeMenuOperator, Operator):
+    bl_idname = "sequencer.add_asset_modifier_menu"
+    bl_label = "Add Asset Modifier"
+    bl_description = "Add a modifier nodegroup to the strip"
+    menu_id = "SEQUENCER_MT_modifier_add_assets"
+    space_type = 'PROPERTIES'
+    space_context = 'STRIP_MODIFIER'
+
+
 class STRIP_PT_modifiers(StripModButtonsPanel, Panel):
     bl_label = "Modifiers"
     bl_options = {'HIDE_HEADER'}
@@ -29,7 +63,10 @@ class STRIP_PT_modifiers(StripModButtonsPanel, Panel):
 
         row = layout.row()
         row.operator("wm.call_menu", text="Add Modifier", icon='ADD').name = "SEQUENCER_MT_modifier_add"
-        
+
+        # BFA - Modifier Assets
+        row.operator("sequencer.add_asset_modifier_menu", icon='ADD')
+
         # BFA - adde and expose the copy to selected to the stack consistently, and make it intuitive when selected strips are more than 1.
         copy_row = row.row()
         copy_row.enabled = len(bpy.context.selected_strips) > 1
@@ -40,6 +77,8 @@ class STRIP_PT_modifiers(StripModButtonsPanel, Panel):
 
 classes = (
     STRIP_PT_modifiers,
+    SEQUENCER_MT_modifier_add_assets,  # BFA
+    SEQUENCER_OT_add_asset_modifier_menu,  # BFA
 )
 
 if __name__ == "__main__":  # only for live edit.

--- a/scripts/startup/bl_ui/space_sequencer.py
+++ b/scripts/startup/bl_ui/space_sequencer.py
@@ -1968,7 +1968,6 @@ class SEQUENCER_MT_modifier_add(Menu):
             self.operator_modifier_add(layout, 'MASK')
             self.operator_modifier_add(layout, 'TONEMAP')
             self.operator_modifier_add(layout, 'WHITE_BALANCE')
-            layout.menu_contents("SEQUENCER_MT_modifier_add_root_catalogs")
 
 
 class SequencerButtonsPanel:


### PR DESCRIPTION
 -- Separated the Assets to their own menu just like the Geometry Nodes

<img width="446" height="273" alt="image" src="https://github.com/user-attachments/assets/c8899eed-3992-4913-86d9-d390dd6ff1a4" />
<img width="452" height="205" alt="image" src="https://github.com/user-attachments/assets/5e69f8e1-fa5a-40b5-a107-7acb6e789d19" />
<img width="452" height="265" alt="image" src="https://github.com/user-attachments/assets/62b2f394-48ea-4185-acac-9e2e2da5466e" />
