### PR TITLE
Compositor - Sidebar - Option - Make Cache Frames better with indents #6661

### DIFF
--- a/scripts/startup/bl_ui/space_node.py
+++ b/scripts/startup/bl_ui/space_node.py
@@ -1309,8 +1309,12 @@ class NODE_PT_quality(Panel):
             col.prop(rd, "compositor_precision", text="Precision")
 
         if snode.node_tree_sub_type == 'SCENE':
-            col = layout.column(heading="Cache", align=True)
-            col.prop(rd, "use_compositor_frames_cache", text="Frames")
+            # BFA - label with indented checkbox on its own line
+            col = layout.column(align=True)
+            col.label(text="Cache")
+            row = col.row()
+            row.separator()
+            row.prop(rd, "use_compositor_frames_cache", text="Frames")
 
 
 class NODE_PT_overlay(Panel):


### PR DESCRIPTION
<img width="616" height="366" alt="bforartists_csHPlHO20g" src="https://github.com/user-attachments/assets/67b3b24a-7958-4bcf-9a3a-a4a6890f44dd" />

Not documented yet. Do that! 
