### PR TITLE
Outliner - Recent merge issues

### DIFF
--- a/scripts/startup/bl_ui/space_outliner.py
+++ b/scripts/startup/bl_ui/space_outliner.py
@@ -604,110 +604,17 @@ class OUTLINER_PT_filter(Panel):
             col = layout.column(align=True)
             split = col.split(factor=0.65)
             split.prop(space, "use_sync_select", text="Sync Selection")
+            split.label(icon='DISCLOSURE_TRI_DOWN' if space.use_sync_select else 'DISCLOSURE_TRI_RIGHT')
             if space.use_sync_select:
-                split.label(icon="DISCLOSURE_TRI_DOWN")
-            else:
-                split.label(icon="DISCLOSURE_TRI_RIGHT")
-            if space.use_sync_select:
-            row = col.row(align=True)
+                row = col.row(align=True)
                 row.separator(factor=2.5)
-            row.prop(space, "scroll_to_active", text="Scroll to Active") # BFA - WIP, float left
+                row.prop(space, "scroll_to_active", text="Scroll to Active") # BFA - WIP, float left
 
             row = layout.row(align=True)
             row.prop(space, "show_mode_column", text="Show Mode Column")
             layout.separator()
 
-        # Same exception for library overrides as in OUTLINER_HT_header.
-        if display_mode == 'LIBRARY_OVERRIDES' and space.lib_override_view_mode == 'HIERARCHIES':
-            filter_text_supported = False
-        else:
-            col = layout.column(align=True)
-            col.label(text="Search")
-            
-            row = col.row()
-            row.separator()
-            col = row.column(align=True)
-            
-            col.prop(space, "use_filter_complete", text="Exact Match")
-            col.prop(space, "use_filter_case_sensitive", text="Case Sensitive")
 
-        if display_mode == 'LIBRARY_OVERRIDES' and space.lib_override_view_mode == 'PROPERTIES' and bpy.data.libraries:
-            row = layout.row()
-            row.label(icon='LIBRARY_DATA_OVERRIDE')
-            row.prop(space, "use_filter_lib_override_system", text="System Overrides")
-
-        if display_mode == 'VIEW_LAYER':
-            layout.label(text="Filter")
-            row = layout.row()
-            row.separator()
-            col = row.column(align=True)        
-
-            self.draw_prop_row(col, space, "use_filter_view_layers", text="All View Layers", icon='RENDERLAYERS')
-            self.draw_prop_row(col, space, "use_filter_collection", text="Collections", icon='OUTLINER_COLLECTION')
-                
-            row = col.row()
-            row.label(icon='OBJECT_DATAMODE')
-            row = row.row(align=True)
-            row.alignment = 'LEFT'
-            row.prop(space, "use_filter_object", text="Objects")
-
-            if space.use_filter_object:
-                row.label(icon='DISCLOSURE_TRI_DOWN')
-            else:
-                row.label(icon='DISCLOSURE_TRI_RIGHT')
-            
-            if space.use_filter_object:
-                row = col.row(align=True)
-                row.prop(space, "filter_state", text="")
-                if space.filter_state != 'ALL':
-                    row.prop(space, "filter_invert", text="", icon='ARROW_LEFTRIGHT')
-                
-                row = col.row()
-                row.separator()
-                col = row.column(align=True)
-                
-                self.draw_prop_row(col, space, "use_filter_object_content", text="Object Contents", icon='OBJECT_CONTENTS')
-                self.draw_prop_row(col, space, "use_filter_children", text="Object Children", icon='CHILD')
-
-                if bpy.data.meshes:
-                    self.draw_prop_row(col, space, "use_filter_object_mesh", text="Meshes", icon='MESH_DATA')
-
-                if bpy.data.armatures:
-                    self.draw_prop_row(col, space, "use_filter_object_armature", text="Armatures", icon='ARMATURE_DATA')
-
-                    if space.use_filter_object_armature:
-                        self.draw_prop_row(col, space, "use_filter_pose_bones", text="Pose Bones", icon='BONE_DATA')
-
-                if bpy.data.lights:
-                    self.draw_prop_row(col, space, "use_filter_object_light", text="Lights", icon='LIGHT_DATA')
-
-                if bpy.data.cameras:
-                    self.draw_prop_row(col, space, "use_filter_object_camera", text="Cameras", icon='CAMERA_DATA')
-                
-                if bpy.data.grease_pencils:
-                    self.draw_prop_row(col, space, "use_filter_object_grease_pencil", text="Grease Pencil", icon='STROKE')
-                
-                self.draw_prop_row(col, space, "use_filter_object_empty", text="Empties", icon='EMPTY_DATA')
-                
-                other_data = (
-                    "curves",
-                    "metaballs",
-                    "hair_curves",
-                    "pointclouds",
-                    "volumes",
-                    "lightprobes",
-                    "lattices",
-                    "fonts",
-                    "speakers",
-                )    
-                
-                has_others = any((getattr(bpy.data, data_type, False) for data_type in other_data))
-                
-                if has_others:
-                    self.draw_prop_row(col, space, "use_filter_object_others", text="Others", icon='OBJECT_DATAMODE')
-
-
-# BFA - Not used, consolidated above
 class OUTLINER_PT_options_search(Panel):
     bl_space_type = 'OUTLINER'
     bl_region_type = 'HEADER'
