### PR TITLE
Sequencer - Hotkeys - Expose Transform Select on Side to GUI #6558

### DIFF
--- a/scripts/presets/keyconfig/Bforartists-macOS.py
+++ b/scripts/presets/keyconfig/Bforartists-macOS.py
@@ -1,4 +1,4 @@
-keyconfig_version = (5, 2, 7)
+keyconfig_version = (5, 2, 36)
 keyconfig_data = \
 [("3D View",
   {"space_type": 'VIEW_3D', "region_type": 'WINDOW'},
@@ -4730,7 +4730,7 @@ keyconfig_data = \
    [("paint.image_paint",
      {"type": 'LEFTMOUSE', "value": 'PRESS'},
      {"properties":
-      [("mode", 'None'),
+      [("brush_toggle", 'None'),
        ],
       },
      ),
@@ -8282,7 +8282,7 @@ keyconfig_data = \
    [("sculpt.brush_stroke",
      {"type": 'LEFTMOUSE', "value": 'PRESS'},
      {"properties":
-      [("mode", 'None'),
+      [("brush_toggle", 'None'),
        ],
       },
      ),
@@ -8533,7 +8533,7 @@ keyconfig_data = \
    [("sculpt_curves.brush_stroke",
      {"type": 'LEFTMOUSE', "value": 'PRESS'},
      {"properties":
-      [("mode", 'None'),
+      [("brush_toggle", 'None'),
        ],
       },
      ),
@@ -9006,6 +9006,13 @@ keyconfig_data = \
      ),
     ("sequencer.retiming_key_delete", {"type": 'DEL', "value": 'PRESS'}, None),
     ("sequencer.delete", {"type": 'DEL', "value": 'PRESS'}, None),
+    ("sequencer.select",
+     {"type": 'LEFTMOUSE', "value": 'CLICK', "oskey": True},
+     {"properties":
+      [("side_of_frame", True),
+       ],
+      },
+     ),
     ],
    },
   ),

--- a/scripts/presets/keyconfig/Bforartists.py
+++ b/scripts/presets/keyconfig/Bforartists.py
@@ -1,4 +1,4 @@
-keyconfig_version = (5, 2, 7)
+keyconfig_version = (5, 2, 36)
 keyconfig_data = \
 [("3D View",
   {"space_type": 'VIEW_3D', "region_type": 'WINDOW'},
@@ -3683,7 +3683,7 @@ keyconfig_data = \
    [("paint.image_paint",
      {"type": 'LEFTMOUSE', "value": 'PRESS'},
      {"properties":
-      [("mode", 'None'),
+      [("brush_toggle", 'None'),
        ],
       },
      ),
@@ -6795,7 +6795,7 @@ keyconfig_data = \
    [("sculpt.brush_stroke",
      {"type": 'LEFTMOUSE', "value": 'PRESS'},
      {"properties":
-      [("mode", 'None'),
+      [("brush_toggle", 'None'),
        ],
       },
      ),
@@ -7046,7 +7046,7 @@ keyconfig_data = \
    [("sculpt_curves.brush_stroke",
      {"type": 'LEFTMOUSE', "value": 'PRESS'},
      {"properties":
-      [("mode", 'None'),
+      [("brush_toggle", 'None'),
        ],
       },
      ),
@@ -7519,6 +7519,13 @@ keyconfig_data = \
      ),
     ("sequencer.retiming_key_delete", {"type": 'DEL', "value": 'PRESS'}, None),
     ("sequencer.delete", {"type": 'DEL', "value": 'PRESS'}, None),
+    ("sequencer.select",
+     {"type": 'LEFTMOUSE', "value": 'CLICK', "ctrl": True},
+     {"properties":
+      [("side_of_frame", True),
+       ],
+      },
+     ),
     ],
    },
   ),

--- a/scripts/startup/bl_app_templates_system/Video_Editing/startup.blend
+++ b/scripts/startup/bl_app_templates_system/Video_Editing/startup.blend
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8a1c2f40fae83617d9db99af6b6d8a74201d6f48b3dcd54e665fea8031ce53eb
-size 552425
+oid sha256:49a261f009ce71ac903ed2e2bdc7ed56edbda797966ccc09684090081d34be1d
+size 538266

--- a/scripts/startup/bl_ui/space_sequencer.py
+++ b/scripts/startup/bl_ui/space_sequencer.py
@@ -747,6 +747,8 @@ class SEQUENCER_MT_select(Menu):
         col.separator()
 
         if has_sequencer:
+            col.operator("sequencer.select", text="Side of Cursor", icon="RESTRICT_SELECT_OFF").side_of_frame = True
+            layout.separator()
             col.operator_menu_enum("sequencer.select_side_of_frame", "side", text="Side of Frame")
             col.menu("SEQUENCER_MT_select_handle", text="Handle")
             col.menu("SEQUENCER_MT_select_channel", text="Channel")
@@ -2906,8 +2908,6 @@ class SEQUENCER_PT_time(SequencerButtonsPanel, Panel):
                 )
 
 # BFA - Legacy
-
-
 class SEQUENCER_PT_adjust_sound(SequencerButtonsPanel, Panel):
     bl_label = "Sound"
     bl_category = "Strip"


### PR DESCRIPTION
Added the hotkey too.

<img width="522" height="368" alt="image" src="https://github.com/user-attachments/assets/d5b8a1e5-639a-45b7-888a-2f698988512c" />

Since that menu was an enum, decided to name this "Select side of Cursor" and expose to top level for discoverability. 