### PR TITLE
UI: Tool System - Use fallback tool's icon in drag action popover #6798

### DIFF
--- a/scripts/startup/bl_ui/space_toolsystem_common.py
+++ b/scripts/startup/bl_ui/space_toolsystem_common.py
@@ -843,8 +843,15 @@ class ToolSelectPanelHelper:
                 tool_fallback_id = cls.tool_fallback_id
                 item, _select_index = cls._tool_get_by_id_active(context, tool_fallback_id)
                 label = item.label
+                # BFA - use the active fallback tool's own icon (Tweak, Select Box, Select Circle, Select Lasso)
+                # instead of the generic TOOL_SETTINGS icon.
+                popover_icon_kw = {
+                    "icon_value": ToolSelectPanelHelper._icon_value_from_icon_handle(item.icon),
+                }
             else:
                 label = "Active Tool"
+                # BFA - use the generic TOOL_SETTINGS icon for the active tool.
+                popover_icon_kw = {"icon": 'TOOL_SETTINGS'}
 
             row = layout.row(heading="Drag", heading_ctxt=i18n_contexts.editor_view3d)
             row.context_pointer_set("tool", tool)
@@ -852,7 +859,7 @@ class ToolSelectPanelHelper:
                 panel="TOPBAR_PT_tool_fallback",
                 text=iface_(label, i18n_contexts.operator_default),
                 translate=False,
-                icon='TOOL_SETTINGS', # bfa - added icon
+                **popover_icon_kw,
             )
 
         return tool


### PR DESCRIPTION
UI: Tool System - Use fallback tool's icon in drag action popover

When a fallback tool is active (Tweak, Select Box, Select Circle, Select Lasso), display that tool's specific icon in the drag action popover instead of the generic TOOL_SETTINGS icon. Keep TOOL_SETTINGS for other active tools.

[Screencast_20260906_122918.webm](https://github.com/user-attachments/assets/0d761c74-c031-41dc-a6c5-db807c73d147)