@@ -737,7 +644,7 @@ class OUTLINER_PT_options_search(Panel):
         col.prop(space, "use_filter_case_sensitive", text="Case Sensitive")
 
 
-# BFA - Not used, consolidated above
+
 class OUTLINER_PT_options_filter(Panel):
     bl_space_type = 'OUTLINER'
     bl_region_type = 'HEADER'
@@ -766,62 +673,64 @@ class OUTLINER_PT_options_filter(Panel):
 
         row = col.row()
         row.label(icon='OBJECT_DATAMODE')
-        row.prop(space, "use_filter_object", text="Objects")
-        row = col.row(align=True)
-        row.label(icon='BLANK1')
-        row.prop(space, "filter_state", text="")
-        sub = row.row(align=True)
-        sub.enabled = space.filter_state != 'ALL'
-        sub.prop(space, "filter_invert", text="", icon='ARROW_LEFTRIGHT')
+        split = row.split(factor=0.60)
+        split.prop(space, "use_filter_object", text="Objects")
+        split.label(icon='DISCLOSURE_TRI_DOWN' if space.use_filter_object else 'DISCLOSURE_TRI_RIGHT')
+        if space.use_filter_object:
+            row = col.row(align=True)
+            row.label(icon='BLANK1')
+            row.prop(space, "filter_state", text="")
+            sub = row.row(align=True)
+            sub.enabled = space.filter_state != 'ALL'
+            sub.prop(space, "filter_invert", text="", icon='ARROW_LEFTRIGHT')
 
-        sub = col.column(align=True)
-        sub.active = space.use_filter_object
+            sub = col.column(align=True)
 
-        row = sub.row()
-        row.label(icon='BLANK1')
-        row.prop(space, "use_filter_object_content", text="Object Contents")
-        row = sub.row()
-        row.label(icon='BLANK1')
-        row.prop(space, "use_filter_children", text="Object Children")
-
-        if bpy.data.meshes:
-            row = sub.row()
-            row.label(icon='MESH_DATA')
-            row.prop(space, "use_filter_object_mesh", text="Meshes")
-        if bpy.data.armatures:
-            row = sub.row()
-            row.label(icon='ARMATURE_DATA')
-            row.prop(space, "use_filter_object_armature", text="Armatures")
-        if bpy.data.lights:
-            row = sub.row()
-            row.label(icon='LIGHT_DATA')
-            row.prop(space, "use_filter_object_light", text="Lights")
-        if bpy.data.cameras:
-            row = sub.row()
-            row.label(icon='CAMERA_DATA')
-            row.prop(space, "use_filter_object_camera", text="Cameras")
-        if bpy.data.grease_pencils:
-            row = sub.row()
-            row.label(icon='STROKE')
-            row.prop(space, "use_filter_object_grease_pencil", text="Grease Pencil")
-        row = sub.row()
-        row.label(icon='EMPTY_DATA')
-        row.prop(space, "use_filter_object_empty", text="Empties")
-
-        if (
-                bpy.data.curves or
-                bpy.data.metaballs or
-                (hasattr(bpy.data, "hair_curves") and bpy.data.hair_curves) or
-                (hasattr(bpy.data, "pointclouds") and bpy.data.pointclouds) or
-                bpy.data.volumes or
-                bpy.data.lightprobes or
-                bpy.data.lattices or
-                bpy.data.fonts or
-                bpy.data.speakers
-        ):
             row = sub.row()
             row.label(icon='BLANK1')
