### PR TITLE
Preferences - Viewport tab > Display panel - Better visibility and hierarchy for Playback Frame Rate and related properties #6770

### DIFF
--- a/scripts/startup/bl_ui/space_userpref.py
+++ b/scripts/startup/bl_ui/space_userpref.py
@@ -1016,29 +1016,27 @@ class USERPREF_PT_viewport_display(ViewportPanel, CenterAlignMixIn, Panel):
         prefs = context.preferences
         view = prefs.view
 
-        layout.label(text="Text Info Overlay")
+        header, col = layout.indented_column()
+        header.label(text="Text Info Overlay")
+        
+        col.use_property_split = True
+        col.use_property_decorate = False
+        col.prop(view, "show_object_info", text="Object Info")
+        col.prop(view, "show_view_name", text="View Name")
+        
+        header, col = col.indented_column(draw_body=view.show_playback_fps)
+        header_row = header.row()
+        header_row.alignment = 'LEFT'
+        header_row.prop(view, "show_playback_fps", text="Playback Frame Rate (FPS)")
 
-        col = layout.column()
-
-        col.use_property_split = False
-        row = col.row()
-        row.separator()
-        row.prop(view, "show_object_info", text="Object Info")
-        row = col.row()
-        row.separator()
-        row.prop(view, "show_view_name", text="View Name")
-        row = col.row()
-        row.separator()
-
-        split = row.split()
-        col = split.column()
-        col.use_property_split = False
-        col.prop(view, "show_playback_fps", text="Playback Frame Rate (FPS)")
-
-        if view.show_playback_fps:
-            split.prop(view, "playback_fps_samples", text="Samples")
+        if col:
+            header_row.label(icon='DISCLOSURE_TRI_DOWN')
+            
+            col.use_property_split = True
+            col.use_property_decorate = False
+            col.prop(view, "playback_fps_samples", text="Samples")
         else:
-            split.label(icon='DISCLOSURE_TRI_RIGHT')
+            header_row.label(icon='DISCLOSURE_TRI_RIGHT')
 
         layout.separator()
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="405" height="100" alt="image" src="https://github.com/user-attachments/assets/e5bca12a-360b-4e0c-a079-f11ded0dad4f" /> | <img width="360" height="97" alt="image" src="https://github.com/user-attachments/assets/33f8da71-da5c-4978-ac27-797c53c6e42b" /> |
| <img width="430" height="104" alt="image" src="https://github.com/user-attachments/assets/52f0ae1c-4a18-4944-b14a-0978f1c69450" /> | <img width="372" height="119" alt="image" src="https://github.com/user-attachments/assets/ad3ee483-70da-4ef1-91a1-58c04e873646" /> |

- Have toggle take up the full row.
- Indent `Samples` subprop.
- Use split layout for indented column.

Resolves: #6770

