### PR TITLE
Timeline + Timeline Footers - Consolidate and improve the keyframing group of operators and properties #6726

### DIFF
--- a/scripts/startup/bl_ui/space_time.py
+++ b/scripts/startup/bl_ui/space_time.py
@@ -43,7 +43,8 @@ class TIME_PT_playhead_snapping(Panel):
 def playback_controls(layout, context):
     st = context.space_data
     is_sequencer = st.type == 'SEQUENCE_EDITOR'
-    is_timeline = st.mode == 'TIMELINE'  # BFA
+    is_timeline = st.type == 'DOPESHEET_EDITOR' and st.mode == 'TIMELINE'  # BFA
+    is_nla = st.type == 'NLA_EDITOR'  # BFA
 
     scene = context.scene if not is_sequencer else context.sequencer_scene
     tool_settings = scene.tool_settings if scene else None
@@ -127,10 +128,27 @@ def playback_controls(layout, context):
 
         # BFA - Keyframing controls
         row = layout.row(align=True)
-        row.operator("anim.keyframe_insert", text="", icon="KEYFRAMES_INSERT")  # BFA - updated icon
+        # BFA - NLA uses action.keyframe_insert instead of anim.keyframe_insert
+        if is_nla:
+            row.operator("action.keyframe_insert", text="", icon="KEYFRAMES_INSERT")
+        else:
+            row.operator("anim.keyframe_insert", text="", icon="KEYFRAMES_INSERT")
         row.operator(
             "anim.keyframe_delete_v3d", text="", icon="KEYFRAMES_REMOVE"
         )  # BFA - updated to work like it would in the 3D View (as expected)
+
+        # BFA - Auto keyframing toggle (opens consolidated keyframing settings popover)
+        row.prop(tool_settings, "use_keyframe_insert_auto", text="", toggle=True)
+
+        # BFA - Keying set selector and keyframing settings popover in the same row
+        row.prop_search(scene.keying_sets_all, "active", scene, "keying_sets_all", text="")
+        if tool_settings:
+            icon_keytype = 'KEYTYPE_{:s}_VEC'.format(tool_settings.keyframe_type)
+            row.popover(
+                panel="TIME_PT_keyframing_settings",
+                text="",
+                icon=icon_keytype,
+            )
 
         # BFA - Grease Pencil mode doesn't need snapping, as it's frame-aligned only
         if is_timeline:
@@ -149,20 +167,6 @@ def playback_controls(layout, context):
             sub = row.row(align=True)
             sub.prop(tool_settings, "use_snap_playhead", text="")
             sub.popover(panel="TIME_PT_playhead_snapping", text="")
-
-        # BFA - Auto keyframing toggle (opens consolidated keyframing settings popover)
-        row = layout.row(align=True)
-        row.prop(tool_settings, "use_keyframe_insert_auto", text="", toggle=True)
-
-        # BFA - Keying set selector and keyframing settings popover in the same row
-        row.prop_search(scene.keying_sets_all, "active", scene, "keying_sets_all", text="")
-        if tool_settings:
-            icon_keytype = 'KEYTYPE_{:s}_VEC'.format(tool_settings.keyframe_type)
-            row.popover(
-                panel="TIME_PT_keyframing_settings",
-                text="",
-                icon=icon_keytype,
-            )
 
         if scene:
             layout.popover(
@@ -394,12 +398,13 @@ class TIME_PT_keyframing(TimelinePanelButtons, Panel):
     def draw(self, _context):
         pass
 
-
+# BFA - consolidated keyframing settings into a single popover, instead of multiple sub-panels
 class TIME_PT_keyframing_settings(TimelinePanelButtons, Panel):
     # BFA - standalone popover, not a child of TIME_PT_keyframing
     bl_label = "Keyframing Settings"
     bl_options = {"HIDE_HEADER"}
     bl_region_type = "HEADER"
+    bl_ui_units_x = 12
     bl_description = "Active keying set and keyframing settings"
 
     @classmethod
@@ -426,13 +431,30 @@ class TIME_PT_keyframing_settings(TimelinePanelButtons, Panel):
         # BFA - keying set search and insert/delete are exposed at the header top level, not here
 
         # BFA - consolidated auto-keyframing settings (hidden when auto-key is off)
+        # BFA - Use a manual row to avoid property_split label column stealing space from buttons
         if tool_settings.use_keyframe_insert_auto:
             col = layout.column(align=True)
             col.label(text="Auto Keyframing")
-            col.prop(tool_settings, "auto_keying_mode", expand=True, text="Mode")
+            col.use_property_split = False
+            row = col.row()
+            row.separator()
+            split = row.split(factor=0.3)
+            split.label(text="Mode")
+            split.prop(tool_settings, "auto_keying_mode", text="")
+
+            col.separator()
+            row = col.row()
+            row.separator()
+            row.prop(tool_settings, "use_keyframe_insert_keyingset", text="Only Active Keying Set", icon="KEYINGSET")
 
         col = layout.column(align=True)
         col.label(text="Keyframing")
+
+        col.use_property_split = False
+        row = col.row()
+        row.separator()
+        row.label(text="Type")
+        row.prop(tool_settings, "keyframe_type", expand=True, text="")
 
         if not prefs.edit.use_keyframe_insert_available:
             row = col.row()

--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -3940,11 +3940,11 @@ class VIEW3D_MT_object_animation(Menu):
             icon="BAKE_ACTION")
         layout.operator("anim.replace_action", icon="ACTION_REPLACE")
         layout.operator("anim.replace_action_new", icon="ACTION_REPLACE_NEW")
-        layout.operator("anim.replace_action_duplicate")
+        layout.operator("anim.replace_action_duplicate", icon="ACTION_REPLACE_DUPLICATE")
 
         layout.separator()
 
-        layout.operator("anim.rotation_mode_convert")
+        layout.operator("anim.rotation_mode_convert") # BFA - WIP
 
 
 class VIEW3D_MT_object_rigid_body(Menu):

--- a/source/blender/makesrna/intern/rna_scene.cc
+++ b/source/blender/makesrna/intern/rna_scene.cc
@@ -3322,8 +3322,8 @@ static void rna_def_tool_settings(BlenderRNA *brna)
    * exclusive options but which will only have any effect when autokey is enabled
    */
   static const EnumPropertyItem auto_key_items[] = {
-      {AUTOKEY_MODE_NORMAL & ~AUTOKEY_ON, "ADD_REPLACE_KEYS", 0, "Add & Replace", ""},
-      {AUTOKEY_MODE_EDITKEYS & ~AUTOKEY_ON, "REPLACE_KEYS", 0, "Replace", ""},
+      {AUTOKEY_MODE_NORMAL & ~AUTOKEY_ON, "ADD_REPLACE_KEYS", ICON_ADD, "Add & Replace", ""},
+      {AUTOKEY_MODE_EDITKEYS & ~AUTOKEY_ON, "REPLACE_KEYS", ICON_SWAP, "Replace", ""},
       {0, nullptr, 0, nullptr, nullptr},
   };
 


### PR DESCRIPTION
<img width="1604" height="248" alt="image" src="https://github.com/user-attachments/assets/dcd99764-c409-46f6-93c3-473b311b366a" />

- Grouped keyframes operators together and moved snapping after
- Made the insert keyframe NLA aware (another operator)
- Made the keyframing panel split properties and conditional based on auto-keyframe state
- Added icons to Auto-Keying Mode
- Expanded Keyframing type to top level to dig less