-            row.prop(space, "use_filter_object_others", text="Others")
+            row.prop(space, "use_filter_object_content", text="Object Contents")
+            row = sub.row()
+            row.label(icon='BLANK1')
+            row.prop(space, "use_filter_children", text="Object Children")
+
+            if bpy.data.meshes:
+                row = sub.row()
+                row.label(icon='MESH_DATA')
+                row.prop(space, "use_filter_object_mesh", text="Meshes")
+            if bpy.data.armatures:
+                row = sub.row()
+                row.label(icon='ARMATURE_DATA')
+                row.prop(space, "use_filter_object_armature", text="Armatures")
+            if bpy.data.lights:
+                row = sub.row()
+                row.label(icon='LIGHT_DATA')
+                row.prop(space, "use_filter_object_light", text="Lights")
+            if bpy.data.cameras:
+                row = sub.row()
+                row.label(icon='CAMERA_DATA')
+                row.prop(space, "use_filter_object_camera", text="Cameras")
+            if bpy.data.grease_pencils:
+                row = sub.row()
+                row.label(icon='STROKE')
+                row.prop(space, "use_filter_object_grease_pencil", text="Grease Pencil")
+            row = sub.row()
+            row.label(icon='EMPTY_DATA')
+            row.prop(space, "use_filter_object_empty", text="Empties")
+
+            if (
+                    bpy.data.curves or
+                    bpy.data.metaballs or
+                    (hasattr(bpy.data, "hair_curves") and bpy.data.hair_curves) or
+                    (hasattr(bpy.data, "pointclouds") and bpy.data.pointclouds) or
+                    bpy.data.volumes or
+                    bpy.data.lightprobes or
+                    bpy.data.lattices or
+                    bpy.data.fonts or
+                    bpy.data.speakers
+            ):
+                row = sub.row()
+                row.label(icon='BLANK1')
+                row.prop(space, "use_filter_object_others", text="Others")
 
 classes = (
     OUTLINER_HT_header,
@@ -843,8 +752,8 @@ classes = (
     OUTLINER_MT_context_menu_view,#BFA - not used
     OUTLINER_MT_view_pie,
     OUTLINER_PT_filter,
-    OUTLINER_PT_options_search, #BFA - not used
-    OUTLINER_PT_options_filter, #BFA - not used
+    OUTLINER_PT_options_search,
+    OUTLINER_PT_options_filter,
 )
 
 if __name__ == "__main__":  # only for live edit.


### PR DESCRIPTION
-- Fixed up use_sync_select/scroll_to_active indent issue
-- Removed the duplicated consolidated codebases of our OUTLINER_PT_options_search and OUTLINER_PT_options_filter changes and moved it back to their own classes with our DISCLOSURE arrows  (see below) .

This was done since has other parts of GUI are now using this (like VIEW3D_PT_shading), and makes it cleaner/closer to blender codebases for easier merging.

<img width="467" height="1057" alt="image" src="https://github.com/user-attachments/assets/a32bb7de-883b-44c9-88e6-545d379f1c91" />
