### PR TITLE
6732-properties-editor---world---open-node-editor-button-to-open-shad…

### DIFF
--- a/scripts/startup/bl_ui/properties_world.py
+++ b/scripts/startup/bl_ui/properties_world.py
@@ -71,6 +71,12 @@ class WORLD_PT_context_world(WorldButtonsPanel, Panel):
         elif world:
             layout.template_ID(space, "pin_id")
 
+        # BFA - Open Shader Editor
+        if world:
+            col = layout.column(align=True)
+            col.separator()
+            col.operator("world.open_node_editor", icon='NODE_MATERIAL')
+
 
 # bfa - move mist panel to view layers
 # class EEVEE_WORLD_PT_mist(WorldButtonsPanel, Panel):

--- a/source/blender/editors/render/render_intern.hh
+++ b/source/blender/editors/render/render_intern.hh
@@ -35,6 +35,7 @@ void WORLD_OT_new(wmOperatorType *ot);
 /* BFA - Open Node Editor Operators */
 void MATERIAL_OT_open_node_editor(wmOperatorType *ot);
 void TEXTURE_OT_open_node_editor(wmOperatorType *ot);
+void WORLD_OT_open_node_editor(wmOperatorType *ot);
 
 void MATERIAL_OT_copy(wmOperatorType *ot);
 void MATERIAL_OT_paste(wmOperatorType *ot);

--- a/source/blender/editors/render/render_ops.cc
+++ b/source/blender/editors/render/render_ops.cc
@@ -40,6 +40,7 @@ void ED_operatortypes_render()
   /* BFA - Open Node Editor Operators */
   WM_operatortype_append(MATERIAL_OT_open_node_editor);
   WM_operatortype_append(TEXTURE_OT_open_node_editor);
+  WM_operatortype_append(WORLD_OT_open_node_editor);
 
   WM_operatortype_append(MATERIAL_OT_copy);
   WM_operatortype_append(MATERIAL_OT_paste);

--- a/source/blender/editors/render/render_shading.cc
+++ b/source/blender/editors/render/render_shading.cc
@@ -3249,6 +3249,64 @@ void MATERIAL_OT_open_node_editor(wmOperatorType *ot)
 /** \} */
 
 /* -------------------------------------------------------------------- */
+/** \name BFA - Open World Shader Editor Operator
+ * \{ */
+
+static wmOperatorStatus world_open_node_editor_exec(bContext *C, wmOperator *op)
+{
+  World *wo = static_cast<World *>(
+      CTX_data_pointer_get_type(C, "world", RNA_World).data);
+  if (!wo) {
+    BKE_report(op->reports, RPT_ERROR, "No active world");
+    return OPERATOR_CANCELLED;
+  }
+
+  if (!wo->nodetree) {
+    BKE_report(op->reports, RPT_ERROR, "World has no node tree");
+    return OPERATOR_CANCELLED;
+  }
+
+  ScrArea *area = ED_screen_temp_space_open(
+      C, IFACE_("Shader Editor"), SPACE_NODE, USER_TEMP_SPACE_DISPLAY_WINDOW, false);
+  if (!area) {
+    BKE_report(op->reports, RPT_ERROR, "Failed to open Shader Editor");
+    return OPERATOR_CANCELLED;
+  }
+
+  SpaceNode *snode = static_cast<SpaceNode *>(area->spacedata.first);
+  STRNCPY(snode->tree_idname, "ShaderNodeTree");
+  snode->shaderfrom = SNODE_SHADER_WORLD;
+  snode->selected_node_group = nullptr;
+
+  ARegion *region = BKE_area_find_region_type(area, RGN_TYPE_WINDOW);
+  ED_node_tree_start(region, snode, wo->nodetree, &wo->id, nullptr);
+  blender::ed::space_node::tree_update(C);
+
+  WM_event_add_notifier(C, NC_WORLD | ND_NODES, nullptr);
+
+  return OPERATOR_FINISHED;
+}
+
+static bool world_open_node_editor_poll(bContext *C)
+{
+  World *wo = static_cast<World *>(
+      CTX_data_pointer_get_type(C, "world", RNA_World).data);
+  return wo != nullptr && wo->nodetree != nullptr;
+}
+
+void WORLD_OT_open_node_editor(wmOperatorType *ot)
+{
+  ot->name = "Open Shader Editor";
+  ot->idname = "WORLD_OT_open_node_editor";
+  ot->description = "Open a Shader Editor window for this world";
+  ot->exec = world_open_node_editor_exec;
+  ot->poll = world_open_node_editor_poll;
+  ot->flag = OPTYPE_REGISTER | OPTYPE_UNDO;
+}
+
+/** \} */
+
+/* -------------------------------------------------------------------- */
 /** \name BFA - Open Texture Node Editor Operator
  * \{ */
 


### PR DESCRIPTION
World Properties - Add Open Shader Editor operator button

Adds a new "Open Shader Editor" button to the World Properties panel that opens a Shader Editor window configured for the active world's node tree. Implements WORLD_OT_open_node_editor operator following the same pattern as the existing material and texture node editor operators.

<img width="331" height="488" alt="image" src="https://github.com/user-attachments/assets/873fbeb8-6105-443d-aaa1-b6dc39c01ac2" />

<img width="851" height="668" alt="image" src="https://github.com/user-attachments/assets/956a1dee-8b75-4819-900d-9b5afcd5b293" />

