### PR TITLE
Fix: Sequencer - Hotkeys - Make gizmos work on press instead of drag,#6557

### DIFF
--- a/scripts/presets/keyconfig/Bforartists-macOS.py
+++ b/scripts/presets/keyconfig/Bforartists-macOS.py
@@ -3367,6 +3367,13 @@ keyconfig_data = \
     ],
    },
   ),
+ ("Generic Gizmo Maybe Drag",
+  {"space_type": 'EMPTY', "region_type": 'WINDOW'},
+  {"items":
+   [("gizmogroup.gizmo_tweak", {"type": 'LEFTMOUSE', "value": 'PRESS', "shift": -1, "ctrl": -1, "oskey": -1, "hyper": -1}, None),
+    ],
+   },
+  ),
  ("Generic Tool: Annotate",
   {"space_type": 'EMPTY', "region_type": 'WINDOW'},
   {"items":

--- a/scripts/presets/keyconfig/Bforartists.py
+++ b/scripts/presets/keyconfig/Bforartists.py
@@ -2611,6 +2611,13 @@ keyconfig_data = \
     ],
    },
   ),
+ ("Generic Gizmo Maybe Drag",
+  {"space_type": 'EMPTY', "region_type": 'WINDOW'},
+  {"items":
+   [("gizmogroup.gizmo_tweak", {"type": 'LEFTMOUSE', "value": 'PRESS', "shift": -1, "ctrl": -1, "oskey": -1, "hyper": -1}, None),
+    ],
+   },
+  ),
  ("Graph Editor",
   {"space_type": 'GRAPH_EDITOR', "region_type": 'WINDOW'},
   {"items":


### PR DESCRIPTION
Nothing really to document here. 