### PR TITLE
Node Editor - Overlay - Minimap properties need work #6785

### DIFF
--- a/scripts/startup/bl_ui/space_node.py
+++ b/scripts/startup/bl_ui/space_node.py
@@ -440,29 +440,35 @@ class NODE_PT_gizmo_display(Panel):
             colsub.active = snode.node_tree is not None and col.active
             colsub.prop(snode, "show_gizmo_active_node", text="Active Node")
         
-        col.separator()
-        col = col.column(align=True)
-        row = col.row()
-        row.prop(snode, "show_minimap", text="Show Minimap")
-        if not snode.show_minimap:
-            row.label(icon="DISCLOSURE_TRI_RIGHT")
+        header, col = col.indented_column(align=False, draw_body=snode.show_minimap)        
+        header_row = header.row()
+        header_row.alignment = 'LEFT'
+        header_row.prop(snode, "show_minimap", text="Show Minimap")
+
+        if col:
+            header_row.label(icon="DISCLOSURE_TRI_DOWN")
+            col.use_property_split = True
+            col.use_property_decorate = False
+
+            col.separator()
+            col.prop(snode, "minimap_aspect_ratio", text="Aspect Ratio")
+            col.prop(snode, "minimap_scale", text="Scale")
+            col.separator()
+        
+            col.prop(snode, "minimap_auto_hide", text="Auto Hide")
+            col.prop(snode, "minimap_top", text="Draw on Top")
+            col.prop(snode, "show_nodes_in_frame", text="Show Nodes in Frame")
+
+            col.separator()
+            subheader, subcol = col.indented_column()        
+            subheader.label(text="Color")
+
+            split = subcol.split()
+            split.prop(snode, "use_node_colors", text="Nodes")
+            split.prop(snode, "use_frame_colors", text="Frames")
         else:
-            row.label(icon="DISCLOSURE_TRI_DOWN")
-            
-            split = col.split()
-            row = split.column()
-            row.separator()
-            row.use_property_split = True
-            row.prop(snode, "minimap_top")
-            row.prop(snode, "minimap_auto_hide")
-            row.separator()
-            row.prop(snode, "minimap_aspect_ratio")
-            row.prop(snode, "minimap_scale")
-            row.separator()
-            row.prop(snode, "use_node_colors")
-            row.separator()
-            row.prop(snode, "use_frame_colors")
-            row.prop(snode, "show_nodes_in_frame")
+            header_row.label(icon="DISCLOSURE_TRI_RIGHT")
+
 
 class NODE_MT_editor_menus(Menu):
     bl_idname = "NODE_MT_editor_menus"

--- a/source/blender/makesrna/intern/rna_space.cc
+++ b/source/blender/makesrna/intern/rna_space.cc
@@ -9122,7 +9122,7 @@ static void rna_def_space_node(BlenderRNA *brna)
 
   prop = RNA_def_property(srna, "minimap_top", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_sdna(prop, nullptr, "gizmo_flag", SNODE_GIZMO_MINIMAP_MOVE_TO_TOP);
-  RNA_def_property_ui_text(prop, "Minimap Top", "Move the minimap to top right, otherwise it will be in the bottom right");
+  RNA_def_property_ui_text(prop, "Minimap Draw on Top", "Move the minimap to top right, otherwise it will be in the bottom right");
   RNA_def_property_update(prop, NC_SPACE | ND_SPACE_NODE_VIEW, nullptr);
 
   prop = RNA_def_property(srna, "minimap_auto_hide", PROP_BOOLEAN, PROP_NONE);


### PR DESCRIPTION
- Indent items under `Show Minimap`
- Remove redundant "Minimap ..." label in properties
- Re-order elements for better grouping

| Before | After |
| --- | --- |
| <img width="275" height="303" alt="image" src="https://github.com/user-attachments/assets/23a13933-6024-45f7-9727-1c776cc9945e" /> | <img width="281" height="289" alt="image" src="https://github.com/user-attachments/assets/12861796-6741-4a24-9fc2-766ff9af8504" /> |

Resolves: #6785