### PR TITLE
Properties Editor - Object - Visibility - Align new Ray Visibility toggles #6633

### DIFF
--- a/scripts/startup/bl_ui/properties_object.py
+++ b/scripts/startup/bl_ui/properties_object.py
@@ -508,10 +508,12 @@ class OBJECT_PT_visibility(ObjectButtonsPanel, Panel):
         layout.use_property_split = True # bfa - this just sets decorators for all the props below, since we internally align left with 6162.
         ob = context.object
 
-        row = layout.row()
-        row.separator()
         # bfa - we turn the selectable on or off in the outliner. Not in a hidden panel.
         # col.prop(ob, "hide_select", text="Selectable", toggle=False, invert_checkbox=True)
+        col = layout.column(align = True)
+        col.label(text = "Selection")
+        row = col.row()
+        row.separator()
         row.prop(ob, "hide_surface_pick", text="Surface Picking", toggle=False, invert_checkbox=True)
         
         col = layout.column(align = True)
@@ -528,11 +530,17 @@ class OBJECT_PT_visibility(ObjectButtonsPanel, Panel):
 
         if context.engine == 'BLENDER_EEVEE':
             if ob.type in {'MESH', 'CURVE', 'SURFACE', 'META', 'FONT', 'CURVES', 'POINTCLOUD', 'VOLUME'}:
-                layout.separator()
-                col = layout.column(heading="Ray Visibility")
-                col.prop(ob, "visible_camera", text="Camera", toggle=False)
-                col.prop(ob, "visible_shadow", text="Shadow", toggle=False)
-                col.prop(ob, "visible_raycast", text="Raycast", toggle=False)
+                col = layout.column(align = True)
+                col.label(text = "Ray Visibility")
+                row = col.row()
+                row.separator()
+                row.prop(ob, "visible_camera", text="Camera", toggle=False)
+                row = col.row()
+                row.separator()
+                row.prop(ob, "visible_shadow", text="Shadow", toggle=False)
+                row = col.row()
+                row.separator()
+                row.prop(ob, "visible_raycast", text="Raycast", toggle=False)
 
             if ob.type in {'LIGHT'}:
                 col.label(text = "Ray Visibility")


### PR DESCRIPTION
This also adds a label for selection, it was confusing. Keep in mind this menu is contextual for different object types.


<img width="308" height="606" alt="bforartists_h6qtlao42A" src="https://github.com/user-attachments/assets/e8fbbbc4-f23b-44f1-9bc4-e8f4debe0697" />
