### PR TITLE
3D View - Overlay - Convey that Attribute Text Overlay is disabled when Text Info is disabled #6711

### DIFF
--- a/source/blender/makesrna/intern/rna_space.cc
+++ b/source/blender/makesrna/intern/rna_space.cc
@@ -5391,7 +5391,9 @@ static void rna_def_space_view3d_overlay(BlenderRNA *brna)
 
   prop = RNA_def_property(srna, "show_text", PROP_BOOLEAN, PROP_NONE);
   RNA_def_property_boolean_negative_sdna(prop, nullptr, "overlay.flag", V3D_OVERLAY_HIDE_TEXT);
-  RNA_def_property_ui_text(prop, "Show Text", "Display overlay text");
+  RNA_def_property_ui_text(prop, "Show Text", 
+                           "Display overlay text.\n"
+                           "Also affects the Geometry Nodes viewer overlay");
   RNA_def_property_update(prop, NC_SPACE | ND_SPACE_VIEW3D, nullptr);
 
   prop = RNA_def_property(srna, "show_stats", PROP_BOOLEAN, PROP_NONE);


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="466" height="93" alt="image" src="https://github.com/user-attachments/assets/3103f72d-9987-41ef-ae24-fe45f44d1cbd" /> | <img width="470" height="99" alt="image" src="https://github.com/user-attachments/assets/ae0dc202-b04d-48f3-94e6-3c57817d7cb3" /> |

Resolves: #6711