### PR TITLE
Properties Editor - Modifiers - Curve to Tube currently broken #6765

### DIFF
--- a/assets_bfa/nodes/geometry_nodes_essentials.blend
+++ b/assets_bfa/nodes/geometry_nodes_essentials.blend
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:755d2a6d5ebcf9bcf312f63d0157c1921b8ae87f1a73fef70a70f7daf04a9c15
-size 2018007
+oid sha256:2a29eb5c5eb6da8d861e81654e9cb3b95341e54a6d080529216be95ca2626534
+size 1892696


### PR DESCRIPTION
A name mismatch causes the import operator to be unable to find the asset.
This patch fixes this by renaming `Curve to Tube BFA` back to `Curve to Tube`.

Resolves: #6765 