### PR TITLE
Outliner - Filter Popover - Add icon back #6745

### DIFF
--- a/scripts/startup/bl_ui/space_outliner.py
+++ b/scripts/startup/bl_ui/space_outliner.py
@@ -75,6 +75,7 @@ class OUTLINER_HT_header(Header):
         if display_mode in {'SCENES', 'VIEW_LAYER', 'LIBRARY_OVERRIDES'}:
             row.popover(
                 panel="OUTLINER_PT_filter",
+                icon="FILTER", # BFA - add icon back
                 text="",
             )
 


### PR DESCRIPTION
This got removed in Blender main, add it back because not having the icon makes the filter popover less discoverable.

| Before | After |
| --- | --- |
| <img width="235" height="156" alt="image" src="https://github.com/user-attachments/assets/02cef91c-c55a-4fda-8835-6a2069583485" /> | <img width="232" height="161" alt="image" src="https://github.com/user-attachments/assets/1016739f-7198-49ea-bb7e-a7969a6083f2" /> |

Resolves: #6745

