### PR TITLE
Node Editor - Remove double "New Group" oeprator

### DIFF
--- a/scripts/startup/bl_ui/node_add_menu.py
+++ b/scripts/startup/bl_ui/node_add_menu.py
@@ -396,15 +396,9 @@ class NodeMenu(Menu):
             cls.node_operator(layout, "NodeGroupInput")
             cls.node_operator(layout, "NodeGroupOutput")
 
-        operators = []
-        operators.append(cls.new_empty_group(layout))
-
         # BFA - Draw node groups with corresponding icons
         use_transform = getattr(cls, "use_transform", False)
-        groups = draw_node_groups(context, layout, cls.main_operator_id, use_transform)
-        operators.extend(groups)
-
-        return operators
+        draw_node_groups(context, layout, cls.main_operator_id, use_transform)
 
         # BFA - WIP
         if node_tree:


### PR DESCRIPTION
-- Removed the duplicated New Group, kept the top one.

<img width="431" height="90" alt="image" src="https://github.com/user-attachments/assets/b8d35158-8665-4636-a97d-a20500919659" />
