### PR TITLE
User Interface - Internal - Create `indented_column` helper function

### DIFF
--- a/source/blender/editors/include/UI_interface_layout.hh
+++ b/source/blender/editors/include/UI_interface_layout.hh
@@ -65,6 +65,11 @@ struct PanelLayout {
   Layout *body;
 };
 
+struct IndentedColumn {
+  Layout *header;
+  Layout *body;
+};
+
 struct Item {
 
   Item(ItemType type);
@@ -272,6 +277,14 @@ struct Layout : public Item, NonCopyable, NonMovable {
    * label column when there is no label defined.
    */
   Layout &column(bool align, StringRef heading);
+
+  /**
+   * Add a new indented column sub-layout, items placed in this sub-layout are added vertically one under
+   * each other in a column with left indentation.
+   */
+  IndentedColumn indented_column(bool align, bool draw_body); /* BFA */
+  Layout &indented_column(bool align, StringRef heading); /* BFA - simple case where header row is just text. */
+  Layout &indented_column(bool align, const char *heading);
 
   /**
    * Add a new row sub-layout, items placed in this sub-layout are added horizontally next to each

--- a/source/blender/editors/interface/interface_layout.cc
+++ b/source/blender/editors/interface/interface_layout.cc
@@ -5297,6 +5297,42 @@ Layout &Layout::column(bool align, const StringRef heading)
   return litem;
 }
 
+IndentedColumn Layout::indented_column(bool align, bool draw_body=true) /* BFA */
+{
+  Layout *col, *row;
+  IndentedColumn indented_column{};
+  
+  col = &this->column(true);
+  row = &col->row(false);
+
+  indented_column.header = row;
+
+  if (!draw_body){
+    indented_column.body = nullptr;
+    return indented_column;
+  }
+  
+  row = &col->row(false);
+  row->separator();
+  col = &row->column(align);
+  
+  indented_column.body = col;
+
+  return indented_column;
+}
+
+Layout &Layout::indented_column(bool align, StringRef heading) /* BFA */
+{
+  IndentedColumn indented_column = this->indented_column(align, true);
+  indented_column.header->label(heading, ICON_NONE);
+  
+  return *indented_column.body;
+}
+
+Layout &Layout::indented_column(bool align, const char *heading){ /* BFA */
+  return this->indented_column(align, StringRef{heading});
+}
+
 Layout &Layout::column_flow(int number, bool align)
 {
   LayoutItemFlow *flow = MEM_new<LayoutItemFlow>(__func__);

--- a/source/blender/makesrna/intern/rna_ui_api.cc
+++ b/source/blender/makesrna/intern/rna_ui_api.cc
@@ -1008,6 +1008,14 @@ static Layout *rna_uiLayoutColumnWithHeading(
   return &layout->column(align, text.value_or(""));
 }
 
+void rna_uiLayoutIndentedColumn(
+    Layout *layout, bool align, bool draw_body, Layout **r_layout_header, Layout **r_layout_body)
+{
+  ui::IndentedColumn indented_column = layout->indented_column(align, draw_body);
+  *r_layout_header = indented_column.header;
+  *r_layout_body = indented_column.body;
+}
+
 static Layout *rna_uiLayoutColumnFlow(Layout *layout, int number, bool align)
 {
   return &layout->column_flow(number, align);
@@ -1433,6 +1441,22 @@ void RNA_api_ui_layout(StructRNA *srna)
       "in a column.");
   RNA_def_boolean(func, "align", false, "", "Align buttons to each other");
   api_ui_item_common_heading(func);
+
+  func = RNA_def_function(srna, "indented_column", "rna_uiLayoutIndentedColumn");
+  RNA_def_function_ui_description(func,
+                                  "Sub-layout. Items placed in this sub-layout are placed under "
+                                  "each other in a column with left indentation.");
+  RNA_def_boolean(func, "align", false, "", "Align buttons to each other");
+  RNA_def_boolean(func, "draw_body", true, "", "Toggle whether the column body is drawn or not");
+  parm = RNA_def_pointer(func, "layout", "UILayout", "", "Sub-layout to put items in");
+  RNA_def_parameter_flags(parm, PROP_NEVER_NULL, ParameterFlag(0));
+  RNA_def_function_output(func, parm);
+  parm = RNA_def_pointer(func,
+                         "layout_body",
+                         "UILayout",
+                         "",
+                         "Sub-layout to put items in. Will be none if the panel is collapsed.");
+  RNA_def_function_output(func, parm);
 
   func = RNA_def_function(srna, "panel", "rna_uiLayoutPanel");
   RNA_def_function_ui_description(


### PR DESCRIPTION
There is a common pattern in BForArtist's UI of having a column of items with indentation. This often requires setting up UILayout rows & columns in a specific configuration to achieve.

This patch aims to make that process easier by exposing said pattern as a `UILayout` member function in both C++ & the Python API.

This allows us to minimize the modified code wherever the UI pattern is used, and to enforce consistency between the different places where we need indentation. Should we have to modify the implementation in the future, we only have to change it once instead of having to scan for all the different call sites and change them one-by-one.

