### PR TITLE
3D View - Add - Lattice menu needs icon #6781

### DIFF
--- a/scripts/startup/bl_ui/space_view3d.py
+++ b/scripts/startup/bl_ui/space_view3d.py
@@ -3547,7 +3547,7 @@ class VIEW3D_MT_add(Menu):
         else:
             layout.operator("object.armature_add", text="Armature", icon="OUTLINER_OB_ARMATURE")
 
-        layout.menu("VIEW3D_MT_lattice_add")
+        layout.menu("VIEW3D_MT_lattice_add", icon="OUTLINER_OB_LATTICE")
 
         layout.separator()
 


### PR DESCRIPTION
in line 3550 of DIR: space_view_3d.py :  layout.menu("VIEW3D_MT_lattice_add"), was needing an icon, I added: ", icon="OUTLINER_OB_LATTICE")" in DIR: space_view_3d.py effectively fixing the missing icon.

buld and debug succeeded.

Github-Repo issue title has a typo, change "lattive" to "lattice".

<img width="1920" height="1040" alt="image" src="https://github.com/user-attachments/assets/0ac033bc-5586-403d-bb3a-fc06ed1f5c5f" />

